### PR TITLE
rel to #8713: add parser for trailing-hemisphere decimal coordinates …

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -27,7 +27,7 @@ public class GeopointParser {
     private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. ([-+]?\\d{2,})");
     private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("([-+]?\\d{1,3},\\d+), ([-+]?\\d{1,3},\\d+)");
 
-    private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
+    private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecTrailingSignParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 
     private GeopointParser() {
         // utility class
@@ -382,6 +382,40 @@ public class GeopointParser {
     }
 
     /**
+     * Parser for DegDec format with trailing hemisphere: DD.DDDDDDD° X (e.g. mapy.cz "50.3481209N, 7.0445565E").
+     */
+    private static final class DegDecTrailingSignParser extends AbstractLatLonParser {
+        //                                        (       1       )        (  2  )
+        private static final String STRING_LAT = "(\\d++\\.\\d++)°?\\s*([NS])";
+
+        //                                        (       1       )        (   2  )
+        private static final String STRING_LON = "(\\d++\\.\\d++)°?\\s*([WEO])\\b";
+        private static final String STRING_SEPARATOR = "[,\\s]+";
+        private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
+        private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);
+        private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);
+
+        DegDecTrailingSignParser() {
+            super(PATTERN_LAT, PATTERN_LON, PATTERN_LATLON);
+        }
+
+        /**
+         * @see AbstractLatLonParser#parse(List)
+         */
+        @Override
+        @Nullable
+        public Double parse(@NonNull final List<String> groups) {
+            final String group1 = groups.get(0);
+            final String group2 = groups.get(1);
+            if (StringUtils.isBlank(group2)) {
+                return null;
+            }
+
+            return createCoordinate(group2, group1, "", "");
+        }
+    }
+
+    /**
      * Parser for DegDec format: DD.DDDDDDD°.
      */
     private static final class DegDecParser extends AbstractLatLonParser {
@@ -587,6 +621,7 @@ public class GeopointParser {
      * - X DD° MM.MMM
      * - X DD° MM SS
      * - DD.DDDDDDD
+     * - DD.DDDDDDD X (trailing hemisphere, e.g. mapy.cz)
      * - UTM
      * <br>
      * Both . and , are accepted, also variable count of spaces (also 0)

--- a/main/src/main/res/raw/changelog_base.md
+++ b/main/src/main/res/raw/changelog_base.md
@@ -98,3 +98,4 @@ As announced with 2025.07.17 and 2025.12.01 releases, we have finally removed th
 - Fix: "Use imperial settings" not initialized correctly on fresh installs
 - Change: Bergamot open source offline translation module replacing closed-source Google ML Kit translator
 - Change: New emoji selector
+- New: Support parsing coordinates with trailing hemisphere (e.g. mapy.cz "50.3481209N, 7.0445565E")

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -373,6 +373,23 @@ public class GeoPointParserTest {
     }
 
     @Test
+    public void test8713() {
+        // decimal degrees with trailing hemisphere (e.g. mapy.cz): "50.3481209N, 7.0445565E"
+        final Geopoint ref = new Geopoint(50.3481209, 7.0445565);
+        assertGeopointEquals(GeopointParser.parse("50.3481209N, 7.0445565E"), ref, 1e-6f);
+        // without space after the comma separator
+        assertGeopointEquals(GeopointParser.parse("50.3481209N,7.0445565E"), ref, 1e-6f);
+        // with a space before the hemisphere letter
+        assertGeopointEquals(GeopointParser.parse("50.3481209 N, 7.0445565 E"), ref, 1e-6f);
+        // with degree sign
+        assertGeopointEquals(GeopointParser.parse("50.3481209°N, 7.0445565°E"), ref, 1e-6f);
+        // German "O" (Ost) equals East
+        assertGeopointEquals(GeopointParser.parse("50.3481209N, 7.0445565O"), ref, 1e-6f);
+        // southern and western hemisphere yield negative values
+        assertGeopointEquals(GeopointParser.parse("50.3481209S, 7.0445565W"), new Geopoint(-50.3481209, -7.0445565), 1e-6f);
+    }
+
+    @Test
     public void parseMultipleCoordinatesWithCorrectStartEndPositions() {
         final String initalText = "@n1 (W) N48 01.194 E011 43.814\n" +
                 "@n2 (W) N48 01.194 E011 43.814";


### PR DESCRIPTION
…(mapy.cz)

Adds a parser for decimal-degree coordinates with a trailing hemisphere letter (e.g. mapy.cz 50.3481209N, 7.0445565E), including variants with a space before the letter and an optional degree sign.

This makes such coordinates recognized for clipboard import in the coordinate input dialog (hasClipboardCoordinates() → GeopointParser.parse()).

Adds unit test test8713 and a changelog entry.

Fixes #8713.

Remark for reviewer: Targeting master because this is in fact a new feature (the issue additionally has a Bug label)