### PR TITLE
set finals as corrected

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -57,6 +57,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.models.GCList;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.network.DownloadProgress;
 import cgeo.geocaching.network.Send2CgeoDownloader;
 import cgeo.geocaching.sensors.GeoData;
@@ -116,11 +117,13 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.ListView;
+import android.widget.RadioGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.graphics.Insets;
 import androidx.core.util.Consumer;
 import androidx.loader.app.LoaderManager;
@@ -647,6 +650,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setMenuItemLabel(menu, R.id.menu_show_attributes, R.string.caches_show_attributes_selected, R.string.caches_show_attributes_all, checkedCount);
             MenuUtils.setEnabled(menu, R.id.menu_set_cache_icon, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_set_cache_icon, R.string.caches_set_cache_icon_selected, R.string.caches_set_cache_icon_all, checkedCount);
+            MenuUtils.setEnabled(menu, R.id.menu_set_final_wp_as_corrected_coords, !isEmpty);
+            setMenuItemLabel(menu, R.id.menu_set_final_wp_as_corrected_coords, R.string.caches_set_final_wp_as_corrected_coords_selected, R.string.caches_set_final_wp_as_corrected_coords_all, checkedCount);
             MenuUtils.setVisibleEnabled(menu, R.id.menu_recalculate_health_score, true, !isEmpty);
 
             // Manage Lists submenu
@@ -753,6 +758,57 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 refreshCurrentList(AfterLoadAction.CHECK_IF_EMPTY);
             }
         }.execute();
+    }
+
+    private void setFinalWpAsCorrectedCoords() {
+        final List<Geocache> candidates = adapter.getCheckedOrAllCaches();
+        final List<Geocache> matching = new ArrayList<>();
+        for (final Geocache cache : candidates) {
+            int count = 0;
+            for (final Waypoint wp : cache.getWaypoints()) {
+                if (wp.isFinalWithCoords()) {
+                    count++;
+                }
+            }
+            if (count == 1) {
+                matching.add(cache);
+            }
+        }
+        if (matching.isEmpty()) {
+            showToast(LocalizationUtils.getString(R.string.caches_set_final_wp_as_corrected_coords_none_found));
+            return;
+        }
+        final AlertDialog.Builder builder = Dialogs.newBuilder(this);
+        final View layout = View.inflate(this, R.layout.dialog_set_final_wp_as_corrected_coords, null);
+
+        builder.setTitle(R.string.caches_set_final_wp_as_corrected_coords_all)
+                .setView(layout)
+                .setMessage(LocalizationUtils.getString(R.string.caches_set_final_wp_as_corrected_coords_info, matching.size()))
+                .setPositiveButton(R.string.ok, (dialog, which) ->
+                    applyFinalWpAsCorrectedCoords(matching, ((RadioGroup) layout.findViewById(R.id.radioGroup)).getCheckedRadioButtonId() == R.id.radio_also_online))
+                .setNegativeButton(R.string.cancel, null)
+                .create().show();
+    }
+
+    private void applyFinalWpAsCorrectedCoords(final List<Geocache> caches, final boolean uploadOnline) {
+        AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
+            for (final Geocache cache : caches) {
+                final Waypoint finalWp = cache.getFirstMatchingWaypoint(Waypoint::isFinalWithCoords);
+                if (finalWp != null) {
+                    if (!cache.hasUserModifiedCoords()) {
+                        cache.createOriginalWaypoint(cache.getCoords());
+                    }
+                    cache.setCoords(finalWp.getCoords());
+                    DataStore.saveUserModifiedCoords(cache);
+                }
+            }
+        }, () -> {
+            adapter.setSelectMode(false);
+            refreshCurrentList(AfterLoadAction.CHECK_IF_EMPTY);
+            if (uploadOnline) {
+                new BatchUploadModifiedCoordinates(true).export(caches, CacheListActivity.this);
+            }
+        });
     }
 
     @Override
@@ -878,6 +934,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             EmojiUtils.selectEmojiPopup(this, markerId, false, null, this::setListMarker);
         } else if (menuItem == R.id.menu_set_cache_icon) {
             EmojiUtils.selectEmojiPopup(this, null, true, null, this::setCacheIcons);
+        } else if (menuItem == R.id.menu_set_final_wp_as_corrected_coords) {
+            setFinalWpAsCorrectedCoords();
         } else if (menuItem == R.id.menu_set_askfordeletion) {
             setPreventAskForDeletion(false);
         } else {

--- a/main/src/main/res/drawable/ic_menu_final.xml
+++ b/main/src/main/res/drawable/ic_menu_final.xml
@@ -1,0 +1,11 @@
+<!-- taken from home / material.com -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M14.4,6L14,4H5V21H7V14H12.6L13,16H20V6H14.4Z"/>
+</vector>

--- a/main/src/main/res/layout/dialog_set_final_wp_as_corrected_coords.xml
+++ b/main/src/main/res/layout/dialog_set_final_wp_as_corrected_coords.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingHorizontal="25dp"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/text_default" />
+
+    <RadioGroup
+        android:id="@+id/radioGroup"
+        android:checkedButton="@id/radio_local_only"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <RadioButton
+            android:id="@+id/radio_local_only"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/waypoint_set_as_cache_coords" />
+        <RadioButton
+            android:id="@+id/radio_also_online"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/waypoint_save_and_modify_on_website" />
+    </RadioGroup>
+
+</LinearLayout>

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -127,6 +127,12 @@
                 android:enabled="false"
                 app:showAsAction="never"/>
             <item
+                android:id="@+id/menu_set_final_wp_as_corrected_coords"
+                android:title="@string/caches_set_final_wp_as_corrected_coords_all"
+                android:icon="@drawable/ic_menu_final"
+                android:enabled="false"
+                app:showAsAction="never"/>
+            <item
                 android:id="@+id/menu_recalculate_health_score"
                 android:title="@string/caches_recalculate_health_score"
                 android:enabled="false"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -570,6 +570,10 @@
     <string name="caches_set_cache_icon">Set cache icon</string>
     <string name="caches_set_cache_icon_all">Set cache icon for all caches</string>
     <string name="caches_set_cache_icon_selected">Set cache icon for selected caches</string>
+    <string name="caches_set_final_wp_as_corrected_coords_all">Set Final as coordinates</string>
+    <string name="caches_set_final_wp_as_corrected_coords_selected">Set Final as coordinates (selected)</string>
+    <string name="caches_set_final_wp_as_corrected_coords_info">Apply the finals waypoint as corrected coordinates on %1$d caches.</string>
+    <string name="caches_set_final_wp_as_corrected_coords_none_found">No caches with final waypoint found.</string>
     <string name="caches_reset_cache_icons_title">Reset cache icon</string>
     <string name="caches_make_list_unique">Make list unique</string>
     <string name="caches_set_listmarker">Set list marker</string>


### PR DESCRIPTION
adds an option to cache list menu to mass-apply the coordinates of a "Final" waypoint as corrected coordinates, both offline and online.

Useful e.g. for challenges.