### PR TITLE
redesign parent list select for reuse in namedfilters: approach eddiemuc

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,6 @@ android.useAndroidX=true
 
 # For local instrumented tests: leave original c:geo installation intact on device
 android.injected.androidTest.leaveApksInstalledAfterRun=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.ui.HierarchicalListHelper;
 import cgeo.geocaching.ui.ImageParam;
 import cgeo.geocaching.ui.SimpleItemListModel;
 import cgeo.geocaching.ui.TextParam;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -94,6 +96,38 @@ public final class StoredList extends AbstractList {
         private final WeakReference<Activity> activityRef;
 
         public static final String GROUP_SEPARATOR = ":";
+
+        private static final HierarchicalListHelper.HierarchyAccessor<AbstractList> HIERARCHY_ACCESSOR = new HierarchicalListHelper.HierarchyAccessor<AbstractList>() {
+
+
+            @NonNull
+            @Override
+            public String getFullName(final AbstractList item) {
+                return item.getTitle();
+            }
+
+            @Override
+            public TextParam getDisplayText(final AbstractList item, final String simpleName) {
+                if (item instanceof StoredList) {
+                    return TextParam.text(simpleName + " [" + ((StoredList) item).count + "]");
+                }
+                return TextParam.text(item.getTitleAndCount());
+            }
+
+            @Override
+            public boolean supportsMarkers() {
+                return true;
+            }
+
+            @Nullable
+            @Override
+            public String getMarker(final AbstractList item) {
+                if (item instanceof StoredList) {
+                    return ((StoredList) item).emojiMarker;
+                }
+                return null;
+            }
+        };
 
         public UserInterface(@NonNull final Activity activity) {
             this.activityRef = new WeakReference<>(activity);
@@ -226,7 +260,7 @@ public final class StoredList extends AbstractList {
             return CommonUtils.getNullHandlingComparator((p1, p2) -> collator.compare(getSortString(p1, selectedIds), getSortString(p2, selectedIds)), true);
         }
 
-        private String getSortString(final Object item, final Set<Integer> selectedIds) {
+        private static String getSortString(final Object item, final Set<Integer> selectedIds) {
             //Stored list sorting:
             // A. If displayed: "Create new"
             // B. If displayed: "Stored",
@@ -332,13 +366,13 @@ public final class StoredList extends AbstractList {
 
         public void promptForListCreation(@NonNull final Action1<Integer> runAfterwards, final String newListName) {
             // We need to update the list cache by creating a new StoredList object here.
-            handleListNameInput(newListName, R.string.list_dialog_create_title, R.string.list_dialog_create, listName -> {
+            handleListNameInput(null, R.string.list_dialog_create_title, R.string.list_dialog_create, (listName, marker) -> {
                 final Activity activity = activityRef.get();
                 if (activity == null) {
                     return;
                 }
                 final int newId = DataStore.createList(listName);
-                new StoredList(newId, listName, EmojiUtils.NO_EMOJI, false, 0);
+                new StoredList(newId, listName, marker, false, 0);
 
                 if (newId >= DataStore.customListIdOffset) {
                     runAfterwards.call(newId);
@@ -350,13 +384,14 @@ public final class StoredList extends AbstractList {
 
         public void promptForListCreation(@NonNull final Action1<Set<Integer>> runAfterwards, final Set<Integer> selectedLists, final String newListName) {
             // We need to update the list cache by creating a new StoredList object here.
-            handleListNameInput(newListName, R.string.list_dialog_create_title, R.string.list_dialog_create, listName -> {
+            handleListNameInput(null, R.string.list_dialog_create_title, R.string.list_dialog_create, (listName, marker) -> {
                 final Activity activity = activityRef.get();
                 if (activity == null) {
                     return;
                 }
                 final int newId = DataStore.createList(listName);
-                new StoredList(newId, listName, EmojiUtils.NO_EMOJI, false, 0);
+                DataStore.setListEmoji(newId, marker);
+                new StoredList(newId, listName, marker, false, 0);
 
                 if (newId >= DataStore.customListIdOffset) {
                     selectedLists.remove(PseudoList.NEW_LIST.id);
@@ -369,56 +404,58 @@ public final class StoredList extends AbstractList {
             });
         }
 
-        private void handleListNameInput(final String defaultValue, final int dialogTitle, final int buttonTitle, final Action1<String> runnable) {
+        private void handleListNameInput(final StoredList currentList, final int dialogTitle, final int buttonTitle, final BiConsumer<String, String> runnable) {
             final Activity activity = activityRef.get();
             if (activity == null) {
                 return;
             }
 
-            final View menu = LayoutInflater.from(activity).inflate(R.layout.createlist, null);
-            final TextInputLayout parentList = menu.findViewById(R.id.parentList);
-            final AutoCompleteTextView parentListView = menu.findViewById(R.id.parentListView);
-            final TextInputEditText listname = menu.findViewById(R.id.title);
+            HierarchicalListHelper.of(HIERARCHY_ACCESSOR).upsertItem(activity, getMenuLists(true, -1), currentList, dialogTitle, buttonTitle, runnable);
 
-            final String current = defaultValue != null ? defaultValue.substring(defaultValue.lastIndexOf(GROUP_SEPARATOR) + 1).trim() : "";
-            final String oldPrefix = defaultValue != null ? defaultValue.substring(0, defaultValue.length() - current.length()) : "";
-
-            final List<String> hierarchies = DataStore.getListHierarchy();
-            hierarchies.add(0, LocalizationUtils.getString(R.string.init_custombnitem_none)); // overwrite empty entry
-            hierarchies.add(1, LocalizationUtils.getString(R.string.list_create_parent));
-            parentList.setVisibility(View.VISIBLE);
-            parentListView.setText(Strings.CS.endsWith(oldPrefix, GROUP_SEPARATOR) ? oldPrefix.substring(0, oldPrefix.length() - 1) : oldPrefix);
-            parentListView.setAdapter(new NewListAdapter(activity, R.layout.createlist_item, hierarchies));
-
-            ((EditText) menu.findViewById(R.id.title)).setText(current);
-            final AlertDialog.Builder builder = Dialogs.newBuilder(activity)
-                    .setTitle(dialogTitle)
-                    .setPositiveButton(buttonTitle, ((d, which) -> {
-                            // same logic as in updateButtonState()
-                            String prefix = "";
-                        final String temp = ((AutoCompleteTextView) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.parentListView))).getText().toString().trim();
-                            if (Strings.CS.equals(temp, LocalizationUtils.getString(R.string.list_create_parent))) {
-                                prefix = Objects.requireNonNull(((TextInputEditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.newParent))).getText()).toString().trim();
-                            } else if (!Strings.CS.equals(temp, LocalizationUtils.getString(R.string.init_custombnitem_none))) {
-                                prefix = temp;
-                            }
-                            prefix += (prefix.isEmpty() || Strings.CS.endsWith(prefix, GROUP_SEPARATOR) ? "" : GROUP_SEPARATOR);
-                            runnable.call(handleListNameInputHelper(prefix, ((EditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.title))).getText().toString().trim()));
-                        }))
-                    .setNegativeButton(android.R.string.cancel, (d, which) -> d.dismiss())
-                    .setView(menu);
-            Keyboard.show(activity, menu.findViewById(R.id.title));
-            final AlertDialog dialog = builder.show();
-            ((NewListAdapter) parentListView.getAdapter()).setNewParentInput(dialog.findViewById(R.id.newParentWrapper));
-
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-            final String oldListname = Objects.requireNonNull(listname.getText()).toString();
-            parentListView.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, s.toString(), oldListname, listname.getText().toString(), false)));
-            ((TextInputEditText) Objects.requireNonNull(dialog.findViewById(R.id.newParent))).addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, parentListView.getText().toString(), oldListname, listname.getText().toString(), false)));
-            listname.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, parentListView.getText().toString(), oldListname, s.toString(), false)));
-
-            ViewUtils.closeKeyboardOnLosingFocus(activity, listname);
-            ViewUtils.closeKeyboardOnLosingFocus(activity, menu.findViewById(R.id.newParent));
+//            final View menu = LayoutInflater.from(activity).inflate(R.layout.createlist, null);
+//            final TextInputLayout parentList = menu.findViewById(R.id.parentList);
+//            final AutoCompleteTextView parentListView = menu.findViewById(R.id.parentListView);
+//            final TextInputEditText listname = menu.findViewById(R.id.title);
+//
+//            final String current = defaultValue != null ? defaultValue.substring(defaultValue.lastIndexOf(GROUP_SEPARATOR) + 1).trim() : "";
+//            final String oldPrefix = defaultValue != null ? defaultValue.substring(0, defaultValue.length() - current.length()) : "";
+//
+//            final List<String> hierarchies = DataStore.getListHierarchy();
+//            hierarchies.add(0, LocalizationUtils.getString(R.string.init_custombnitem_none)); // overwrite empty entry
+//            hierarchies.add(1, LocalizationUtils.getString(R.string.list_create_parent));
+//            parentList.setVisibility(View.VISIBLE);
+//            parentListView.setText(Strings.CS.endsWith(oldPrefix, GROUP_SEPARATOR) ? oldPrefix.substring(0, oldPrefix.length() - 1) : oldPrefix);
+//            parentListView.setAdapter(new NewListAdapter(activity, R.layout.createlist_item, hierarchies));
+//
+//            ((EditText) menu.findViewById(R.id.title)).setText(current);
+//            final AlertDialog.Builder builder = Dialogs.newBuilder(activity)
+//                    .setTitle(dialogTitle)
+//                    .setPositiveButton(buttonTitle, ((d, which) -> {
+//                            // same logic as in updateButtonState()
+//                            String prefix = "";
+//                        final String temp = ((AutoCompleteTextView) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.parentListView))).getText().toString().trim();
+//                            if (Strings.CS.equals(temp, LocalizationUtils.getString(R.string.list_create_parent))) {
+//                                prefix = Objects.requireNonNull(((TextInputEditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.newParent))).getText()).toString().trim();
+//                            } else if (!Strings.CS.equals(temp, LocalizationUtils.getString(R.string.init_custombnitem_none))) {
+//                                prefix = temp;
+//                            }
+//                            prefix += (prefix.isEmpty() || Strings.CS.endsWith(prefix, GROUP_SEPARATOR) ? "" : GROUP_SEPARATOR);
+//                            runnable.call(handleListNameInputHelper(prefix, ((EditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.title))).getText().toString().trim()));
+//                        }))
+//                    .setNegativeButton(android.R.string.cancel, (d, which) -> d.dismiss())
+//                    .setView(menu);
+//            Keyboard.show(activity, menu.findViewById(R.id.title));
+//            final AlertDialog dialog = builder.show();
+//            ((NewListAdapter) parentListView.getAdapter()).setNewParentInput(dialog.findViewById(R.id.newParentWrapper));
+//
+//            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+//            final String oldListname = Objects.requireNonNull(listname.getText()).toString();
+//            parentListView.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, s.toString(), oldListname, listname.getText().toString(), false)));
+//            ((TextInputEditText) Objects.requireNonNull(dialog.findViewById(R.id.newParent))).addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, parentListView.getText().toString(), oldListname, listname.getText().toString(), false)));
+//            listname.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> updateButtonState(dialog, oldPrefix, parentListView.getText().toString(), oldListname, s.toString(), false)));
+//
+//            ViewUtils.closeKeyboardOnLosingFocus(activity, listname);
+//            ViewUtils.closeKeyboardOnLosingFocus(activity, menu.findViewById(R.id.newParent));
         }
 
         private static void updateButtonState(final AlertDialog dialog, @Nullable final String oldPrefix, @Nullable final String newPrefix, @Nullable final String oldListname, @Nullable final String newListname, final boolean ignoreEmptyPrefix) {
@@ -462,8 +499,9 @@ public final class StoredList extends AbstractList {
 
         public void promptForListRename(final int listId, @NonNull final Runnable runAfterRename) {
             final StoredList list = DataStore.getList(listId);
-            handleListNameInput(list.title, R.string.list_dialog_rename_title, R.string.list_dialog_rename, listName -> {
+            handleListNameInput(list, R.string.list_dialog_rename_title, R.string.list_dialog_rename, (listName, marker) -> {
                 DataStore.renameList(listId, listName);
+                DataStore.setListEmoji(listId, marker);
                 runAfterRename.run();
             });
         }

--- a/main/src/main/java/cgeo/geocaching/ui/HierarchicalListHelper.java
+++ b/main/src/main/java/cgeo/geocaching/ui/HierarchicalListHelper.java
@@ -1,0 +1,258 @@
+package cgeo.geocaching.ui;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.Keyboard;
+import cgeo.geocaching.databinding.HierarchylisthelperUpsertBinding;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.CommonUtils;
+import cgeo.geocaching.utils.EmojiUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.util.Pair;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class HierarchicalListHelper<T> {
+
+    public static final String SEPARATOR = ":";
+
+    public interface HierarchyAccessor<T> {
+
+        @NonNull
+        String getFullName(T item);
+
+        @Nullable
+        default TextParam getDisplayText(T item, String simpleName) {
+            return null;
+        }
+
+        boolean supportsMarkers();
+
+        @Nullable
+        default String getMarker(T item) {
+            return null;
+        }
+
+        default String getGroupSortString(String groupName) {
+            return null;
+        }
+    }
+
+    private final HierarchyAccessor<T> accessor;
+
+    private HierarchicalListHelper(final HierarchyAccessor<T> accessor) {
+        this.accessor = accessor;
+    }
+
+    public static <T> HierarchicalListHelper<T> of(final HierarchyAccessor<T> accessor) {
+        return new HierarchicalListHelper<>(accessor);
+    }
+
+    public SimpleItemListModel<T>.GroupingOptions<String> configureDisplay(final SimpleDialog.ItemSelectModel<T> model) {
+
+        // Display for normal items
+        model.setDisplayMapper((item, itemGroup) -> {
+            final String fullName = accessor.getFullName(item);
+            final String simple = getSimpleName(fullName);
+            final TextParam tp = accessor.getDisplayText(item, simple);
+            return tp != null ? tp : TextParam.text(simple);
+        }, (item, itemGroup) -> accessor.getFullName(item), null);
+        if (accessor.supportsMarkers()) {
+            model.setDisplayIconMapper(this::getMarkerImage);
+        }
+
+        // GROUPING
+        final SimpleItemListModel<T>.GroupingOptions<String> groupingOptions =
+        model.activateGrouping(this::getParent)
+            .setGroupGroupMapper(this::getParent)
+            .setItemGroupComparator(getGroupListSorter())
+            .setGroupDisplayMapper(gi -> {
+                final String parentGroup = gi.getParent() == null || gi.getParent().getGroup() == null ? "" : gi.getParent().getGroup();
+                String title = gi.getGroup();
+                if (title.startsWith(parentGroup + SEPARATOR)) {
+                    title = title.substring(parentGroup.length() + 1);
+                }
+                return TextParam.text("**" + title + "** *(" + gi.getContainedItemCount() + ")*").setMarkdown(true);
+            })
+            .setGroupPruner(gi -> gi.getSize() >= 2);
+        if (accessor.supportsMarkers()) {
+            groupingOptions.setGroupDisplayIconMapper(gi -> gi.getItems().isEmpty() ? null : getMarkerImage(gi.getItems().get(0)));
+        }
+        return groupingOptions;
+    }
+
+    public void upsertItem(final Context ctx, final Collection<T> items, @Nullable final T currentItem, final int dialogTitle, final int buttonTitle, final BiConsumer<String, String> onNewName) {
+
+        final HierarchylisthelperUpsertBinding binding = HierarchylisthelperUpsertBinding.inflate(LayoutInflater.from(ctx));
+        final Pair<List<String>, Map<String, String>> groupsAndMarkers = calculateGroups(items);
+        final Map<String, String> markerMap = new HashMap<>(groupsAndMarkers.second);
+
+        //parent list
+        final String none = LocalizationUtils.getString(R.string.init_custombnitem_none);
+        final String initialGroup = currentItem == null ? null : getParent(accessor.getFullName(currentItem));
+        final String[] rawListStorage = new String[] { initialGroup };
+        setParentListInView(initialGroup, none, markerMap, binding);
+        binding.parentList.setOnClickListener(v -> {
+            final List<String> hierarchies = new ArrayList<>(groupsAndMarkers.first);
+            hierarchies.add(0, none);
+            final SimpleDialog.ItemSelectModel<String> model = new SimpleDialog.ItemSelectModel<>();
+            model
+                .setItems(hierarchies)
+                .setDisplayMapper(TextParam::text);
+            if (accessor.supportsMarkers()) {
+                model.setDisplayIconMapper(g -> groupToImageParam(g, markerMap));
+            }
+            SimpleDialog.ofContext(ctx).selectSingle(model, str -> {
+                rawListStorage[0] = none.equals(str) ? null : str;
+                setParentListInView(rawListStorage[0], none, markerMap, binding);
+            });
+        });
+
+        //add new parent list
+        binding.newParentLayout.setVisibility(View.GONE);
+        binding.newParentAdd.setOnClickListener(v -> {
+            binding.newParentAdd.setEnabled(false);
+            binding.newParentDelete.setEnabled(true);
+            binding.newParentLayout.setVisibility(View.VISIBLE);
+            binding.newParent.requestFocus();
+            Keyboard.show(ctx, binding.newParent);
+        });
+        binding.newParentDelete.setOnClickListener(v -> {
+            binding.newParentAdd.setEnabled(true);
+            binding.newParentDelete.setEnabled(false);
+            binding.newParentLayout.setVisibility(View.GONE);
+        });
+
+        //name field
+        if (currentItem != null) {
+            binding.name.setText(getSimpleName(accessor.getFullName(currentItem)));
+        }
+        //marker
+        binding.marker.setVisibility(accessor.supportsMarkers() ? View.VISIBLE : View.GONE);
+        EmojiUtils.initializeEmojiMarkerButton(binding.marker, accessor.getMarker(currentItem));
+
+        final SimpleDialog dialog = SimpleDialog.ofContext(ctx)
+            .setTitle(dialogTitle)
+            .setButtons(buttonTitle, android.R.string.cancel)
+            .setCustomView(binding);
+
+        dialog.confirm(() -> {
+            if (StringUtils.isBlank(binding.name.getText())) {
+                return;
+            }
+            //collect new name from dialog
+            String name = binding.name.getText().toString().trim();
+            if (binding.newParentLayout.getVisibility() == View.VISIBLE && !StringUtils.isBlank(binding.newParent.getText())) {
+                name = binding.newParent.getText().toString().trim() + SEPARATOR + name;
+            }
+            if (!StringUtils.isBlank(rawListStorage[0])) {
+                name = rawListStorage[0] + SEPARATOR + name;
+            }
+
+            onNewName.accept(name, accessor.supportsMarkers() && binding.marker.getText() != null ? binding.marker.getText().toString() : null);
+        });
+
+        //disable create/update button on empty name
+        final Runnable checker = () -> dialog.getDialog().getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(!StringUtils.isBlank(binding.name.getText()));
+        checker.run();
+        binding.name.addTextChangedListener(ViewUtils.createSimpleWatcher(s -> checker.run()));
+    }
+
+    private void setParentListInView(final String text, final String none, final Map<String, String> markerMap, final HierarchylisthelperUpsertBinding binding) {
+        if (text == null) {
+            binding.parentList.setText(none);
+            return;
+        }
+        final String emoji = markerMap.get(text);
+        binding.parentList.setText(emoji == null ? "" : emoji + " " + text);
+    }
+
+    private ImageParam groupToImageParam(final String text, final Map<String, String> markerMap) {
+        return StringUtils.isBlank(text) || !markerMap.containsKey(text) ? null : ImageParam.emoji(markerMap.get(text), 30);
+    }
+
+    @Nullable
+    private ImageParam getMarkerImage(final T item) {
+        final String marker = accessor.getMarker(item);
+        return marker == null ? null : ImageParam.emoji(marker, 30);
+    }
+
+    @NonNull
+    private String getSimpleName(@NonNull final Object obj) {
+        final String str = String.valueOf(obj);
+        final int idx = str.lastIndexOf(SEPARATOR);
+        return idx <= 0 ? str : str.substring(idx + 1);
+    }
+
+    @Nullable
+    private String getParent(@NonNull final Object obj) {
+        final String str = String.valueOf(obj);
+        final int idx = str.lastIndexOf(SEPARATOR);
+        return idx <= 0 ? null : str.substring(0, idx);
+    }
+
+    private Comparator<Object> getGroupListSorter() {
+        final Collator collator = Collator.getInstance();
+        return CommonUtils.getNullHandlingComparator((g1, g2) -> {
+            final String s1 = accessor.getGroupSortString(String.valueOf(g1));
+            final String s2 = accessor.getGroupSortString(String.valueOf(g2));
+            return collator.compare(s1 != null ? s1 : String.valueOf(g1), s2 != null ? s2 : String.valueOf(g2));
+        }, true);
+    }
+
+    private Pair<List<String>, Map<String, String>> calculateGroups(final Collection<T> items) {
+
+        final NavigableMap<String, String> markerMap = items.stream().collect(Collectors.toMap(
+            accessor::getFullName,
+            item -> Objects.toString(accessor.getMarker(item), ""),
+            (existing, replacement) -> existing,
+            TreeMap::new));
+        markerMap.replaceAll((key, value) -> "".equals(value) ? null : value);
+
+
+        final List<String> sortedGroups = new ArrayList<>(markerMap.keySet()).stream()
+                .flatMap(key -> {
+                    final List<String> subGroups = new ArrayList<>();
+                    String group = getParent(key);
+                    while (group != null) {
+                        subGroups.add(group);
+
+                        final String marker = markerMap.get(group);
+                        if (StringUtils.isBlank(marker)) {
+                            markerMap.put(group, markerMap.get(key));
+                        }
+
+                        group = getParent(group);
+                    }
+                    return subGroups.stream();
+                })
+                .distinct()
+                .sorted()
+                .toList();
+
+        return new Pair<>(sortedGroups, markerMap);
+    }
+
+
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/EmojiUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/EmojiUtils.java
@@ -33,6 +33,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
@@ -228,6 +229,27 @@ public class EmojiUtils {
         }
 
         dialog.show();
+    }
+
+    public static void initializeEmojiMarkerButton(final Button markerBtn, final String initialValue) {
+        setEmojiMarkerButton(markerBtn, initialValue);
+        markerBtn.setOnClickListener(v ->
+            selectEmojiPopup(markerBtn.getContext(), markerBtn.getText().toString(), false, null,
+            newValue -> setEmojiMarkerButton(markerBtn, newValue)));
+    }
+
+    private static void setEmojiMarkerButton(final Button markerBtn, final String value) {
+        if (StringUtils.isNotBlank(value)) {
+            markerBtn.setText(value);
+            if (markerBtn instanceof MaterialButton) {
+                ((MaterialButton) markerBtn).setIcon(null);
+            }
+        } else {
+            markerBtn.setText(null);
+            if (markerBtn instanceof MaterialButton) {
+                ((MaterialButton) markerBtn).setIconResource(R.drawable.ic_menu_marker_off);
+            }
+        }
     }
 
     // This cross-converting solves a tinting issue described in #11616. Sorry, it is ugly but the only possibility we have found so far.

--- a/main/src/main/res/color/button_icon_tint_selector.xml
+++ b/main/src/main/res/color/button_icon_tint_selector.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- makes icon-only buttons (see style "button_icon" and derivatives) appear grayed-out when disabled -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.38" android:color="@color/colorText" android:state_enabled="false" />
+    <item android:color="@color/colorText" />
+</selector>
+

--- a/main/src/main/res/layout/hierarchylisthelper_upsert.xml
+++ b/main/src/main/res/layout/hierarchylisthelper_upsert.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="10dp"
+        android:orientation="horizontal">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="center_vertical"
+            android:id="@+id/parentListWrapper"
+            style="@style/textinput_dropdown"
+            android:hint="@string/list_parent_list"
+            android:labelFor="@id/parentList">
+
+            <AutoCompleteTextView
+                android:id="@+id/parentList"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                style="@style/textinput_dropdown"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/newParentAdd"
+            style="@style/button_icon"
+            android:layout_gravity="center_vertical"
+            app:icon="@drawable/ic_menu_add" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginHorizontal="10dp"
+        android:id="@+id/newParentLayout"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/newParentWrapper"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="1"
+            style="@style/textinput_edittext_singleline">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/newParent"
+                android:inputType="textPersonName"
+                style="@style/textinput_embedded_singleline"
+                android:hint="@string/list_parent_list"
+                android:importantForAutofill="yes"
+                android:autofillHints="@string/list_parent_list" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/newParentDelete"
+            style="@style/button_icon"
+            android:layout_gravity="center_vertical"
+            android:layout_marginTop="14dp"
+            app:icon="@drawable/ic_menu_delete" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginHorizontal="10dp"
+        android:gravity="center_vertical">
+
+        <Button
+            android:id="@+id/marker"
+            style="@style/button_icon"
+            android:layout_gravity="center_vertical"
+            android:layout_marginTop="14dp"
+            android:textSize="@dimen/textSize_listsPrimary"
+            app:icon="@drawable/ic_menu_marker" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/nameWrapper"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="center_vertical"
+            style="@style/textinput_edittext_singleline">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/name"
+                android:inputType="textPersonName"
+                style="@style/textinput_embedded_singleline"
+                android:hint="@string/list_name"
+                android:importantForAutofill="yes"
+                android:autofillHints="@string/list_name" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -628,6 +628,7 @@
     <string name="list_dialog_rename">Rename</string>
     <string name="list_not_available">List no longer available, switching to standard list</string>
     <string name="list_parent_list">Parent list</string>
+    <string name="create_new_parent">Create new parent</string>
     <string name="list_create_parent">&lt;Create new parent list&gt;</string>
     <string name="list_name">List name</string>
     <string name="list_confirm_rename">Renaming from \"%1$s\" to \"%2$s\"\n%3$s\nThis action cannot be undone!</string>

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -120,7 +120,7 @@
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">@dimen/textSize_buttonsPrimary</item>
         <item name="strokeColor">@color/button_strokecolor_selector</item>
-        <item name="iconTint">@color/colorText</item>
+        <item name="iconTint">@color/button_icon_tint_selector</item>
     </style>
 
     <style name="button_full_base" parent="button_base">


### PR DESCRIPTION
redesign parent list select for reuse in namedfilters: approach eddiemuc

Ok, I couldn't keep my fingers from it. This is my own approach to handle the "create/rename list" parent thingies. Idea is to provide it in a way that it can be reused for other places where hierarchical lists are used, esp for namedfilters.

The approach is far from ready! This is to gather feedback whether I should continue this or abort.

Key class is the new HierarchicalListHelper to provide helpers for entities using hierarchical lists 

Features:
* reusable hierarchical list helpers (ready for usage in storedlists and named filters)
* allows renaming/creating with selecting existing parent or add a new parent
* allows edit/creation of markers in same dialog

Create dialog initial:
<img width="397" height="260" alt="image" src="https://github.com/user-attachments/assets/887ee460-9859-4337-8805-526c62860671" />

Parent selection:
<img width="400" height="178" alt="image" src="https://github.com/user-attachments/assets/a9769caa-daeb-444d-8328-c91603c30ac8" />

Add parent ("plus" button) + add marker:
<img width="405" height="337" alt="image" src="https://github.com/user-attachments/assets/44104fb1-216f-424b-8e47-4276e2de505a" />

