### PR TITLE
Fix native crashes in offline translation

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/BergamotTranslateAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/BergamotTranslateAccessor.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
 
@@ -40,6 +41,12 @@ import org.json.JSONObject;
  * from Mozilla's production model registry and cached in the app's private storage.
  * Each non-English language requires two pair downloads: lang→en and en→lang
  * (needed for pivot translation through English).
+ *
+ * Two rules protect the app from the native library, which aborts the whole process on any
+ * internal error (a native abort cannot be caught in Java):
+ * a direction is only ever handed to the native library once all of its files are completely
+ * downloaded (see {@link #COMPLETE_MARKER}), and every call into the native library runs on
+ * {@link #NATIVE_SCHEDULER}, because the native model cache is not thread safe.
  */
 public class BergamotTranslateAccessor implements ITranslateAccessor {
 
@@ -51,6 +58,17 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
     private static final String MODEL_REGISTRY_URL = MODEL_BUCKET_URL + "db/models.json";
 
     private static final String PIVOT_LANGUAGE = "en";
+
+    /** Written into a direction's directory once all of its files are completely downloaded */
+    private static final String COMPLETE_MARKER = ".complete";
+
+    /**
+     * All calls into the native library are serialized onto this single thread: the native model
+     * cache is not thread safe. Translations are serialized inside the native library anyway,
+     * so this costs no throughput.
+     */
+    private static final Scheduler NATIVE_SCHEDULER =
+        Schedulers.from(Executors.newSingleThreadExecutor(r -> new Thread(r, "bergamot-native")));
 
     // All language codes with Release-status models in both directions in Mozilla's registry.
     // Verified against https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/db/models.json
@@ -89,6 +107,14 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
     private final Set<String> availableLanguages = new HashSet<>();
     private final Object availableLock = new Object();
 
+    /** Directions already present in the native model cache. Only touched on {@link #NATIVE_SCHEDULER} */
+    private final Set<String> loadedDirections = new HashSet<>();
+
+    // Serializes downloads. downloadLanguage() and getTranslatorWithDownload() are independent
+    // entry points which can ask for the same language at the same time, and they would otherwise
+    // write the same files concurrently.
+    private final Object downloadLock = new Object();
+
     // models.json cached for the session (fetched once, then reused)
     private String cachedRegistryJson = null;
     private final Object registryLock = new Object();
@@ -102,7 +128,7 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
         this.langDetect = new LangDetect();
         // NativeLib runs initializeService() from its own constructor; no
         // explicit call is needed (the method is not public in the AAR).
-        // Run on IO thread — loading 30MB models per pair is too heavy for main thread
+        // Run on IO thread — the scan touches the file system
         Schedulers.io().createWorker().schedule(this::scanAvailableModels);
     }
 
@@ -167,15 +193,13 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
             try {
                 downloadPairFiles(language, PIVOT_LANGUAGE);   // lang → en
                 downloadPairFiles(PIVOT_LANGUAGE, language);   // en  → lang
-                loadPairIntoNative(language);
                 synchronized (availableLock) {
                     availableLanguages.add(language);
                     availableLanguages.add(PIVOT_LANGUAGE);
                 }
                 runCallback(onSuccess);
             } catch (final Throwable e) {
-                // Catch Throwable (not just Exception) so that native-library Errors
-                // (e.g. UnsatisfiedLinkError) are handled and don't crash the process.
+                // Catch Throwable (not just Exception) so that nothing escapes uncaught into RxJava
                 Log.e(TAG + ": Error downloading models for " + language, e);
                 runCallback(() -> onError.accept(asException(e)));
             }
@@ -227,10 +251,10 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
     @Override
     public ITranslatorImpl getTranslator(final String sourceLanguage, final String targetLanguage) {
         if (!PIVOT_LANGUAGE.equals(sourceLanguage)) {
-            ensureModelLoaded(sourceLanguage);
+            ensureLanguageAvailable(sourceLanguage);
         }
         if (!PIVOT_LANGUAGE.equals(targetLanguage)) {
-            ensureModelLoaded(targetLanguage);
+            ensureLanguageAvailable(targetLanguage);
         }
         return createTranslatorImpl(sourceLanguage, targetLanguage);
     }
@@ -248,7 +272,7 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
                 }
                 runCallback(() -> onSuccess.accept(createTranslatorImpl(sourceLanguage, targetLanguage)));
             } catch (final Throwable e) {
-                // Catch Throwable (not just Exception) so that native-library Errors are handled.
+                // Catch Throwable (not just Exception) so that nothing escapes uncaught into RxJava
                 runCallback(() -> onError.accept(asException(e)));
             }
         });
@@ -271,7 +295,7 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
 
             @Override
             public void translate(final String source, final Consumer<String> onSuccess, final Consumer<Exception> onError) {
-                Schedulers.computation().createWorker().schedule(() -> {
+                NATIVE_SCHEDULER.createWorker().schedule(() -> {
                     try {
                         final String[] result;
                         // skip translation if src == target
@@ -279,12 +303,16 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
                             result = null;
                         } else if (PIVOT_LANGUAGE.equals(sourceLang)) {
                             // en → target: direct
+                            loadDirection(PIVOT_LANGUAGE, targetLang);
                             result = nativeLib.translateMultiple(new String[]{source}, pairKey(PIVOT_LANGUAGE, targetLang));
                         } else if (PIVOT_LANGUAGE.equals(targetLang)) {
                             // source → en: direct
+                            loadDirection(sourceLang, PIVOT_LANGUAGE);
                             result = nativeLib.translateMultiple(new String[]{source}, pairKey(sourceLang, PIVOT_LANGUAGE));
                         } else {
                             // source → en → target: pivot via English
+                            loadDirection(sourceLang, PIVOT_LANGUAGE);
+                            loadDirection(PIVOT_LANGUAGE, targetLang);
                             result = nativeLib.pivotMultiple(
                                 pairKey(sourceLang, PIVOT_LANGUAGE),
                                 pairKey(PIVOT_LANGUAGE, targetLang),
@@ -335,25 +363,21 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
         );
     }
 
-    /** Scan previously downloaded models on startup and load them into the native service */
+    /** Scan the models present on device. They are loaded into the native service lazily, on first use */
     private void scanAvailableModels() {
         for (final String lang : SUPPORTED_LANGUAGES) {
             if (PIVOT_LANGUAGE.equals(lang)) {
                 continue;
             }
             if (isPairComplete(lang)) {
-                try {
-                    Log.i(TAG + ": Loading cached models for " + lang);
-                    loadPairIntoNative(lang);
-                    synchronized (availableLock) {
-                        availableLanguages.add(lang);
-                        availableLanguages.add(PIVOT_LANGUAGE);
-                    }
-                    Log.i(TAG + ": Models loaded for " + lang);
-                } catch (final Throwable e) {
-                    // Catch Throwable (not just Exception) so that native-library Errors
-                    // (e.g. from loadModelIntoCache) don't propagate uncaught through RxJava.
-                    Log.e(TAG + ": Could not reload cached models for " + lang, e);
+                synchronized (availableLock) {
+                    availableLanguages.add(lang);
+                    availableLanguages.add(PIVOT_LANGUAGE);
+                }
+            } else {
+                synchronized (downloadLock) {
+                    dropIfIncomplete(lang, PIVOT_LANGUAGE);
+                    dropIfIncomplete(PIVOT_LANGUAGE, lang);
                 }
             }
         }
@@ -362,12 +386,34 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
         }
     }
 
+    /**
+     * Free the space of a direction which will never be loaded: leftovers of an aborted download,
+     * or files of a c:geo version which did not write the completion marker yet. A re-download
+     * would discard them anyway, and without this they would stay behind unusable and invisible.
+     */
+    private void dropIfIncomplete(final String from, final String to) {
+        final File dir = getPairDir(from, to);
+        if (dir.exists() && !isDirectionComplete(from, to)) {
+            Log.i(TAG + ": Discarding incomplete model files for " + pairKey(from, to));
+            deleteDir(dir);
+        }
+    }
+
     private boolean isPairComplete(final String lang) {
         return isDirectionComplete(lang, PIVOT_LANGUAGE) && isDirectionComplete(PIVOT_LANGUAGE, lang);
     }
 
+    /**
+     * A direction is complete only if it carries the marker file, which is written after its last
+     * file was downloaded. The marker alone would accept files which vanished after it was
+     * written, the file check alone would accept the truncated leftovers of an aborted download,
+     * and handing either to the native library aborts the whole app.
+     */
     private boolean isDirectionComplete(final String from, final String to) {
         final File dir = getPairDir(from, to);
+        if (!new File(dir, COMPLETE_MARKER).isFile()) {
+            return false;
+        }
         for (final String fileName : pairFileNames(from, to)) {
             if (!new File(dir, fileName).exists()) {
                 return false;
@@ -381,19 +427,30 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
      * URLs are resolved from Mozilla's model registry; files are served gzip-compressed.
      */
     private void downloadPairFiles(final String from, final String to) throws IOException {
-        if (isDirectionComplete(from, to)) {
-            return;
+        synchronized (downloadLock) {
+            if (isDirectionComplete(from, to)) {
+                return;
+            }
+            // Drop whatever is there: leftovers of an aborted download, or files of a c:geo version
+            // which did not yet write the marker and may therefore be truncated
+            final File dir = getPairDir(from, to);
+            deleteDir(dir);
+            if (!dir.isDirectory() && !dir.mkdirs()) {
+                throw new IOException("Could not create model directory " + dir);
+            }
+
+            final PairUrls urls = resolveModelUrls(from, to);
+            final String lc = from + to;
+
+            downloadFile(urls.modelUrl,    new File(dir, "model." + lc + ".intgemm.alphas.bin"));
+            downloadFile(urls.vocabSrcUrl, new File(dir, "vocab." + lc + ".src.spm"));
+            downloadFile(urls.vocabTrgUrl, new File(dir, "vocab." + lc + ".trg.spm"));
+            downloadFile(urls.lexUrl,      new File(dir, "lex.50.50." + lc + ".s2t.bin"));
+
+            if (!new File(dir, COMPLETE_MARKER).createNewFile()) {
+                throw new IOException("Could not mark direction " + lc + " as complete");
+            }
         }
-        final File dir = getPairDir(from, to);
-        dir.mkdirs();
-
-        final PairUrls urls = resolveModelUrls(from, to);
-        final String lc = from + to;
-
-        downloadFileIfMissing(urls.modelUrl,    new File(dir, "model." + lc + ".intgemm.alphas.bin"));
-        downloadFileIfMissing(urls.vocabSrcUrl, new File(dir, "vocab." + lc + ".src.spm"));
-        downloadFileIfMissing(urls.vocabTrgUrl, new File(dir, "vocab." + lc + ".trg.spm"));
-        downloadFileIfMissing(urls.lexUrl,      new File(dir, "lex.50.50." + lc + ".s2t.bin"));
     }
 
     /**
@@ -557,39 +614,52 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
         }
     }
 
-    private void downloadFileIfMissing(final String url, final File dest) throws IOException {
-        if (dest.exists()) {
+    /**
+     * Download a single file, automatically decompressing if the URL ends in .gz.
+     * The data is written to a temporary file and only moved into place after the transfer
+     * finished, so a file under its final name is always a complete file.
+     */
+    private void downloadFile(final String fileUrl, final File dest) throws IOException {
+        Log.i(TAG + ": Downloading " + fileUrl + " -> " + dest.getName());
+        final File part = new File(dest.getParentFile(), dest.getName() + ".part");
+        try {
+            final InputStream raw = Network.getResponseStream(Network.getRequest(fileUrl));
+            if (raw == null) {
+                throw new IOException("Failed to download: " + dest.getName());
+            }
+            try (InputStream in = fileUrl.endsWith(".gz") ? new GZIPInputStream(raw) : raw;
+                 FileOutputStream out = new FileOutputStream(part)) {
+                final byte[] buf = new byte[65536];
+                int read;
+                while ((read = in.read(buf)) != -1) {
+                    out.write(buf, 0, read);
+                }
+            }
+            if (!part.renameTo(dest)) {
+                throw new IOException("Could not move " + part.getName() + " into place");
+            }
+        } finally {
+            part.delete(); // does nothing once the file was moved into place
+        }
+    }
+
+    /**
+     * Make a direction usable by the native library, unless it already is.
+     * Must only be called on {@link #NATIVE_SCHEDULER}.
+     */
+    private void loadDirection(final String from, final String to) {
+        final String key = pairKey(from, to);
+        if (loadedDirections.contains(key)) {
             return;
         }
-        Log.i(TAG + ": Downloading " + url + " -> " + dest.getName());
-        downloadFile(url, dest);
-    }
-
-    /** Download a single file, automatically decompressing if the URL ends in .gz */
-    private void downloadFile(final String fileUrl, final File dest) throws IOException {
-        final InputStream raw = Network.getResponseStream(Network.getRequest(fileUrl));
-        if (raw == null) {
-            throw new IOException("Failed to download: " + dest.getName());
+        // last gate before the native library: it aborts the app on a missing or truncated file
+        if (!isDirectionComplete(from, to)) {
+            throw new IllegalStateException("Model files not available for " + key);
         }
-        try (InputStream in = fileUrl.endsWith(".gz") ? new GZIPInputStream(raw) : raw;
-             FileOutputStream out = new FileOutputStream(dest)) {
-            final byte[] buf = new byte[65536];
-            int read;
-            while ((read = in.read(buf)) != -1) {
-                out.write(buf, 0, read);
-            }
-        }
-    }
-
-    private void loadPairIntoNative(final String language) throws IOException {
-        loadDirectionIntoNative(language, PIVOT_LANGUAGE);
-        loadDirectionIntoNative(PIVOT_LANGUAGE, language);
-    }
-
-    private void loadDirectionIntoNative(final String from, final String to) throws IOException {
-        final File dir = getPairDir(from, to);
-        final String config = buildModelConfig(from, to, dir);
-        nativeLib.loadModelIntoCache(config, pairKey(from, to));
+        Log.i(TAG + ": Loading model for " + key);
+        nativeLib.loadModelIntoCache(buildModelConfig(from, to, getPairDir(from, to)), key);
+        loadedDirections.add(key);
+        Log.i(TAG + ": Model loaded for " + key);
     }
 
     private String buildModelConfig(final String from, final String to, final File dir) {
@@ -620,7 +690,7 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
             + "  - false\n";
     }
 
-    private void ensureModelLoaded(final String language) {
+    private void ensureLanguageAvailable(final String language) {
         synchronized (availableLock) {
             if (!availableLanguages.contains(language)) {
                 throw new IllegalStateException("Model not available for language: " + language);
@@ -636,7 +706,6 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
         if (!available) {
             downloadPairFiles(language, PIVOT_LANGUAGE);
             downloadPairFiles(PIVOT_LANGUAGE, language);
-            loadPairIntoNative(language);
             synchronized (availableLock) {
                 availableLanguages.add(language);
                 availableLanguages.add(PIVOT_LANGUAGE);

--- a/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/BergamotTranslateAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/BergamotTranslateAccessor.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.utils.offlinetranslate;
 
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 
 import java.io.ByteArrayOutputStream;
@@ -17,7 +18,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
 
@@ -67,8 +67,7 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
      * cache is not thread safe. Translations are serialized inside the native library anyway,
      * so this costs no throughput.
      */
-    private static final Scheduler NATIVE_SCHEDULER =
-        Schedulers.from(Executors.newSingleThreadExecutor(r -> new Thread(r, "bergamot-native")));
+    private static final Scheduler NATIVE_SCHEDULER = AndroidRxUtils.singleThreadPool();
 
     // All language codes with Release-status models in both directions in Mozilla's registry.
     // Verified against https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/db/models.json


### PR DESCRIPTION
## Description

All three crash signatures in #18416 share one cause: a model directory was treated as usable as soon as its four files existed. `File.exists()` is true long before a download is finished, so a connection that drops midway leaves a truncated file behind that looks complete. The native library aborts the whole process when it cannot parse a model, so there is no way to recover from that in Java.

This PR makes completeness something the app can actually verify:

- downloads are atomic. Each file is written to `<name>.part` and renamed only after the stream finished, so a partial file can never take the place of a real one
- a direction counts as available only when a `.complete` marker sits next to its four files. The marker is written last, after all four downloads succeeded
- directories left incomplete by an older version are deleted on startup and fetched again

Two smaller changes remove the remaining crash paths. Models were loaded into the native cache at every app start, even when no translation was ever opened. Loading now happens lazily before the first translation of a direction, and all native calls run on one dedicated thread, which keeps the unsynchronised model cache inside the native library out of trouble. The two download entry points (initial download and language change) could also write into the same directory at the same time and now share a lock.

Users with a broken model on their device download that language once more. That is the only user visible cost.

## Related issues

Fixes #18416

## Additional context

The native side still calls `abort()` on any model error, so a file corrupted by something other than a broken download would still take the app down. A follow up in [cgeo/offline-translator](https://github.com/cgeo/offline-translator) turns those aborts into exceptions and guards the model cache, but it needs a new AAR release, so it is deliberately not part of this PR. Everything here works with the current `v0.2.6-cgeo.1` and needs no native change.

Verified on an emulator: the crash reproduces with a truncated model file, is gone after the fix, and normal translation, language switching, pivot translation and a restart all still work.
