### PR TITLE
fix #16265: prevent crash when parsing truncated/invalid cache pages

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -479,49 +479,4 @@ public class GCParserTest {
         assertThat(trackablesNew.get(1).getGeocode()).isEqualTo("TBABCD5");
         assertThat(trackablesNew.get(1).getName()).isEqualTo("the test tb");
     }
-
-    /**
-     * Regression test for #16265: feeding degenerate / non-cache pages to the GC cache parser must
-     * never throw (historically a NullPointerException in {@code parseCacheFromText}), but return a
-     * defined error {@link StatusCode}. Such pages are exactly what "network trouble" (logout,
-     * gc.com error page, incomplete response) can produce.
-     */
-    @SmallTest
-    @Test
-    public void testParseInvalidPageDoesNotCrashIssue16265() {
-        assertThat(GCParser.testParseCacheStatus(null)).isEqualTo(StatusCode.UNKNOWN_ERROR);
-        assertThat(GCParser.testParseCacheStatus("")).isEqualTo(StatusCode.UNKNOWN_ERROR);
-        assertThat(GCParser.testParseCacheStatus("    \n\t  ")).isEqualTo(StatusCode.UNKNOWN_ERROR);
-        // an unrelated / incomplete HTML page without the cacheDetails marker
-        assertThat(GCParser.testParseCacheStatus("<html><body>some unrelated page</body></html>")).isEqualTo(StatusCode.UNKNOWN_ERROR);
-        // a geocaching.com "404 - File Not Found" page
-        assertThat(GCParser.testParseCacheStatus("<html><head>" + GCConstants.STRING_404_FILE_NOT_FOUND + "</head></html>")).isEqualTo(StatusCode.CACHE_NOT_FOUND);
-        // an unpublished-cache page
-        assertThat(GCParser.testParseCacheStatus("<html><body>" + GCConstants.STRING_UNPUBLISHED_OTHER + "</body></html>")).isEqualTo(StatusCode.UNPUBLISHED_CACHE);
-    }
-
-    /**
-     * Simulates "network trouble" for #16265: a real, valid cache page that is truncated at many
-     * different lengths (as an interrupted / partial download would produce). Every partial page
-     * must be handled without throwing, always yielding a defined {@link StatusCode}.
-     */
-    @MediumTest
-    @Test
-    public void testParseTruncatedPageDoesNotCrashIssue16265() {
-        final String fullPage = CgeoTestUtils.getFileContent(R.raw.gc366bq);
-        assertThat(fullPage).isNotEmpty();
-        // cut the page at many increasing lengths spread across the whole page
-        final int steps = 200;
-        for (int i = 0; i <= steps; i++) {
-            final int length = (int) ((long) fullPage.length() * i / steps);
-            final String truncated = fullPage.substring(0, length);
-            final StatusCode status;
-            try {
-                status = GCParser.testParseCacheStatus(truncated);
-            } catch (final RuntimeException e) {
-                throw new AssertionError("Parsing a page truncated to " + length + " chars threw " + e, e);
-            }
-            assertThat(status).as("page truncated to %d chars", length).isNotNull();
-        }
-    }
 }

--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -479,4 +479,49 @@ public class GCParserTest {
         assertThat(trackablesNew.get(1).getGeocode()).isEqualTo("TBABCD5");
         assertThat(trackablesNew.get(1).getName()).isEqualTo("the test tb");
     }
+
+    /**
+     * Regression test for #16265: feeding degenerate / non-cache pages to the GC cache parser must
+     * never throw (historically a NullPointerException in {@code parseCacheFromText}), but return a
+     * defined error {@link StatusCode}. Such pages are exactly what "network trouble" (logout,
+     * gc.com error page, incomplete response) can produce.
+     */
+    @SmallTest
+    @Test
+    public void testParseInvalidPageDoesNotCrashIssue16265() {
+        assertThat(GCParser.testParseCacheStatus(null)).isEqualTo(StatusCode.UNKNOWN_ERROR);
+        assertThat(GCParser.testParseCacheStatus("")).isEqualTo(StatusCode.UNKNOWN_ERROR);
+        assertThat(GCParser.testParseCacheStatus("    \n\t  ")).isEqualTo(StatusCode.UNKNOWN_ERROR);
+        // an unrelated / incomplete HTML page without the cacheDetails marker
+        assertThat(GCParser.testParseCacheStatus("<html><body>some unrelated page</body></html>")).isEqualTo(StatusCode.UNKNOWN_ERROR);
+        // a geocaching.com "404 - File Not Found" page
+        assertThat(GCParser.testParseCacheStatus("<html><head>" + GCConstants.STRING_404_FILE_NOT_FOUND + "</head></html>")).isEqualTo(StatusCode.CACHE_NOT_FOUND);
+        // an unpublished-cache page
+        assertThat(GCParser.testParseCacheStatus("<html><body>" + GCConstants.STRING_UNPUBLISHED_OTHER + "</body></html>")).isEqualTo(StatusCode.UNPUBLISHED_CACHE);
+    }
+
+    /**
+     * Simulates "network trouble" for #16265: a real, valid cache page that is truncated at many
+     * different lengths (as an interrupted / partial download would produce). Every partial page
+     * must be handled without throwing, always yielding a defined {@link StatusCode}.
+     */
+    @MediumTest
+    @Test
+    public void testParseTruncatedPageDoesNotCrashIssue16265() {
+        final String fullPage = CgeoTestUtils.getFileContent(R.raw.gc366bq);
+        assertThat(fullPage).isNotEmpty();
+        // cut the page at many increasing lengths spread across the whole page
+        final int steps = 200;
+        for (int i = 0; i <= steps; i++) {
+            final int length = (int) ((long) fullPage.length() * i / steps);
+            final String truncated = fullPage.substring(0, length);
+            final StatusCode status;
+            try {
+                status = GCParser.testParseCacheStatus(truncated);
+            } catch (final RuntimeException e) {
+                throw new AssertionError("Parsing a page truncated to " + length + " chars threw " + e, e);
+            }
+            assertThat(status).as("page truncated to %d chars", length).isNotNull();
+        }
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -198,13 +198,6 @@ public final class GCParser {
         return result;
     }
 
-    //method is only used in AndroidTests: parses a page and returns only the resulting status code,
-    //without any network access or database side effects (isolates {@link #parseCacheFromText}).
-    @NonNull
-    static StatusCode testParseCacheStatus(@Nullable final String page) {
-        return parseCacheFromText(page, null).left;
-    }
-
     /**
      * Parse cache from text and return either an error code or a cache object in a pair. Note that inline logs are
      * not parsed nor saved, while the cache itself is.

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -198,6 +198,13 @@ public final class GCParser {
         return result;
     }
 
+    //method is only used in AndroidTests: parses a page and returns only the resulting status code,
+    //without any network access or database side effects (isolates {@link #parseCacheFromText}).
+    @NonNull
+    static StatusCode testParseCacheStatus(@Nullable final String page) {
+        return parseCacheFromText(page, null).left;
+    }
+
     /**
      * Parse cache from text and return either an error code or a cache object in a pair. Note that inline logs are
      * not parsed nor saved, while the cache itself is.
@@ -558,7 +565,9 @@ public final class GCParser {
 
             if (!wpList.contains("No additional waypoints to display.")) {
                 wpEnd = wpList.indexOf("</table>");
-                wpList = wpList.substring(0, wpEnd);
+                if (wpEnd > -1) {
+                    wpList = wpList.substring(0, wpEnd);
+                }
 
                 wpBegin = wpList.indexOf("<tbody>");
                 wpEnd = wpList.indexOf("</tbody>");


### PR DESCRIPTION
## Description
Closes #16265.

### What
#16265 reported a fatal crash in `GCParser.parseCacheFromText` when loading a cache whose page
was not a valid listing (the reporter noted it was network-related). The original
`String.equals()`-on-null NPE is already resolved on current code, but while hardening the parser
against "network trouble" I found a **remaining crash of the same class**: on a partial/truncated
page (interrupted download) the waypoint section did an unchecked
`substring(0, indexOf("</table>"))`; the closing tag is missing, `indexOf` returns -1, and
`substring(0, -1)` throws `StringIndexOutOfBoundsException`.

### How
- Guard the `</table>` index just like the surrounding `</p>` and `<tbody>` cases.
- Add two instrumented regression tests (via a small package-private test seam
  `testParseCacheStatus` that isolates the parser without network/DB):
  - degenerate/invalid pages (null, empty, whitespace, non-cache HTML, gc.com 404, unpublished)
    return defined `StatusCode`s;
  - a real cache page truncated at 200 increasing lengths never throws.

The truncation test fails before the fix (reproduces the crash) and passes after.

### Tests
assembleBasicDebug, testBasicDebug, checkstyle and androidTest compilation all pass; both new
instrumented tests run green on an Android 15 emulator.

### Notes
- Base branch is `release` (bug fix).
- No changelog entry included (let the team add it on merge).
- No new user-facing strings / no Crowdin impact.

### CI note
The "Unit tests" run on my fork shows a red `check-secrets` job with "No secret defined or no
access to secrets", and `checkstyle` / `lint` / `integration-tests` as skipped. This is expected
for an external fork: those jobs are gated on repository secrets and the `ok-to-test` label, so
the actual `testDebug` job doesn't run until a core team member approves it. It is not a test
failure — the tests pass locally (and the truncation test only fails without the fix). Please add
`ok-to-test` to run CI here.

## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
_Disclosure: implemented with AI assistance (GitHub Copilot) and reviewed by me._