### PR TITLE
Fix persistent cookie expiration restoration

### DIFF
--- a/main/src/main/java/cgeo/geocaching/network/Cookies.java
+++ b/main/src/main/java/cgeo/geocaching/network/Cookies.java
@@ -106,10 +106,25 @@ public final class Cookies {
             final String oldCookies = Settings.getPersistentCookies();
             if (oldCookies != null) {
                 for (final String cookie : StringUtils.split(oldCookies, ';')) {
-                    final String[] split = StringUtils.split(cookie, "=", 3);
-                    if (split.length == 3) {
+                    final int nameSeparator = cookie.indexOf('=');
+                    final int expiresAtSeparator = cookie.lastIndexOf('=');
+                    long expiresAt = Long.MAX_VALUE;
+                    String cookieWithoutExpiresAt = cookie;
+                    if (expiresAtSeparator > nameSeparator) {
                         try {
-                            addCookie(new Builder().name(split[0]).value(split[1]).domain(split[2]).build());
+                            expiresAt = Long.parseLong(cookie.substring(expiresAtSeparator + 1));
+                            cookieWithoutExpiresAt = cookie.substring(0, expiresAtSeparator);
+                        } catch (final NumberFormatException ignored) {
+                            // Legacy cookie without expiresAt
+                        }
+                    }
+                    final int domainSeparator = cookieWithoutExpiresAt.lastIndexOf('=');
+                    if (nameSeparator > 0 && domainSeparator > nameSeparator) {
+                        final String name = cookieWithoutExpiresAt.substring(0, nameSeparator);
+                        final String value = cookieWithoutExpiresAt.substring(nameSeparator + 1, domainSeparator);
+                        final String domain = cookieWithoutExpiresAt.substring(domainSeparator + 1);
+                        try {
+                            addCookie(new Builder().name(name).value(value).domain(domain).expiresAt(expiresAt).build());
                         } catch (final RuntimeException ignored) {
                             // ignore
                         }
@@ -129,6 +144,8 @@ public final class Cookies {
                 persistentCookies.append(cookie.value());
                 persistentCookies.append('=');
                 persistentCookies.append(cookie.domain());
+                persistentCookies.append('=');
+                persistentCookies.append(cookie.expiresAt());
                 persistentCookies.append(';');
             }
             Settings.setPersistentCookies(persistentCookies.toString());


### PR DESCRIPTION
## Description

Preserve the expiration time of persistent cookies when saving and restoring the cookie store.

Previously, restored cookies lost their original expiration timestamp. This could cause them to be treated as session cookies and disappear from persistent storage after a subsequent update or restart.

This change:

- Stores each persistent cookie's `expiresAt` timestamp.
- Restores cookies with their original expiration time.
- Remains compatible with cookies stored using the legacy format.
- Correctly handles cookie values containing `=` characters.

> Sorry for submitting two incorrect PRs Orz