### PR TITLE
Calculate list size in background to prevent ANR in ListChooser

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/CacheListActionBarChooser.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListActionBarChooser.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.list.AbstractList;
 import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.ColorUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
@@ -114,12 +115,14 @@ public class CacheListActionBarChooser {
             } else {
                 TextParam.text(list.getTitle()).setImage(ip).applyTo(titleTv);
             }
-            if (list.getNumberOfCaches() >= 0) {
-                subtitleTv.setVisibility(View.VISIBLE);
-                subtitleTv.setText(getCacheListSubtitle(list));
-            } else {
-                subtitleTv.setVisibility(View.GONE);
-            }
+            AndroidRxUtils.andThenOnUi(AndroidRxUtils.computationScheduler, () -> list.getNumberOfCaches() >= 0, (hasCaches) -> {
+                if (hasCaches) {
+                    subtitleTv.setVisibility(View.VISIBLE);
+                    subtitleTv.setText(getCacheListSubtitle(list));
+                } else {
+                    subtitleTv.setVisibility(View.GONE);
+                }
+            });
         } else if (this.title != null) {
             titleTv.setText(this.title);
             subtitleTv.setVisibility(View.VISIBLE);


### PR DESCRIPTION
## Description
Calculating list size for ListChooser can lead to ANR for large lists (eg. "history" list for large database).
Fixes ANR reported by Play Store stats.