### PR TITLE
Fix #18302: Make "Has Offline Log" more prominent

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
@@ -86,6 +86,7 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         statusFound = createGroup(ll, StatusGeocacheFilter.StatusType.FOUND, false);
         statusDnf = createGroup(ll, StatusGeocacheFilter.StatusType.DNF, true);
         statusHasOfflineFoundLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_FOUND_LOG, false);
+        statusHasOfflineLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_LOG, true);
         statusOwn = createGroup(ll, StatusGeocacheFilter.StatusType.OWNED, false);
         statusStored = createGroup(ll, StatusGeocacheFilter.StatusType.STORED, true);
         statusFavorite = createGroup(ll, StatusGeocacheFilter.StatusType.FAVORITE, true);
@@ -93,7 +94,6 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         statusPremium = createGroup(ll, StatusGeocacheFilter.StatusType.PREMIUM, true);
         statusHasTrackable = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_TRACKABLE, true);
         statusHasOwnVote = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OWN_VOTE, true);
-        statusHasOfflineLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_LOG, true);
         statusSolvedMystery = createGroup(ll, StatusGeocacheFilter.StatusType.SOLVED_MYSTERY, true);
         statusCorrectedCoordinates = createGroup(ll, StatusGeocacheFilter.StatusType.CORRECTED_COORDINATES, true);
         statusHasUserDefinedWaypoints = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_USER_DEFINED_WAYPOINTS, true);

--- a/main/src/main/java/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
@@ -86,7 +86,7 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         statusFound = createGroup(ll, StatusGeocacheFilter.StatusType.FOUND, false);
         statusDnf = createGroup(ll, StatusGeocacheFilter.StatusType.DNF, true);
         statusHasOfflineFoundLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_FOUND_LOG, false);
-        statusHasOfflineLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_LOG, true);
+        statusHasOfflineLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_LOG, false);
         statusOwn = createGroup(ll, StatusGeocacheFilter.StatusType.OWNED, false);
         statusStored = createGroup(ll, StatusGeocacheFilter.StatusType.STORED, true);
         statusFavorite = createGroup(ll, StatusGeocacheFilter.StatusType.FAVORITE, true);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
I always missed the offline-log-entries, which are not found-logs.
Reason was, I didn't read the label for status filter "Has Offline **found** log" correctly, so I used this settings to filter for my offline logs...
Today I figured out, that there is a status for my purpose "Has Offline log" but it wasn't prominent enough for me

I would suggest to move it to the other offline-log status to make it more prominent.
 
Maybe we can also show it in simple mode?

| Current position | Suggested position | Simple View |
| --- | --- | --- |
| <img width="200" alt="Image" src="https://github.com/user-attachments/assets/31df4cd1-8539-4775-ba23-bd3c570c6d72" /> |<img width="200" alt="Image" src="https://github.com/user-attachments/assets/cc9904c3-3954-4453-82a7-a4c6676aae09" /> | <img width="200" alt="grafik" src="https://github.com/user-attachments/assets/aa40343d-7677-4723-b603-daf372efc81a" />|


## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fix #18302

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->