### PR TITLE
Jackson Release 2.21.4

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -371,7 +371,7 @@ dependencies {
     implementation 'com.github.moving-bits:dbinspection:v0.1.2'
 
     // Jackson XML processing
-    String jacksonVersion = '2.21.3'
+    String jacksonVersion = '2.21.4'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"


### PR DESCRIPTION
Update to latest patch version in the 2.x LTS branch 2.21.x.

For release notes see https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21 and https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21.4.
