### PR TITLE
fix #18388: Wherigo: handle nonexisting/wrong media file gracefully

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/WherigoMediaView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/WherigoMediaView.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.ui;
 import cgeo.geocaching.R;
 import cgeo.geocaching.databinding.WherigoMediaViewBinding;
 import cgeo.geocaching.wherigo.WherigoGame;
+import cgeo.geocaching.wherigo.WherigoUtils;
 import cgeo.geocaching.wherigo.openwig.Engine;
 import cgeo.geocaching.wherigo.openwig.Media;
 
@@ -15,7 +16,6 @@ import android.widget.LinearLayout;
 import androidx.annotation.Nullable;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Locale;
 import java.util.function.Supplier;
 
@@ -121,13 +121,7 @@ public class WherigoMediaView extends LinearLayout {
             return;
         }
 
-        setMediaData(media.id, media.type, media.jarFilename(), media.altText, () -> {
-            try {
-                return Engine.mediaFile(media);
-            } catch (IOException ex) {
-                return null;
-            }
-        });
+        setMediaData(media.id, media.type, media.jarFilename(), media.altText, () -> WherigoUtils.getMediaFileSafe(media));
 
     }
 

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoCartridgeInfo.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoCartridgeInfo.java
@@ -79,10 +79,10 @@ public class WherigoCartridgeInfo {
         }
         try {
             if (forceIcon || readIcon) {
-                this.iconData = closedCartridgeFile.getFile(closedCartridgeFile.iconId);
+                this.iconData = WherigoUtils.getFileSafe(closedCartridgeFile, closedCartridgeFile.iconId);
             }
             if (forceSplash || readSplash) {
-                this.splashData = closedCartridgeFile.getFile(closedCartridgeFile.splashId);
+                this.splashData = WherigoUtils.getFileSafe(closedCartridgeFile, closedCartridgeFile.splashId);
             }
         } catch (Exception e) {
             Log.w("Problem reading data from cartridgeFile " + this, e);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
@@ -282,6 +282,30 @@ public final class WherigoUtils {
         }
     }
 
+    public static byte[] getFileSafe(final CartridgeFile cartridgeFile, final int oid) {
+        if (cartridgeFile == null) {
+            return null;
+        }
+        try {
+            return cartridgeFile.getFile(oid);
+        } catch (Exception e) {
+            Log.w("WHERIGO: Couldn't read file with oid " + oid + " from cartridge " + cartridgeFile.name, e);
+            return null;
+        }
+    }
+
+    public static byte[] getMediaFileSafe(final Media media) {
+        if (media == null) {
+            return null;
+        }
+        try {
+            return Engine.mediaFile(media);
+        } catch (Exception e) {
+            Log.w("WHERIGO: Couldn't read file from media " + media, e);
+            return null;
+        }
+    }
+
     public static Drawable getDrawableForImageData(@Nullable final Context ctx, final byte[] data) {
         if (data == null || data.length == 0) {
             return null;


### PR DESCRIPTION
fix #18388: Wherigo: handle nonexisting/wrong media file gracefully