### PR TITLE
fix #6631: keep offline log verbatim, trim only when publishing

### DIFF
--- a/main/src/main/java/cgeo/geocaching/export/FieldNotes.java
+++ b/main/src/main/java/cgeo/geocaching/export/FieldNotes.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.export;
 
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.log.LogUtils;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.Folder;
@@ -46,7 +47,7 @@ class FieldNotes {
                 .append(',')
                 .append(StringUtils.capitalize(log.logType.type))
                 .append(",\"")
-                .append(StringUtils.replaceChars(log.log, '"', '\''))
+                .append(StringUtils.replaceChars(LogUtils.trimForPublishing(log.log), '"', '\''))
                 .append("\"\n");
         if (log.reportProblem.logType != LogType.UNKNOWN) {
             add(cache, new LogEntry.Builder().setLog(LocalizationUtils.getString(log.reportProblem.textId)).setLogType(log.reportProblem.logType).setDate(log.date).build());

--- a/main/src/main/java/cgeo/geocaching/log/LogUtils.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogUtils.java
@@ -131,6 +131,12 @@ public final class LogUtils {
         LogCacheActivity.startForEdit(activity, cache.getGeocode(), entry);
     }
 
+    // Offline log drafts are stored verbatim; trim leading/trailing whitespace only here, right before a log is uploaded or exported (#6631).
+    @NonNull
+    public static String trimForPublishing(@Nullable final String log) {
+        return StringUtils.trimToEmpty(log);
+    }
+
     @WorkerThread
     @SuppressWarnings("PMD.NPathComplexity") // readability won't be imporved upon split
     public static LogResult createLogTaskLogic(final Geocache cache, final OfflineLogEntry logEntry, final Map<String, Trackable> inventory, final Consumer<String> progress) {
@@ -141,9 +147,10 @@ public final class LogUtils {
                 final ILoggingManager loggingManager = cache.getLoggingManager();
                 final IConnector cacheConnector = loggingManager.getConnector();
 
-                //Upload new log entry
+                //Upload new log entry (trim the log only now, right before publishing; the offline draft stays verbatim - #6631)
                 progress.accept(LocalizationUtils.getString(R.string.log_posting_log));
-                final LogResult logResult = loggingManager.createLog(logEntry, inventory);
+                final OfflineLogEntry logEntryToUpload = logEntry.buildUponOfflineLogEntry().setLog(trimForPublishing(logEntry.log)).build();
+                final LogResult logResult = loggingManager.createLog(logEntryToUpload, inventory);
                 if (!logResult.isOk()) {
                     return logResult;
                 }

--- a/main/src/main/java/cgeo/geocaching/log/OfflineLogEntry.java
+++ b/main/src/main/java/cgeo/geocaching/log/OfflineLogEntry.java
@@ -145,6 +145,15 @@ public final class OfflineLogEntry extends LogEntry {
          * Build an immutable {@link OfflineLogEntry} Object.
          */
 
+        // Offline logs hold the user's own not-yet-published text (incl. their signature), so store it
+        // verbatim instead of stripping wrapping HTML and leading/trailing whitespace (#6631).
+        @NonNull
+        @Override
+        public T setLog(@NonNull final String message) {
+            this.log = message;
+            return self();
+        }
+
         public T setImageTitlePraefix(final String imageTitlePraefix) {
             this.imageTitlePraefix = imageTitlePraefix;
             return self();

--- a/main/src/test/java/cgeo/geocaching/log/LogUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/log/LogUtilsTest.java
@@ -1,0 +1,24 @@
+package cgeo.geocaching.log;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogUtilsTest {
+
+    @Test
+    public void trimForPublishingRemovesLeadingAndTrailingWhitespace() {
+        // #6631: the offline draft is kept verbatim, but publishing trims outer whitespace
+        assertThat(LogUtils.trimForPublishing("\n\n\nmy signature")).isEqualTo("my signature");
+        assertThat(LogUtils.trimForPublishing("text\n\n")).isEqualTo("text");
+    }
+
+    @Test
+    public void trimForPublishingKeepsInnerNewlines() {
+        assertThat(LogUtils.trimForPublishing("my text\n\n\nmy signature")).isEqualTo("my text\n\n\nmy signature");
+    }
+
+    @Test
+    public void trimForPublishingHandlesNull() {
+        assertThat(LogUtils.trimForPublishing(null)).isEqualTo("");
+    }
+}

--- a/main/src/test/java/cgeo/geocaching/log/OfflineLogEntryLogTextTest.java
+++ b/main/src/test/java/cgeo/geocaching/log/OfflineLogEntryLogTextTest.java
@@ -1,0 +1,27 @@
+package cgeo.geocaching.log;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OfflineLogEntryLogTextTest {
+
+    @Test
+    public void offlineLogPreservesLeadingNewlines() {
+        // #6631: a one-click offline log stores the signature verbatim, keeping its leading newlines
+        final OfflineLogEntry entry = new OfflineLogEntry.Builder().setLog("\n\n\nmy signature").build();
+        assertThat(entry.log).isEqualTo("\n\n\nmy signature");
+    }
+
+    @Test
+    public void offlineLogPreservesTrailingWhitespace() {
+        final OfflineLogEntry entry = new OfflineLogEntry.Builder().setLog("text\n\n").build();
+        assertThat(entry.log).isEqualTo("text\n\n");
+    }
+
+    @Test
+    public void regularLogStillGetsTrimmed() {
+        // online/parsed logs keep the existing trimming behaviour
+        final LogEntry entry = new LogEntry.Builder().setLog("\n\n\nhello").build();
+        assertThat(entry.log).isEqualTo("hello");
+    }
+}


### PR DESCRIPTION
## Description
### What
Closes #6631
One-click offline logs stored the signature trimmed, so leading blank lines were lost.

### How
Store offline drafts verbatim (setLog override in OfflineLogEntry) and move trimming to the publishing
boundaries via a shared LogUtils.trimForPublishing helper — once in the upload path
(createLogTaskLogic, covering all connectors) and in the field-note export. Parsed server logs unchanged.

### Tests
LogUtilsTest (helper) + OfflineLogEntryLogTextTest (verbatim storage). Local gates green:
testBasicDebug, assembleBasicDebug, checkstyle.

## Additional context
Prepared with AI assistance and reviewed.