### PR TITLE
fix TB log deletion, implement generic TrpcWrapper

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLogAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLogAPI.java
@@ -29,8 +29,10 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -230,27 +232,22 @@ public class GCLogAPI {
         }
 
         //2.) Build batch request body: {"0":{"referenceCode":"GCxxx","body":{...}}}
-        final ObjectNode inner = JsonUtils.createObjectNode();
-        inner.put("referenceCode", geocode);
-        inner.set("body", buildLogBodyNode(logEntry, inventory));
-        final ObjectNode requestBody = JsonUtils.createObjectNode();
-        requestBody.set("0", inner);
+        final TrpcRequestBody requestBody = new TrpcRequestBody(geocode).with("body", buildLogBodyNode(logEntry, inventory));
 
         //3.) POST to new batch endpoint
-        final JsonNode response = websiteReq().uri("/api/live/v1/trpc/web.logs.createGeocacheLog?batch=1")
+        final TrpcResponseBody response = TrpcResponseBody.of(websiteReq().uri("/api/live/v1/trpc/web.logs.createGeocacheLog")
+                .uriParams("batch", "1")
                 .method(HttpRequest.Method.POST)
                 .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
                 .bodyJson(requestBody)
-                .requestJsonNode().blockingGet();
+                .requestJsonNode().blockingGet());
 
         //Response: [{"result":{"data":{"logReferenceCode":"GLxxx",...}}}]
-        final JsonNode firstResult = response != null && response.isArray() && !response.isEmpty() ? response.get(0) : null;
-        final JsonNode data = JsonUtils.get(JsonUtils.get(firstResult, "result"), "data");
-        final String logReferenceCode = JsonUtils.getText(data, "logReferenceCode", null);
+        final String logReferenceCode = response.getText("logReferenceCode");
 
         if (logReferenceCode == null) {
-            return generateLogError("CreateLog: Problem with server, request JSON=[" + JsonUtils.nodeToString(requestBody) +
-                    "], response=[" + JsonUtils.nodeToString(response) + "]");
+            return generateLogError("CreateLog: Problem with server, request JSON=[" + requestBody +
+                    "], response=[" + response + "]");
         }
 
         return LogResult.ok(logReferenceCode);
@@ -271,27 +268,21 @@ public class GCLogAPI {
         }
 
         //2.) Build batch request body: {"0":{"referenceCode":"GLxxx","body":{...}}}
-        final ObjectNode inner = JsonUtils.createObjectNode();
-        inner.put("referenceCode", logId);
-        inner.set("body", buildLogBodyNode(logEntry, null));
-        final ObjectNode requestBody = JsonUtils.createObjectNode();
-        requestBody.set("0", inner);
+        final TrpcRequestBody requestBody = new TrpcRequestBody(logId).with("body", buildLogBodyNode(logEntry, null));
 
         //3.) POST to new batch endpoint
-        final JsonNode response = websiteReq().uri("/api/live/v1/trpc/web.logs.updateGeocacheLog?batch=1")
+        final TrpcResponseBody response =  TrpcResponseBody.of(websiteReq().uri("/api/live/v1/trpc/web.logs.updateGeocacheLog")
+                .uriParams("batch", "1")
                 .method(HttpRequest.Method.POST)
                 .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
                 .bodyJson(requestBody)
-                .requestJsonNode().blockingGet();
+                .requestJsonNode().blockingGet());
 
-        //Response: [{"result":{"data":{"logReferenceCode":"GLxxx",...}}}]
-        final JsonNode firstResult = response != null && response.isArray() && !response.isEmpty() ? response.get(0) : null;
-        final JsonNode data = JsonUtils.get(JsonUtils.get(firstResult, "result"), "data");
-        final String logReferenceCode = JsonUtils.getText(data, "logReferenceCode", null);
+        final String logReferenceCode = response.getText("logReferenceCode");
 
         if (logReferenceCode == null) {
-            return generateLogError("EditLog: problem with server, request JSON=[" + JsonUtils.nodeToString(requestBody) +
-                "], response=[" + JsonUtils.nodeToString(response) + "]");
+            return generateLogError("EditLog: problem with server, request JSON=[" + requestBody +
+                "], response=[" + response + "]");
         }
 
         return LogResult.ok(logReferenceCode);
@@ -312,27 +303,23 @@ public class GCLogAPI {
         }
 
         //2.) Build batch request body: {"0":{"referenceCode":"GLxxx","reasonText":"..."}}
-        final ObjectNode inner = JsonUtils.createObjectNode();
-        inner.put("referenceCode", logId);
-        inner.put("reasonText", reason);
-        final ObjectNode requestBody = JsonUtils.createObjectNode();
-        requestBody.set("0", inner);
+        final TrpcRequestBody requestBody = new TrpcRequestBody(logId).with("reasonText", reason);
 
         //3.) POST to new batch endpoint
-        final JsonNode response = websiteReq().uri("/api/live/v1/trpc/web.logs.deleteGeocacheLog?batch=1")
+        try (HttpResponse response = websiteReq().uri("/api/live/v1/trpc/web.logs.deleteGeocacheLog")
+            .uriParams("batch", "1")
             .method(HttpRequest.Method.POST)
             .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
             .bodyJson(requestBody)
-            .requestJsonNode().blockingGet();
+            .request().blockingGet()) {
 
-        //Response: [{"result":{}}] on success
-        final JsonNode firstResult = response != null && response.isArray() && !response.isEmpty() ? response.get(0) : null;
-        if (!JsonUtils.has(firstResult, "result")) {
-            return generateLogError("DeleteLog: Problem deleting, response is: " + JsonUtils.nodeToString(response));
+            // Use status code for checking success
+            if (!response.isSuccessful()) {
+                return generateLogError("DeleteLog: Problem deleting, response is: " + response);
+            }
+
+            return LogResult.ok(logId);
         }
-
-        return LogResult.ok(logId);
-
     }
 
     @WorkerThread
@@ -392,12 +379,15 @@ public class GCLogAPI {
         }
 
         //2,) Send a DELETE Request (which is a POST)
-        try (HttpResponse response = websiteReq().uri("/api/live/v1/trpc/web.images.delete?batch=1")
+        // the payload is not a "normal" trpc one, uses refCode instead of referenceCode. example request: {"0":{"refCode":"GL1GRJXXX","guid":"3908d144-065a-4270-9512-xxxxx"}}
+        try (HttpResponse response = websiteReq().uri("/api/live/v1/trpc/web.images.delete")
+            .uriParams("batch", "1")
             .method(HttpRequest.Method.POST)
             .bodyJson("{\"0\":{\"refCode\":\"" + logId + "\",\"guid\":\"" + getGuidFrom(logImageId) + "\"}}")
             .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
             .request().blockingGet()) {
 
+            // Use status code for checking success
             if (!response.isSuccessful()) {
                 return generateImageLogError("Problem pasting log, response is: " + response);
             }
@@ -443,27 +433,21 @@ public class GCLogAPI {
             }
         }
 
-        final ObjectNode inner = JsonUtils.createObjectNode();
-        inner.put("referenceCode", trackableLog.geocode);
-        inner.set("body", JsonUtils.mapper.valueToTree(logEntry));
-        final ObjectNode requestBody = JsonUtils.createObjectNode();
-        requestBody.set("0", inner);
+        final TrpcRequestBody requestBody = new TrpcRequestBody(trackableLog.geocode).with("body", logEntry);
 
         //URL: https://www.geocaching.com/api/live/v1/trpc/web.logs.createTrackableLog?batch=1
-        //Response: [{"result":{"data":{"logReferenceCode":"TLxxx",...}}}]
-        final JsonNode response = websiteReq().uri("/api/live/v1/trpc/web.logs.createTrackableLog?batch=1")
+        final TrpcResponseBody response = TrpcResponseBody.of(websiteReq().uri("/api/live/v1/trpc/web.logs.createTrackableLog")
+                .uriParams("batch", "1")
                 .method(HttpRequest.Method.POST)
                 .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
                 .bodyJson(requestBody)
-                .requestJsonNode().blockingGet();
+                .requestJsonNode().blockingGet());
 
-        final JsonNode firstResult = response != null && response.isArray() && !response.isEmpty() ? response.get(0) : null;
-        final JsonNode data = JsonUtils.get(JsonUtils.get(firstResult, "result"), "data");
-        final String logReferenceCode = JsonUtils.getText(data, "logReferenceCode", null);
-
+        //Response: [{"result":{"data":{"logReferenceCode":"TLxxx",...}}}]
+        final String logReferenceCode = response.getText("logReferenceCode");
         if (logReferenceCode == null) {
-            return generateLogError("Problem pasting trackable log, request JSON=[" + JsonUtils.nodeToString(requestBody) +
-                    "], response=[" + JsonUtils.nodeToString(response) + "]");
+            return generateLogError("Problem pasting trackable log, request JSON=[" + requestBody +
+                    "], response=[" + response + "]");
         }
 
         return LogResult.ok(logReferenceCode);
@@ -480,7 +464,9 @@ public class GCLogAPI {
         }
 
         //2,) Send a DELETE Request (which is actually a POST)
-        try (HttpResponse response = websiteReq().uri("/api/live/v1/logs/trackableLog/delete/" + logId)
+        try (HttpResponse response = websiteReq().uri("/api/live/v1/trpc/web.logs.deleteTrackableLog")
+            .uriParams("batch", "1")
+            .bodyJson(new TrpcRequestBody(logId).with("reasonText", ""))
             .method(HttpRequest.Method.POST)
             .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
             .request().blockingGet()) {
@@ -611,5 +597,70 @@ public class GCLogAPI {
                 .requestJson(GCWebLogCsrfRequest.class)
                 .blockingGet();
         return StringUtils.isBlank(csrfResponse.csrfToken) ? null : csrfResponse.csrfToken;
+    }
+
+    // Helper classes for building and parsing JSONs for the TRPC batch endpoints
+    static class TrpcResponseBody {
+        private final JsonNode data;
+        private final boolean ok;
+
+        static TrpcResponseBody of(final JsonNode response) {
+            final JsonNode first = response != null && response.isArray() && !response.isEmpty() ? response.get(0) : null;
+            final JsonNode result = JsonUtils.get(first, "result");
+            return new TrpcResponseBody(result != null, JsonUtils.get(result, "data"));
+        }
+
+        private TrpcResponseBody(final boolean ok, final JsonNode data) {
+            this.ok = ok;
+            this.data = data;
+        }
+
+        public boolean isOk() {
+            return ok;
+        }
+
+        public String getText(final String field) {
+            return JsonUtils.getText(data, field, null);
+        }
+
+        @Override
+        public String toString() {
+            return JsonUtils.nodeToString(data);
+        }
+    }
+
+    static class TrpcRequestBody {
+        @JsonProperty("0")
+        TrpcRequestBodyEntry entry;
+
+        public TrpcRequestBody(final String referenceCode) {
+            this.entry = new TrpcRequestBodyEntry(referenceCode);
+        }
+
+        public TrpcRequestBody with(final String key, final Object value) {
+            entry.extra.put(key, value);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return JsonUtils.nodeToString(JsonUtils.mapper.valueToTree(this));
+        }
+
+        static class TrpcRequestBodyEntry {
+            @JsonProperty("referenceCode")
+            String referenceCode;
+
+            private final Map<String, Object> extra = new LinkedHashMap<>();
+
+            public TrpcRequestBodyEntry(final String referenceCode) {
+                this.referenceCode = referenceCode;
+            }
+
+            @JsonAnyGetter
+            public Map<String, Object> extra() {
+                return extra;
+            }
+        }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLogAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLogAPI.java
@@ -29,10 +29,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -239,7 +237,7 @@ public class GCLogAPI {
                 .uriParams("batch", "1")
                 .method(HttpRequest.Method.POST)
                 .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
-                .bodyJson(requestBody)
+                .bodyJson(requestBody.build())
                 .requestJsonNode().blockingGet());
 
         //Response: [{"result":{"data":{"logReferenceCode":"GLxxx",...}}}]
@@ -275,7 +273,7 @@ public class GCLogAPI {
                 .uriParams("batch", "1")
                 .method(HttpRequest.Method.POST)
                 .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
-                .bodyJson(requestBody)
+                .bodyJson(requestBody.build())
                 .requestJsonNode().blockingGet());
 
         final String logReferenceCode = response.getText("logReferenceCode");
@@ -310,7 +308,7 @@ public class GCLogAPI {
             .uriParams("batch", "1")
             .method(HttpRequest.Method.POST)
             .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
-            .bodyJson(requestBody)
+            .bodyJson(requestBody.build())
             .request().blockingGet()) {
 
             // Use status code for checking success
@@ -433,14 +431,14 @@ public class GCLogAPI {
             }
         }
 
-        final TrpcRequestBody requestBody = new TrpcRequestBody(trackableLog.geocode).with("body", logEntry);
+        final TrpcRequestBody requestBody = new TrpcRequestBody(trackableLog.geocode).with("body", JsonUtils.mapper.valueToTree(logEntry));
 
         //URL: https://www.geocaching.com/api/live/v1/trpc/web.logs.createTrackableLog?batch=1
         final TrpcResponseBody response = TrpcResponseBody.of(websiteReq().uri("/api/live/v1/trpc/web.logs.createTrackableLog")
                 .uriParams("batch", "1")
                 .method(HttpRequest.Method.POST)
                 .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
-                .bodyJson(requestBody)
+                .bodyJson(requestBody.build())
                 .requestJsonNode().blockingGet());
 
         //Response: [{"result":{"data":{"logReferenceCode":"TLxxx",...}}}]
@@ -466,7 +464,7 @@ public class GCLogAPI {
         //2,) Send a DELETE Request (which is actually a POST)
         try (HttpResponse response = websiteReq().uri("/api/live/v1/trpc/web.logs.deleteTrackableLog")
             .uriParams("batch", "1")
-            .bodyJson(new TrpcRequestBody(logId).with("reasonText", ""))
+            .bodyJson(new TrpcRequestBody(logId).with("reasonText", "").build())
             .method(HttpRequest.Method.POST)
             .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
             .request().blockingGet()) {
@@ -630,37 +628,31 @@ public class GCLogAPI {
     }
 
     static class TrpcRequestBody {
-        @JsonProperty("0")
-        TrpcRequestBodyEntry entry;
+        private final ObjectNode root;
+        private final ObjectNode entry;
 
         TrpcRequestBody(final String referenceCode) {
-            this.entry = new TrpcRequestBodyEntry(referenceCode);
+            entry = JsonUtils.createObjectNode().put("referenceCode", referenceCode);
+            root = JsonUtils.createObjectNode().set("0", entry);
         }
 
-        public TrpcRequestBody with(final String key, final Object value) {
-            entry.extra.put(key, value);
+        TrpcRequestBody with(final String key, final String value) {
+            entry.put(key, value);
             return this;
+        }
+
+        TrpcRequestBody with(final String key, final JsonNode value) {
+            entry.set(key, value);
+            return this;
+        }
+
+        ObjectNode build() {
+            return root;
         }
 
         @Override
         public String toString() {
-            return JsonUtils.nodeToString(JsonUtils.mapper.valueToTree(this));
-        }
-
-        static class TrpcRequestBodyEntry {
-            @JsonProperty("referenceCode")
-            String referenceCode;
-
-            private final Map<String, Object> extra = new LinkedHashMap<>();
-
-            TrpcRequestBodyEntry(final String referenceCode) {
-                this.referenceCode = referenceCode;
-            }
-
-            @JsonAnyGetter
-            public Map<String, Object> extra() {
-                return extra;
-            }
+            return JsonUtils.nodeToString(root);
         }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLogAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLogAPI.java
@@ -633,7 +633,7 @@ public class GCLogAPI {
         @JsonProperty("0")
         TrpcRequestBodyEntry entry;
 
-        public TrpcRequestBody(final String referenceCode) {
+        TrpcRequestBody(final String referenceCode) {
             this.entry = new TrpcRequestBodyEntry(referenceCode);
         }
 
@@ -653,7 +653,7 @@ public class GCLogAPI {
 
             private final Map<String, Object> extra = new LinkedHashMap<>();
 
-            public TrpcRequestBodyEntry(final String referenceCode) {
+            TrpcRequestBodyEntry(final String referenceCode) {
                 this.referenceCode = referenceCode;
             }
 


### PR DESCRIPTION
Implements generic classes for the new GC Trpc API request and response bodies.

Creating a body:
final TrpcRequestBody requestBody = new TrpcRequestBody(logId).with("reasonText", reason);
-> {"0":{"referenceCode":"XXX","reasonText":reason}} 

Parsing and using a response:
//Response: [{"result":{"data":{"logReferenceCode":"TLxxx",...}}}]
final TrpcResponseBody response = TrpcResponseBody.of(websiteReq().uri("/api/live/v1/trpc/web.logs.deleteGeocacheLog")....
final String logReferenceCode = response.getText("logReferenceCode");
if (logReferenceCode == null) {


and of course there's at least 1 place (so far) where they break their own "rules" by using "refCode" isntead of "referenceCode" 🙁