### PR TITLE
Prevent NPE in MF tilesource change

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -217,7 +217,9 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
 
     @Override
     public void prepareForTileSourceChange() {
-        ((AbstractMapsforgeTileProvider) currentTileProvider).prepareForTileSourceChange(mMapView);
+        if (currentTileProvider != null) {
+            ((AbstractMapsforgeTileProvider) currentTileProvider).prepareForTileSourceChange(mMapView);
+        }
         super.prepareForTileSourceChange();
     }
 


### PR DESCRIPTION
## Description
Fixes an error reported by Play Store debug logs, when trying to prepare for a tilesource change when no tileprovider is set yet