### PR TITLE
Add pseudo bookmark list for own unpublished caches

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,41 @@
+name: Build debug APK
+
+# Secrets-free debug APK build for testing feature branches on forks
+# where the org secrets required by tests.yml are not available.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - claude/unpublished-caches-bookmarklist-7d8mj7
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: true
+
+      - name: Build debug APK
+        run: ./gradlew assembleBasicDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: cgeo-basic-debug-apk
+          path: main/build/outputs/apk/basic/debug/cgeo*.apk
+          if-no-files-found: error

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -51,6 +51,7 @@ import cgeo.geocaching.loaders.LiveFilterGeocacheListLoader;
 import cgeo.geocaching.loaders.NextPageGeocacheListLoader;
 import cgeo.geocaching.loaders.NullGeocacheListLoader;
 import cgeo.geocaching.loaders.OfflineGeocacheListLoader;
+import cgeo.geocaching.loaders.OwnUnpublishedGeocacheListLoader;
 import cgeo.geocaching.loaders.OwnerGeocacheListLoader;
 import cgeo.geocaching.loaders.SearchFilterGeocacheListLoader;
 import cgeo.geocaching.location.Geopoint;
@@ -1789,6 +1790,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                     if (listId == PseudoList.ALL_LIST.id) {
                         title = LocalizationUtils.getString(R.string.list_all_lists);
                         markerId = EmojiUtils.NO_EMOJI;
+                    } else if (listId == PseudoList.OWN_UNPUBLISHED_LIST.id) {
+                        title = LocalizationUtils.getString(R.string.list_own_unpublished_caches);
+                        markerId = EmojiUtils.NO_EMOJI;
                     } else if (listId <= StoredList.TEMPORARY_LIST.id) {
                         listId = StoredList.STANDARD_LIST_ID;
                         title = LocalizationUtils.getString(R.string.stored_caches_button);
@@ -1805,7 +1809,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                         preventAskForDeletion = list.preventAskForDeletion;
                     }
 
-                    loader = new OfflineGeocacheListLoader(this, coords, listId, currentCacheFilterContext.get(), sortContext.getSort().getComparator(), false, offlineListLoadLimit);
+                    loader = listId == PseudoList.OWN_UNPUBLISHED_LIST.id
+                            ? new OwnUnpublishedGeocacheListLoader(this, coords, currentCacheFilterContext.get(), sortContext.getSort().getComparator(), false, offlineListLoadLimit)
+                            : new OfflineGeocacheListLoader(this, coords, listId, currentCacheFilterContext.get(), sortContext.getSort().getComparator(), false, offlineListLoadLimit);
 
                     break;
                 case HISTORY:

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -56,6 +56,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -864,6 +865,44 @@ public final class GCParser {
             return list;
         } catch (final Exception e) {
             Log.e("GCParser.searchBookmarkLists: error parsing html page", e);
+            return null;
+        }
+    }
+
+    /**
+     * Fetches the caches which are owned by the user but not (yet, or no longer) published. Shouldn't be called on main thread!
+     *
+     * @return A non-null search result (which might be empty) on success. Null on error.
+     */
+    @Nullable
+    @WorkerThread
+    public static SearchResult searchOwnUnpublishedGeocaches() {
+        final String page = GCLogin.getInstance().getRequestLogged("https://www.geocaching.com/my/geocaches.aspx", new Parameters("archived", "y"));
+        if (StringUtils.isBlank(page)) {
+            Log.w("GCParser.searchOwnUnpublishedGeocaches: No data from server");
+            return null;
+        }
+
+        try {
+            final Document document = Jsoup.parse(page);
+            final Set<String> geocodes = new LinkedHashSet<>();
+            final Pattern geocodePattern = Pattern.compile(GCConstants.GEOCODE_PATTERN);
+
+            for (final Element link : document.select("p.WrapFix a[href*=/geocache/]")) {
+                final String geocode = TextUtils.getMatch(link.attr("href"), geocodePattern, null);
+                if (StringUtils.isNotBlank(geocode)) {
+                    geocodes.add(geocode);
+                }
+            }
+
+            // The listing page only gives us geocode + name, not type/D/T/size, so fetch full details per cache.
+            final SearchResult searchResult = new SearchResult();
+            for (final String geocode : geocodes) {
+                searchResult.addSearchResult(Geocache.searchByGeocode(geocode, null, false, null));
+            }
+            return searchResult;
+        } catch (final Exception e) {
+            Log.e("GCParser.searchOwnUnpublishedGeocaches: error parsing html page", e);
             return null;
         }
     }

--- a/main/src/main/java/cgeo/geocaching/list/PseudoList.java
+++ b/main/src/main/java/cgeo/geocaching/list/PseudoList.java
@@ -44,6 +44,17 @@ public abstract class PseudoList extends AbstractList {
         }
     };
 
+    private static final int OWN_UNPUBLISHED_LIST_ID = 5;
+    /**
+     * list entry to show the user's own caches which are not (yet, or no longer) published, kept in sync with geocaching.com on every access
+     */
+    public static final AbstractList OWN_UNPUBLISHED_LIST = new PseudoList(OWN_UNPUBLISHED_LIST_ID, R.string.list_own_unpublished_caches, R.drawable.ic_menu_owned) {
+        @Override
+        public int getNumberOfCaches() {
+            return DataStore.getAllStoredCachesCount(OWN_UNPUBLISHED_LIST_ID);
+        }
+    };
+
     /**
      * private constructor to have all instances as constants in the class
      */

--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -234,6 +234,7 @@ public final class StoredList extends AbstractList {
             // D. Grouped and ungrouped user lists w/o selected items (each level sorted alphabetically, groups and lists intermixed)
             // E. If displayed: "All"
             // F. If displayed: "History"
+            // G. If displayed: "Own Unpublished Caches"
 
             if (item instanceof ItemGroup) {
                 return "D-" + ((ItemGroup<?, ?>) item).getGroup().toString();
@@ -256,6 +257,9 @@ public final class StoredList extends AbstractList {
             }
             if (list.id == PseudoList.HISTORY_LIST.id) {
                 return "F";
+            }
+            if (list.id == PseudoList.OWN_UNPUBLISHED_LIST.id) {
+                return "G";
             }
             if (selectedIds != null && selectedIds.contains(list.id)) {
                 return "C-" + list.getTitle();
@@ -322,6 +326,9 @@ public final class StoredList extends AbstractList {
                 }
                 if (!exceptListIds.contains(PseudoList.HISTORY_LIST.id)) {
                     lists.add(PseudoList.HISTORY_LIST);
+                }
+                if (!exceptListIds.contains(PseudoList.OWN_UNPUBLISHED_LIST.id)) {
+                    lists.add(PseudoList.OWN_UNPUBLISHED_LIST);
                 }
             }
             if (!exceptListIds.contains(PseudoList.NEW_LIST.id)) {

--- a/main/src/main/java/cgeo/geocaching/loaders/OwnUnpublishedGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OwnUnpublishedGeocacheListLoader.java
@@ -1,0 +1,31 @@
+package cgeo.geocaching.loaders;
+
+import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.gc.GCParser;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.list.PseudoList;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.sorting.CacheComparator;
+import cgeo.geocaching.storage.DataStore;
+
+import android.app.Activity;
+
+import java.util.Collections;
+
+/**
+ * Offline list loader for {@link PseudoList#OWN_UNPUBLISHED_LIST} which, unlike a normal offline list, first
+ * refreshes its membership from geocaching.com before showing the (now up to date) stored caches.
+ */
+public class OwnUnpublishedGeocacheListLoader extends OfflineGeocacheListLoader {
+
+    public OwnUnpublishedGeocacheListLoader(final Activity activity, final Geopoint searchCenter, final GeocacheFilter filter, final CacheComparator sort, final boolean sortInverse, final int limit) {
+        super(activity, searchCenter, PseudoList.OWN_UNPUBLISHED_LIST.id, filter, sort, sortInverse, limit);
+    }
+
+    @Override
+    public SearchResult runSearch() {
+        final SearchResult online = GCParser.searchOwnUnpublishedGeocaches();
+        DataStore.syncOwnUnpublishedCachesList(online == null ? Collections.emptySet() : online.getCachesFromSearchResult());
+        return super.runSearch();
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -5263,6 +5263,36 @@ public class DataStore {
         });
     }
 
+    /**
+     * Overwrites the membership of {@link PseudoList#OWN_UNPUBLISHED_LIST} with the given caches. Unlike {@link #addToList},
+     * this bypasses the {@link AbstractList#isConcrete()} check, since that pseudo list is intentionally kept in sync
+     * with an external source (geocaching.com) rather than edited by the user like a normal list.
+     */
+    public static void syncOwnUnpublishedCachesList(final Collection<Geocache> caches) {
+        final int listId = PseudoList.OWN_UNPUBLISHED_LIST.id;
+        withAccessLock(() -> {
+
+            init();
+
+            database.beginTransaction();
+            try {
+                database.delete(dbTableCachesLists, dbFieldCachesLists_list_id + " = ?", new String[]{String.valueOf(listId)});
+
+                final SQLiteStatement add = PreparedStatement.ADD_TO_LIST.getStatement();
+                for (final Geocache cache : caches) {
+                    add.bindLong(1, listId);
+                    add.bindString(2, cache.getGeocode());
+                    add.execute();
+
+                    cache.getLists().add(listId);
+                }
+                database.setTransactionSuccessful();
+            } finally {
+                database.endTransaction();
+            }
+        });
+    }
+
     public static void saveLists(final Collection<Geocache> caches, final Set<Integer> listIds) {
         if (caches.isEmpty()) {
             return;

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -439,6 +439,7 @@
     <string name="menu_history_longstring">Finds history</string>
     <string name="menu_lists_pocket_queries">Pocket queries</string>
     <string name="menu_lists_bookmarklists">Bookmark lists</string>
+    <string name="list_own_unpublished_caches">Own Unpublished Caches</string>
     <string name="menu_invert_order">Invert order</string>
 
     <!-- main screen -->


### PR DESCRIPTION
Adds an "Own Unpublished Caches" entry to the Bookmark Lists screen that scrapes my/geocaches.aspx?archived=y instead of the real bookmark-list API, letting users pull in their own not-yet-published (or de-published) geocaches as a cache list.


Claude-Session: https://claude.ai/code/session_01LG5LEBM12ancuVYYTzz9R1

<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->


## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->