### PR TITLE
Fix #18232: Rename prefix: Prefill with parent of current list

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -629,6 +629,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setMenuItemLabel(menu, R.id.menu_drop_caches, R.string.caches_remove_selected, R.string.caches_remove_all, checkedCount);
             MenuUtils.setVisibleEnabled(menu, R.id.menu_drop_caches_all_lists, isHistory || containsStoredCaches, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_drop_caches_all_lists, R.string.caches_remove_selected_completely, R.string.caches_remove_all_completely, checkedCount);
+            MenuUtils.setVisibleEnabled(menu, R.id.menu_remove_from_other_lists, isOffline && listId != PseudoList.ALL_LIST.id, !isEmpty);
+            setMenuItemLabel(menu, R.id.menu_remove_from_other_lists, R.string.caches_remove_from_other_lists_selected, R.string.caches_remove_from_other_lists_all, checkedCount);
 
             //MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_bookmarklist, isGcPremiumMember, !isEmpty);
             MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_bookmarklist, true, !isEmpty);
@@ -645,16 +647,15 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             MenuUtils.setEnabled(menu, R.id.menu_set_cache_icon, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_set_cache_icon, R.string.caches_set_cache_icon_selected, R.string.caches_set_cache_icon_all, checkedCount);
             MenuUtils.setVisibleEnabled(menu, R.id.menu_recalculate_health_score, true, !isEmpty);
-            MenuUtils.setVisibleEnabled(menu, R.id.menu_remove_from_other_lists, isOffline && listId != PseudoList.ALL_LIST.id, !isEmpty);
-            setMenuItemLabel(menu, R.id.menu_remove_from_other_lists, R.string.caches_remove_from_other_lists_selected, R.string.caches_remove_from_other_lists_all, checkedCount);
 
             // Manage Lists submenu
             MenuUtils.setVisibleEnabled(menu, R.id.menu_lists, isOffline, !isSelectMode);
             MenuUtils.setVisible(menu, R.id.menu_drop_list, isNonDefaultList);
             MenuUtils.setVisible(menu, R.id.menu_rename_list, isNonDefaultList);
-            MenuUtils.setVisible(menu, R.id.menu_rename_list_prefix, isNonDefaultList && DataStore.getListHierarchy().size() > 1);
             MenuUtils.setVisibleEnabled(menu, R.id.menu_make_list_unique, listId != PseudoList.ALL_LIST.id, !isEmpty);
             MenuUtils.setVisible(menu, R.id.menu_set_listmarker, isNonDefaultList);
+            final List<String> hierarchies = DataStore.getListHierarchy();
+            MenuUtils.setVisible(menu, R.id.menu_rename_parent_lists, !hierarchies.isEmpty());
             MenuUtils.setVisibleEnabled(menu, R.id.menu_set_askfordeletion, isNonDefaultList, preventAskForDeletion);
 
             // Import submenu
@@ -794,8 +795,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             invalidateOptionsMenuCompatible();
         } else if (menuItem == R.id.menu_rename_list) {
             renameList();
-        } else if (menuItem == R.id.menu_rename_list_prefix) {
-            new StoredList.UserInterface(this).promptForListPrefixRename(() -> {
+        } else if (menuItem == R.id.menu_rename_parent_lists) {
+            new StoredList.UserInterface(this).promptForParentListRename(listId, () -> {
                 refreshCurrentList();
                 invalidateOptionsMenuCompatible();
             });

--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -20,7 +20,6 @@ import cgeo.geocaching.utils.functions.Action1;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -377,8 +376,8 @@ public final class StoredList extends AbstractList {
             }
 
             final View menu = LayoutInflater.from(activity).inflate(R.layout.createlist, null);
-            final TextInputLayout listprefix = menu.findViewById(R.id.listprefix);
-            final AutoCompleteTextView listprefixView = menu.findViewById(R.id.listprefixView);
+            final TextInputLayout parentList = menu.findViewById(R.id.parentList);
+            final AutoCompleteTextView parentListView = menu.findViewById(R.id.parentListView);
             final TextInputEditText listname = menu.findViewById(R.id.title);
 
             final String current = defaultValue != null ? defaultValue.substring(defaultValue.lastIndexOf(GROUP_SEPARATOR) + 1).trim() : "";
@@ -387,9 +386,9 @@ public final class StoredList extends AbstractList {
             final List<String> hierarchies = DataStore.getListHierarchy();
             hierarchies.add(0, LocalizationUtils.getString(R.string.init_custombnitem_none)); // overwrite empty entry
             hierarchies.add(1, LocalizationUtils.getString(R.string.list_create_parent));
-            listprefix.setVisibility(View.VISIBLE);
-            listprefixView.setText(Strings.CS.endsWith(oldPrefix, GROUP_SEPARATOR) ? oldPrefix.substring(0, oldPrefix.length() - 1) : oldPrefix);
-            listprefixView.setAdapter(new NewListAdapter(activity, R.layout.createlist_item , hierarchies));
+            parentList.setVisibility(View.VISIBLE);
+            parentListView.setText(Strings.CS.endsWith(oldPrefix, GROUP_SEPARATOR) ? oldPrefix.substring(0, oldPrefix.length() - 1) : oldPrefix);
+            parentListView.setAdapter(new NewListAdapter(activity, R.layout.createlist_item, hierarchies));
 
             ((EditText) menu.findViewById(R.id.title)).setText(current);
             final AlertDialog.Builder builder = Dialogs.newBuilder(activity)
@@ -397,7 +396,7 @@ public final class StoredList extends AbstractList {
                     .setPositiveButton(buttonTitle, ((d, which) -> {
                             // same logic as in updateButtonState()
                             String prefix = "";
-                            final String temp = ((AutoCompleteTextView) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.listprefixView))).getText().toString().trim();
+                        final String temp = ((AutoCompleteTextView) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.parentListView))).getText().toString().trim();
                             if (Strings.CS.equals(temp, LocalizationUtils.getString(R.string.list_create_parent))) {
                                 prefix = Objects.requireNonNull(((TextInputEditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.newParent))).getText()).toString().trim();
                             } else if (!Strings.CS.equals(temp, LocalizationUtils.getString(R.string.init_custombnitem_none))) {
@@ -410,29 +409,34 @@ public final class StoredList extends AbstractList {
                     .setView(menu);
             Keyboard.show(activity, menu.findViewById(R.id.title));
             final AlertDialog dialog = builder.show();
-            ((NewListAdapter) listprefixView.getAdapter()).setNewParentInput(dialog.findViewById(R.id.newParentWrapper));
+            ((NewListAdapter) parentListView.getAdapter()).setNewParentInput(dialog.findViewById(R.id.newParentWrapper));
 
             dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
             final String oldListname = Objects.requireNonNull(listname.getText()).toString();
-            listprefixView.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, s.toString(), oldListname, listname.getText().toString())));
-            ((TextInputEditText) Objects.requireNonNull(dialog.findViewById(R.id.newParent))).addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, listprefixView.getText().toString(), oldListname, listname.getText().toString())));
-            listname.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, listprefixView.getText().toString(), oldListname, s.toString())));
+            parentListView.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, s.toString(), oldListname, listname.getText().toString(), false)));
+            ((TextInputEditText) Objects.requireNonNull(dialog.findViewById(R.id.newParent))).addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, parentListView.getText().toString(), oldListname, listname.getText().toString(), false)));
+            listname.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, parentListView.getText().toString(), oldListname, s.toString(), false)));
 
             ViewUtils.closeKeyboardOnLosingFocus(activity, listname);
             ViewUtils.closeKeyboardOnLosingFocus(activity, menu.findViewById(R.id.newParent));
         }
 
-        private static void updateButtonState(final AlertDialog dialog, final String oldPrefix, final String newPrefix, final String oldListname, final String newListname) {
-            final String tempListname = newListname.trim();
-            boolean unchanged = Strings.CS.equals(oldListname, tempListname);
-            boolean blocked = tempListname.isEmpty();
-            if (!blocked) {
+        private static void updateButtonState(final AlertDialog dialog, @Nullable final String oldPrefix, @Nullable final String newPrefix, @Nullable final String oldListname, @Nullable final String newListname, final boolean ignoreEmptyPrefix) {
+            boolean unchanged = true;
+            boolean blocked = false;
+            if (newListname != null && oldListname != null) {
+                final String tempListname = newListname.trim();
+                unchanged = Strings.CS.equals(oldListname, tempListname);
+                blocked = tempListname.isEmpty();
+            }
+
+            if (!blocked && oldPrefix != null && newPrefix != null) {
                 // same logic as in handleListNameInput:builder.setPositiveButton() above
                 String prefix = "";
                 final String temp = newPrefix.trim();
                 if (Strings.CS.equals(temp, LocalizationUtils.getString(R.string.list_create_parent))) {
                     prefix = Objects.requireNonNull(((TextInputEditText) Objects.requireNonNull(dialog.findViewById(R.id.newParent))).getText()).toString().trim();
-                    blocked = prefix.isEmpty();
+                    blocked = prefix.isEmpty() && !ignoreEmptyPrefix;
                 } else if (!Strings.CS.equals(temp, LocalizationUtils.getString(R.string.init_custombnitem_none))) {
                     prefix = temp;
                 }
@@ -463,14 +467,14 @@ public final class StoredList extends AbstractList {
             });
         }
 
-        public void promptForListPrefixRename(final Runnable runAfterRename) {
+        public void promptForParentListRename(final int listId, final Runnable runAfterRename) {
             final Activity activity = activityRef.get();
             if (activity == null) {
                 return;
             }
 
             final List<String> hierarchies = DataStore.getListHierarchy();
-            if (hierarchies.size() == 1) {
+            if (hierarchies.isEmpty()) {
                 return;
             }
 
@@ -479,25 +483,31 @@ public final class StoredList extends AbstractList {
             }
 
             final View menu = LayoutInflater.from(activity).inflate(R.layout.createlist, null);
-            final TextInputLayout listprefix = menu.findViewById(R.id.listprefix);
-            final AutoCompleteTextView listprefixView = menu.findViewById(R.id.listprefixView);
+            final TextInputLayout parentList = menu.findViewById(R.id.parentList);
+            final AutoCompleteTextView parentListView = menu.findViewById(R.id.parentListView);
             final TextInputEditText title = menu.findViewById(R.id.title);
 
-            listprefix.setVisibility(View.VISIBLE);
-            listprefix.setHint(R.string.rename_from);
-            listprefixView.setText(hierarchies.get(0));
-            listprefixView.setAdapter(new ArrayAdapter<>(activity, R.layout.createlist_item , hierarchies));
+            final StoredList list = DataStore.getList(listId);
+            final String parentName = StringUtils.defaultIfEmpty(getGroupFromList(list, null), hierarchies.get(0));
+
+            parentList.setVisibility(View.VISIBLE);
+            parentList.setHint(R.string.rename_from);
+            parentListView.setText(parentName);
+            parentListView.setAdapter(new ArrayAdapter<>(activity, R.layout.createlist_item, hierarchies));
+            parentListView.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> {
+                ((EditText) menu.findViewById(R.id.title)).setText(s);
+            }));
 
             ((TextInputLayout) menu.findViewById(R.id.titleWrapper)).setHint(R.string.rename_to);
-            title.setText(hierarchies.get(0));
+            title.setText(parentName);
 
             final AlertDialog.Builder builder = Dialogs.newBuilder(activity)
-                    .setTitle(R.string.list_menu_rename_list_prefix)
+                    .setTitle(R.string.list_menu_rename_parent_lists)
                     .setPositiveButton(android.R.string.ok, ((d, which) -> {
-                        final String from = listprefixView.getText().toString();
+                        final String from = parentListView.getText().toString();
                         final String to = removeSeparatorsAndTrim(Objects.requireNonNull(title.getText()).toString());
                         if (!Strings.CS.equals(from, to)) {
-                            SimpleDialog.of(activity).setTitle(R.string.list_menu_rename_list_prefix).setMessage(TextParam.text(
+                            SimpleDialog.of(activity).setTitle(R.string.list_menu_rename_parent_lists).setMessage(TextParam.text(
                                     LocalizationUtils.getString(R.string.list_confirm_rename, from, to, to.isEmpty() ? LocalizationUtils.getString(R.string.list_confirm_no_hierarchy) : ""))
                                 ).confirm(() -> {
                                     DataStore.renameListPrefix(from + GROUP_SEPARATOR, to + (to.isEmpty() ? "" : GROUP_SEPARATOR));
@@ -509,14 +519,13 @@ public final class StoredList extends AbstractList {
                     .setView(menu);
             Keyboard.show(activity, title);
             final AlertDialog dialog = builder.show();
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+            title.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, parentListView.getText().toString(), title.getText().toString(), null, null, true)));
 
-            listprefixView.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> {
-                ((EditText) menu.findViewById(R.id.title)).setText(s);
-                dialog.getButton(DialogInterface.BUTTON_POSITIVE).setEnabled(s.length() > 0);
-            }));
             ViewUtils.closeKeyboardOnLosingFocus(activity, title);
         }
     }
+
 
     /**
      * Get the list title.

--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -440,8 +440,9 @@ public final class StoredList extends AbstractList {
                 } else if (!Strings.CS.equals(temp, LocalizationUtils.getString(R.string.init_custombnitem_none))) {
                     prefix = temp;
                 }
-                prefix += (prefix.isEmpty() || Strings.CS.endsWith(prefix, GROUP_SEPARATOR) ? "" : GROUP_SEPARATOR);
-                unchanged = unchanged && Strings.CS.equals(oldPrefix, prefix);
+
+                final String prefixWithSeparator = prefix + (prefix.isEmpty() || Strings.CS.endsWith(prefix, GROUP_SEPARATOR) ? "" : GROUP_SEPARATOR);
+                unchanged = unchanged && (Strings.CS.equals(oldPrefix, prefix) || Strings.CS.equals(oldPrefix, prefixWithSeparator));
             }
             dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(!unchanged && !blocked);
         }

--- a/main/src/main/res/layout/createlist.xml
+++ b/main/src/main/res/layout/createlist.xml
@@ -5,15 +5,15 @@
     android:orientation="vertical">
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/listprefix"
+        android:id="@+id/parentList"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/textinput_dropdown"
         android:hint="@string/list_parent_list"
-        android:labelFor="@id/listprefixView">
+        android:labelFor="@id/parentListView">
 
         <AutoCompleteTextView
-            android:id="@+id/listprefixView"
+            android:id="@+id/parentListView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             style="@style/textinput_dropdown"

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -157,10 +157,6 @@
                 android:title="@string/list_menu_rename"
                 app:showAsAction="ifRoom|withText"/>
             <item
-                android:id="@+id/menu_rename_list_prefix"
-                android:title="@string/list_menu_rename_list_prefix"
-                app:showAsAction="never|withText"/>
-            <item
                 android:id="@+id/menu_make_list_unique"
                 android:title="@string/caches_make_list_unique"
                 android:enabled="false"
@@ -174,6 +170,10 @@
                 android:title="@string/caches_askdeletion"
                 app:showAsAction="never"
                 android:visible="false"/>
+            <item
+                android:id="@+id/menu_rename_parent_lists"
+                android:title="@string/list_menu_rename_parent_lists"
+                app:showAsAction="never|withText"/>
         </menu>
     </item>
     <item

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -608,7 +608,7 @@
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
-    <string name="list_menu_rename_list_prefix">Rename list prefix</string>
+    <string name="list_menu_rename_parent_lists">Rename parent lists</string>
     <string name="rename_from">Rename from</string>
     <string name="rename_to">Rename to</string>
     <string name="list_menu_import">Import</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
* Disable if name did not change
* Rename menu-entry from "Rename list prefix" to "Rename parent lists"
* Prefill with parent of current list
* Make it also available for standard lists

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fix #18232


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->