### PR TITLE
Adjust toolbar title padding in landscape mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -508,6 +508,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     @Override
     public void onResume() {
         super.onResume();
+        setAppIconAsUpIndicator(true);
 
         // save current position
         final LastPositionHelper lastPosition = new LastPositionHelper(this);
@@ -756,7 +757,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         final int menuItem = item.getItemId();
-        if (menuItem == R.id.menu_show_on_map) {
+        if (menuItem == android.R.id.home) {
+            startActivity(new Intent(this, AboutActivity.class));
+        } else if (menuItem == R.id.menu_show_on_map) {
             goMap();
         } else if (menuItem == R.id.menu_switch_select_mode) {
             adapter.switchSelectMode();

--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -689,14 +689,7 @@ public class MainActivity extends AbstractNavigationBarActivity {
     @Override
     public void updateSelectedBottomNavItemId() {
         super.updateSelectedBottomNavItemId();
-
-        // Always show c:geo logo for this activity
-        final ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setHomeAsUpIndicator(R.drawable.ic_launcher_rounded_noborder);
-            actionBar.setHomeActionContentDescription(R.string.about);
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }
+        setAppIconAsUpIndicator(false);
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -163,6 +163,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        setAppIconAsUpIndicator(true);
         if (null != searchView) {
             if (searchPerformed) {
                 // search triggered from search field -> return to main screen
@@ -179,6 +180,15 @@ public class SearchActivity extends AbstractNavigationBarActivity {
             }
         }
         searchPerformed = false;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        if (item.getItemId() != android.R.id.home) {
+            return super.onOptionsItemSelected(item);
+        }
+        startActivity(new Intent(this, AboutActivity.class));
+        return true;
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -10,6 +10,9 @@ import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.TextUtils;
 
+import android.content.res.Configuration;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.InsetDrawable;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -19,9 +22,11 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.Insets;
 
 import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.navigation.NavigationBarView;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -34,6 +39,7 @@ public class AbstractActionBarActivity extends AbstractActivity {
     private int statusBarHeight = 0;
     private int actionBarHeightWithStatusBar = 0;
     private boolean showSpacer = false;
+    private static int railWidth = 0;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -80,6 +86,41 @@ public class AbstractActionBarActivity extends AbstractActivity {
         if (actionBarView != null) {
             // set action bar background color, otherwise it would be transparent
             actionBarView.setBackgroundColor(getResources().getColor(R.color.colorBackgroundActionBar));
+        }
+    }
+
+    /** Show c:geo logo for this activity (always or in landscape mode only) */
+    protected void setAppIconAsUpIndicator(final boolean inLandscapeOnly) {
+        final ActionBar actionBar = getSupportActionBar();
+        final int orientation = getResources().getConfiguration().orientation;
+        final boolean showUpIndicator = !inLandscapeOnly || orientation == Configuration.ORIENTATION_LANDSCAPE;
+        if (actionBar != null) {
+            if (showUpIndicator) {
+                if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                    // adjust home icon padding if navigation rail is shown
+                    final NavigationBarView navigation = findViewById(R.id.activity_navigationBar);
+                    toolbar.setContentInsetsAbsolute(0, toolbar.getContentInsetEnd());
+                    setAppIconAsUpIndicatorHelper(actionBar);
+                    if (railWidth == 0) {
+                        navigation.post(() -> {
+                            railWidth = navigation.getWidth(); // get actual width
+                            setAppIconAsUpIndicatorHelper(actionBar);
+                        });
+                    }
+                } else {
+                    actionBar.setHomeAsUpIndicator(R.drawable.ic_launcher_rounded_noborder);
+                }
+            }
+            actionBar.setHomeActionContentDescription(R.string.about);
+            actionBar.setDisplayHomeAsUpEnabled(showUpIndicator);
+        }
+    }
+
+    private void setAppIconAsUpIndicatorHelper(final ActionBar actionBar) {
+        final Drawable customIcon = ContextCompat.getDrawable(this, R.drawable.ic_launcher_rounded_noborder);
+        if (customIcon != null) {
+            final int sidePadding = railWidth == 0 ? 0 : (railWidth - customIcon.getIntrinsicWidth()) / 2;
+            actionBar.setHomeAsUpIndicator(new InsetDrawable(customIcon, sidePadding, 0, sidePadding, 0));
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.unifiedmap;
 
+import cgeo.geocaching.AboutActivity;
 import cgeo.geocaching.AbstractDialogFragment;
 import cgeo.geocaching.CacheListActivity;
 import cgeo.geocaching.Intents;
@@ -950,7 +951,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
         final int id = item.getItemId();
-        if (id == R.id.menu_map_live) {
+        if (id == android.R.id.home) {
+            startActivity(new Intent(this, AboutActivity.class));
+        } else if (id == R.id.menu_map_live) {
             if (viewModel.mapType.enableLiveMap()) {
                 Settings.setLiveMap(!Settings.isLiveMap());
                 viewModel.transientIsLiveEnabled.setValue(Settings.isLiveMap());
@@ -1484,6 +1487,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     @Override
     protected void onResume() {
         super.onResume();
+        setAppIconAsUpIndicator(true);
         if (mapFragment == null) {
             recreate(); // restart with a fresh MapView
             return; // prevent further execution on the old activity instance


### PR DESCRIPTION
## Description
Toolbar title text is pretty much unaligned horizontally currently. This has been done due to limited space on mobile devices in portrait mode. Landscape mode has much more available toolbar space, which we can use to fix this.

(Affects landscape mode only. c:geo icon is centered horizontally within width of navigation rail, toolbar title text starts right of navigation rail.)

### Home screen
<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/ab303a69-3c6e-42c4-8cd3-a33cf6d0f650" />
<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/8c541e4f-f38b-4cd9-acac-593303209724" />

### Map without filter
<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/7e4170cd-fe09-4062-953b-6f9bcc6aac49" />
<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/97b33240-40b9-4a98-b243-477d4ecc9990" />

### Map with filter
<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/19ead812-7f4b-4974-b0d5-0335f2d500f4" />
<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/16aea1f2-e538-4175-bfad-545b83cdca76" />

Currently the c:geo icon links to `AboutActivity` (as it does on home screen), but this can be adjusted.