### PR TITLE
Fix multiple pending download dialogs on main screen (fix #18363)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -470,9 +470,10 @@ public class MainActivity extends AbstractNavigationBarActivity {
                             if (colStatus >= 0) {
                                 final int status = c.getInt(colStatus);
                                 if (status != DownloadManager.STATUS_RUNNING && status != DownloadManager.STATUS_SUCCESSFUL) {
+                                    // show only a single dialog, no matter how many downloads are blocked/failed; PendingDownloadsActivity lists them all
                                     SimpleDialog.of(this).setTitle(R.string.downloader_pending_downloads).setMessage(R.string.downloader_pending_info).confirm(() -> startActivity(new Intent(this, PendingDownloadsActivity.class)));
                                     Settings.setPendingDownloadsLastCheck(false);
-                                    break;
+                                    return;
                                 }
                             }
                         }

--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -471,9 +471,10 @@ public class MainActivity extends AbstractNavigationBarActivity {
                             if (colStatus >= 0) {
                                 final int status = c.getInt(colStatus);
                                 if (status != DownloadManager.STATUS_RUNNING && status != DownloadManager.STATUS_SUCCESSFUL) {
+                                    // show only a single dialog, no matter how many downloads are blocked/failed; PendingDownloadsActivity lists them all
                                     SimpleDialog.of(this).setTitle(R.string.downloader_pending_downloads).setMessage(R.string.downloader_pending_info).confirm(() -> startActivity(new Intent(this, PendingDownloadsActivity.class)));
                                     Settings.setPendingDownloadsLastCheck(false);
-                                    break;
+                                    return;
                                 }
                             }
                         }


### PR DESCRIPTION
checkPendingDownloads() showed one SimpleDialog per blocked/failed
download instead of a single consolidated one, because the break
statement only exited the inner cursor loop, not the outer loop over
all pending downloads.

Fixes cgeo#18363