### PR TITLE
fix #18393: toggle stored-on-device date between relative and exact

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/utils/FormatterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/utils/FormatterTest.java
@@ -123,4 +123,17 @@ public class FormatterTest  {
         assertThat(Formatter.formatStoredAgo(System.currentTimeMillis() - agoInMillis)).isEqualTo(expected);
     }
 
+    @Test
+    public void testFormatStoredExact() {
+        // skip test on non english device
+        if (!Strings.CS.equals(Locale.getDefault().getLanguage(), Locale.ENGLISH.getLanguage())) {
+            return;
+        }
+        // unknown timestamp -> only the "Stored " prefix, no date
+        assertThat(Formatter.formatStoredExact(0)).isEqualTo("Stored ");
+        // known timestamp -> "Stored " prefix plus the exact date (device format, incl. year)
+        final long now = System.currentTimeMillis();
+        assertThat(Formatter.formatStoredExact(now)).isEqualTo("Stored " + Formatter.formatFullDate(now));
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
+++ b/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
@@ -107,13 +107,27 @@ public class CacheInfoBoxes {
         offlineRefresh.setOnClickListener(refreshCacheClickListener);
 
         if (cache.isOffline()) {
-            offlineText.setText(Formatter.formatStoredAgo(cache.getDetailedUpdate()));
+            final long detailedUpdate = cache.getDetailedUpdate();
+            offlineText.setText(Formatter.formatStoredAgo(detailedUpdate));
+            // allow toggling between the relative ("stored ... ago") and the exact date by tapping the text
+            offlineText.setTag(Boolean.FALSE);
+            offlineText.setClickable(true);
+            offlineText.setOnClickListener(v -> {
+                final boolean showExact = !Boolean.TRUE.equals(offlineText.getTag());
+                offlineText.setTag(showExact);
+                offlineText.setText(showExact
+                        ? Formatter.formatStoredExact(detailedUpdate)
+                        : Formatter.formatStoredAgo(detailedUpdate));
+            });
 
             offlineStore.setVisibility(View.GONE);
             offlineDrop.setVisibility(View.VISIBLE);
             offlineEdit.setVisibility(View.VISIBLE);
         } else {
             offlineText.setText(LocalizationUtils.getString(R.string.cache_offline_not_ready));
+            offlineText.setOnClickListener(null);
+            offlineText.setClickable(false);
+            offlineText.setTag(null);
 
             offlineStore.setVisibility(View.VISIBLE);
             offlineDrop.setVisibility(View.GONE);

--- a/main/src/main/java/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Formatter.java
@@ -404,6 +404,20 @@ public final class Formatter {
     }
 
     /**
+     * Format the timestamp when a cache was stored on the device as an exact date,
+     * e.g. "Stored 29 July 2026". Uses the device-configured date format and always
+     * includes the year. Counterpart to {@link #formatStoredAgo(long)}.
+     *
+     * @param updatedTimeMillis milliseconds since the epoch, or 0 if unknown
+     * @return the formatted string
+     */
+    @NonNull
+    public static String formatStoredExact(final long updatedTimeMillis) {
+        final String date = updatedTimeMillis == 0L ? "" : formatFullDate(updatedTimeMillis);
+        return LocalizationUtils.getString(R.string.cache_offline_stored_ago, date);
+    }
+
+    /**
      * Formatting of the hidden date of a cache
      *
      * @return {@code null} or hidden date of the cache (or event date of the cache) in human readable format


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
Closes #18393.

### What
In the cache-detail offline box (and the cache popup), the "stored on device" date is shown
relative by default (e.g. "Stored a few minutes ago"). Tapping that text now toggles it to the
**exact date** — in the device-configured date format, always including the year — and back.

### How
- `Formatter.formatStoredExact(long)`: exact-date counterpart to `formatStoredAgo`, using
  `formatFullDate` (respects the device locale/format and always shows the year). Reuses the
  existing `cache_offline_stored_ago` string ("Stored %s") — no new translatable string.
- `CacheInfoBoxes.updateOfflineBox`: the offline text becomes clickable; a per-view flag in the
  TextView tag toggles relative ⇄ exact. State is transient and resets when the box is rebuilt.
  The non-offline branch clears the listener/tag.

### Design decisions
- Transient per view (no new setting).
- Exact format = device-configured, year always included.
- Single tap toggles.

### Tests
- Instrumented test `FormatterTest#testFormatStoredExact` (English-only assertion) — verified green.
- Manual GUI verification of the relative→exact toggle across locales: en-US ("Stored July 29, 2026"),
  de-DE ("Gespeichert 29. Juli 2026"), ja-JP ("2026年7月30日", shows the timezone effect), plus
  ar-EG RTL formatting.

Local gates all pass: assembleBasicDebug, testBasicDebug, checkstyle, and androidTest compilation.

### Notes
- Base branch is `master` because this is a feature/enhancement.
- No changelog entry is included (per an earlier maintainer request to let the team add it on merge).
- No Crowdin impact (reuses an existing string; no settings change).



## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
_Disclosure: implemented with AI assistance (GitHub Copilot) and reviewed by me._
