### PR TITLE
fix #18406: fix saving last cache log

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -392,11 +392,9 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
         finish(SaveMode.NORMAL);
     }
 
-    public void finish(final SaveMode saveMode) {
+    private void finish(final SaveMode saveMode) {
         saveLog(saveMode);
-        if (lastSavedState != null && !StringUtils.isBlank(lastSavedState.log)) {
-            Settings.setLastCacheLog(lastSavedState.log);
-        }
+
         logActivityHelper.finish();
         super.finish();
     }
@@ -469,7 +467,16 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
 
     private void saveLog(final SaveMode saveMode) {
 
-        if (logEditMode != LogEditMode.CREATE_NEW || saveMode == SaveMode.SENDING) {
+        if (logEditMode != LogEditMode.CREATE_NEW) {
+            return;
+        }
+
+        final String cacheLog = currentLogText();
+        if (StringUtils.isNotEmpty(cacheLog)) {
+            Settings.setLastCacheLog(cacheLog);
+        }
+
+        if (saveMode == SaveMode.SENDING) {
             return;
         }
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Functionality for saving the last cache log to repeat it in the next log was broken during introducing SaveMode.SENDING.
This PR fixes it and saves the last log for reusing it on sending it online.


## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #18406

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Unintentionally introduced with PR #18271 