### PR TITLE
Add bitmap cache for GoogleV2GeoItemLayer (rel. to #18404)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
@@ -13,7 +13,6 @@ import cgeo.geocaching.utils.Log;
 
 import android.content.res.Resources;
 import android.graphics.Point;
-import android.graphics.drawable.BitmapDrawable;
 import android.util.Pair;
 
 import java.util.Collection;
@@ -43,6 +42,8 @@ public class GoogleV2GeoItemLayer implements IProviderGeoItemLayer<Pair<Object, 
     private Resources resources;
     private int defaultZLevel;
 
+    private final BitmapDescriptorCache bitmapDescriptors = new BitmapDescriptorCache();
+
     public GoogleV2GeoItemLayer(final GoogleMap map, final Resources resources) {
         this.map = map;
         this.resources = resources;
@@ -70,6 +71,7 @@ public class GoogleV2GeoItemLayer implements IProviderGeoItemLayer<Pair<Object, 
             remove(v.first, v.second);
         }
 
+        bitmapDescriptors.clear();
         this.map = null;
         this.resources = null;
     }
@@ -130,7 +132,7 @@ public class GoogleV2GeoItemLayer implements IProviderGeoItemLayer<Pair<Object, 
         final GeoIcon icon = item.getIcon();
         if (icon != null && item.getCenter() != null && icon.getBitmap() != null) {
             marker = map.addMarker(new MarkerOptions()
-                .icon(BitmapDescriptorCache.toBitmapDescriptor(new BitmapDrawable(resources, icon.getBitmap())))
+                .icon(bitmapDescriptors.fromBitmap(icon.getBitmap()))
                 .rotation(icon.getRotation())
                 .flat(icon.isFlat())
                 .position(GP_CONVERTER.to(item.getCenter()))

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/BitmapDescriptorCache.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/BitmapDescriptorCache.java
@@ -7,15 +7,35 @@ import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.util.SparseArray;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 
 public class BitmapDescriptorCache {
 
+    /** upper bound for the bitmap-keyed cache. Prevents unbounded growth if marker appearances vary a lot */
+    private static final int MAX_BITMAP_ENTRIES = 256;
+
     /**
      * rely on unique hashcode of CacheMarker
      */
     protected final SparseArray<BitmapDescriptor> cache = new SparseArray<>();
+
+    /**
+     * cache keyed by the source bitmap itself (identity based, Bitmap does not override equals/hashCode).
+     * Used where only the bitmap is available - creating a descriptor per marker would allocate a full
+     * ARGB_8888 copy for every single marker on the map.
+     */
+    private final Map<Bitmap, BitmapDescriptor> bitmapCache = new LinkedHashMap<Bitmap, BitmapDescriptor>(16, 0.75f, true) {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        protected boolean removeEldestEntry(final Map.Entry<Bitmap, BitmapDescriptor> eldest) {
+            return size() > MAX_BITMAP_ENTRIES;
+        }
+    };
 
     public BitmapDescriptor fromCacheMarker(final CacheMarker d) {
         BitmapDescriptor bd = cache.get(d.hashCode());
@@ -24,6 +44,21 @@ public class BitmapDescriptorCache {
             cache.put(d.hashCode(), bd);
         }
         return bd;
+    }
+
+    /** Gets the descriptor for the given bitmap, creating it on first use */
+    public BitmapDescriptor fromBitmap(final Bitmap bitmap) {
+        BitmapDescriptor bd = bitmapCache.get(bitmap);
+        if (bd == null) {
+            bd = BitmapDescriptorFactory.fromBitmap(bitmap);
+            bitmapCache.put(bitmap, bd);
+        }
+        return bd;
+    }
+
+    public void clear() {
+        cache.clear();
+        bitmapCache.clear();
     }
 
     public static BitmapDescriptor toBitmapDescriptor(final Drawable d) {


### PR DESCRIPTION
## Description
First part of https://github.com/cgeo/cgeo/issues/18404#issuecomment-5218883836, related to Google Maps marker cache. Created with AI.