### PR TITLE
Don't intercept taps on menu items (fix #18405)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/search/SearchUtils.java
+++ b/main/src/main/java/cgeo/geocaching/search/SearchUtils.java
@@ -93,13 +93,11 @@ public class SearchUtils {
         if (activityViewroot != null) {
             activityViewroot.setOnInterceptTouchEventListener(ev -> {
                 if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0) {
-                    // Don't intercept touches inside the SearchView (allows long-press paste)
+                    // Don't intercept touches inside the SearchView (allows long-press paste) or menu item
                     final int[] loc = new int[2];
                     searchView.getLocationOnScreen(loc);
-                    final float x = ev.getRawX();
                     final float y = ev.getRawY();
-                    if (x >= loc[0] && x <= loc[0] + searchView.getWidth()
-                            && y >= loc[1] && y <= loc[1] + searchView.getHeight()) {
+                    if (y >= loc[1] && y <= loc[1] + searchView.getHeight()) {
                         return false;
                     }
                     menuSearch.collapseActionView();


### PR DESCRIPTION
## Description
Restrict touch interceptor to space below search view (remove check for search view width) to allow taps on menu items without closing search view.