### PR TITLE
Add pseudo bookmark list for own unpublished caches

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListAdapter.java
@@ -156,7 +156,7 @@ class AbstractListAdapter extends RecyclerView.Adapter<AbstractListAdapter.ViewH
         holder.binding.download.setVisibility(pocketQuery.isDownloadable() && !selectMode ? View.VISIBLE : View.GONE);
 
         // Now we are able to parse bookmark lists without download
-        holder.binding.cachelist.setVisibility((!pocketQuery.isBookmarkList() && StringUtils.isBlank(pocketQuery.getPqHash())) || selectMode ? View.GONE : View.VISIBLE);
+        holder.binding.cachelist.setVisibility((!pocketQuery.isBookmarkList() && !pocketQuery.isOwnUnpublished() && StringUtils.isBlank(pocketQuery.getPqHash())) || selectMode ? View.GONE : View.VISIBLE);
         holder.binding.label.setText(pocketQuery.getName());
         final String info = Formatter.formatPocketQueryInfo(pocketQuery);
         holder.binding.info.setVisibility(StringUtils.isNotBlank(info) ? View.VISIBLE : View.GONE);

--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
@@ -4,7 +4,9 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.models.GCList;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.extension.PocketQueryHistory;
+import cgeo.geocaching.utils.LocalizationUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class BookmarkListActivity extends AbstractListActivity {
@@ -29,12 +31,18 @@ public class BookmarkListActivity extends AbstractListActivity {
 
     @Override
     protected List<GCList> getList() {
-        return GCParser.searchBookmarkLists();
+        final List<GCList> lists = new ArrayList<>();
+        lists.add(GCList.createOwnUnpublished(LocalizationUtils.getString(R.string.list_own_unpublished_caches)));
+        final List<GCList> bookmarkLists = GCParser.searchBookmarkLists();
+        if (bookmarkLists != null) {
+            lists.addAll(bookmarkLists);
+        }
+        return lists;
     }
 
     @Override
     boolean alwaysShow(final GCList list) {
-        return PocketQueryHistory.isNew(list);
+        return list.isOwnUnpublished() || PocketQueryHistory.isNew(list);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -869,6 +869,43 @@ public final class GCParser {
     }
 
     /**
+     * Fetches the caches which are owned by the user but not (yet, or no longer) published. Shouldn't be called on main thread!
+     *
+     * @return A non-null search result (which might be empty) on success. Null on error.
+     */
+    @Nullable
+    @WorkerThread
+    public static SearchResult searchOwnUnpublishedGeocaches() {
+        final String page = GCLogin.getInstance().getRequestLogged("https://www.geocaching.com/my/geocaches.aspx", new Parameters("archived", "y"));
+        if (StringUtils.isBlank(page)) {
+            Log.w("GCParser.searchOwnUnpublishedGeocaches: No data from server");
+            return null;
+        }
+
+        try {
+            final Document document = Jsoup.parse(page);
+            final List<Geocache> caches = new ArrayList<>();
+            final Pattern geocodePattern = Pattern.compile(GCConstants.GEOCODE_PATTERN);
+
+            for (final Element link : document.select("p.WrapFix a[href*=/geocache/]")) {
+                final String geocode = TextUtils.getMatch(link.attr("href"), geocodePattern, null);
+                if (StringUtils.isBlank(geocode)) {
+                    continue;
+                }
+                final Geocache cache = new Geocache();
+                cache.setGeocode(geocode);
+                cache.setName(link.text());
+                caches.add(cache);
+            }
+
+            return new SearchResult(caches);
+        } catch (final Exception e) {
+            Log.e("GCParser.searchOwnUnpublishedGeocaches: error parsing html page", e);
+            return null;
+        }
+    }
+
+    /**
      * Creates a new bookmark list. Shouldn't be called on main thread!
      *
      * @return guid of the new list.

--- a/main/src/main/java/cgeo/geocaching/loaders/GCListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/GCListLoader.java
@@ -23,7 +23,10 @@ public class GCListLoader extends AbstractSearchLoader {
         if (Settings.isGCConnectorActive()) {
             final SearchResult combinedResult = new SearchResult();
             for (final GCList gcList : gcLists) {
-                if (gcList.isBookmarkList()) {
+                if (gcList.isOwnUnpublished()) {
+                    final SearchResult ownUnpublishedResult = GCParser.searchOwnUnpublishedGeocaches();
+                    combinedResult.addSearchResult(ownUnpublishedResult);
+                } else if (gcList.isBookmarkList()) {
                     final SearchResult bmResult = GCParser.searchByBookmarkList(GCConnector.getInstance(), gcList.getGuid(), 0);
                     combinedResult.addSearchResult(bmResult);
                 } else {

--- a/main/src/main/java/cgeo/geocaching/models/GCList.java
+++ b/main/src/main/java/cgeo/geocaching/models/GCList.java
@@ -17,8 +17,13 @@ public final class GCList implements Parcelable {
     private final long lastGenerationTime;
     private final int daysRemaining;
     private final boolean bookmarkList;
+    private final boolean ownUnpublished;
 
     public GCList(final String guid, final String name, final int caches, final boolean downloadable, final long lastGenerationTime, final int daysRemaining, final boolean bookmarkList, final String shortGuid, final String pqHash) {
+        this(guid, name, caches, downloadable, lastGenerationTime, daysRemaining, bookmarkList, shortGuid, pqHash, false);
+    }
+
+    private GCList(final String guid, final String name, final int caches, final boolean downloadable, final long lastGenerationTime, final int daysRemaining, final boolean bookmarkList, final String shortGuid, final String pqHash, final boolean ownUnpublished) {
         this.guid = guid;
         this.name = name;
         this.caches = caches;
@@ -28,6 +33,12 @@ public final class GCList implements Parcelable {
         this.bookmarkList = bookmarkList;
         this.shortGuid = shortGuid;
         this.pqHash = pqHash;
+        this.ownUnpublished = ownUnpublished;
+    }
+
+    /** Pseudo list which fetches the caches the user owns but which are not (yet, or no longer) published. */
+    public static GCList createOwnUnpublished(final String name) {
+        return new GCList(null, name, -1, false, 0, -1, false, null, null, true);
     }
 
     protected GCList(final Parcel in) {
@@ -40,6 +51,7 @@ public final class GCList implements Parcelable {
         lastGenerationTime = in.readLong();
         daysRemaining = in.readInt();
         bookmarkList = in.readInt() != 0;
+        ownUnpublished = in.readInt() != 0;
     }
 
     public static final Creator<GCList> CREATOR = new Creator<GCList>() {
@@ -60,6 +72,10 @@ public final class GCList implements Parcelable {
 
     public boolean isBookmarkList() {
         return bookmarkList;
+    }
+
+    public boolean isOwnUnpublished() {
+        return ownUnpublished;
     }
 
     public String getGuid() {
@@ -122,5 +138,6 @@ public final class GCList implements Parcelable {
         dest.writeLong(lastGenerationTime);
         dest.writeInt(daysRemaining);
         dest.writeInt(bookmarkList ? 1 : 0);
+        dest.writeInt(ownUnpublished ? 1 : 0);
     }
 }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -439,6 +439,7 @@
     <string name="menu_history_longstring">Finds history</string>
     <string name="menu_lists_pocket_queries">Pocket queries</string>
     <string name="menu_lists_bookmarklists">Bookmark lists</string>
+    <string name="list_own_unpublished_caches">Own Unpublished Caches</string>
     <string name="menu_invert_order">Invert order</string>
 
     <!-- main screen -->


### PR DESCRIPTION
Adds an "Own Unpublished Caches" entry to the Bookmark Lists screen that scrapes my/geocaches.aspx?archived=y instead of the real bookmark-list API, letting users pull in their own not-yet-published (or de-published) geocaches as a cache list.


Claude-Session: https://claude.ai/code/session_01LG5LEBM12ancuVYYTzz9R1