### PR TITLE
Cache position bitmaps in PositionLayer (rel. to #18404)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -40,6 +40,7 @@ import cgeo.geocaching.ui.dialog.SimplePopupMenu;
 import cgeo.geocaching.unifiedmap.UnifiedMapType;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.LeastRecentlyUsedMap;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MenuUtils;
@@ -88,6 +89,13 @@ public class MapUtils {
 
     private static TextPaint elevationTextPaint = null;
     private static Paint elevationPaint = null;
+
+    /**
+     * The elevation marker is repainted on every location update, but its content only changes when the
+     * displayed elevation text changes - so keep the last few bitmaps instead of allocating a new one
+     * several times per second.
+     */
+    private static final LeastRecentlyUsedMap<String, Bitmap> ELEVATION_BITMAP_CACHE = new LeastRecentlyUsedMap.LruCache<>(32);
 
     public static Set<Geocache> getGeocachesFromDatabase(final Viewport viewport, final GeocacheFilter filter) {
         if (viewport == null || viewport.isJustADot()) {
@@ -508,6 +516,23 @@ public class MapUtils {
     // elevation handling -------------------------------------------------------------------------------------------
 
     public static Bitmap getElevationBitmap(final Resources res, final int markerHeight, final double altitude) {
+        final String info = Units.formatElevation((float) altitude);
+        final String cacheKey = markerHeight + "|" + info;
+        synchronized (ELEVATION_BITMAP_CACHE) {
+            final Bitmap cached = ELEVATION_BITMAP_CACHE.get(cacheKey);
+            if (cached != null) {
+                return cached;
+            }
+        }
+
+        final Bitmap bm = createElevationBitmap(res, markerHeight, info);
+        synchronized (ELEVATION_BITMAP_CACHE) {
+            ELEVATION_BITMAP_CACHE.put(cacheKey, bm);
+        }
+        return bm;
+    }
+
+    private static Bitmap createElevationBitmap(final Resources res, final int markerHeight, final String info) {
         final float textSizeInPx = ViewUtils.dpToPixel(14f);
         final int width = (int) (8 * textSizeInPx);
         final int height = markerHeight + (int) (2 * textSizeInPx) + 2;
@@ -529,7 +554,6 @@ public class MapUtils {
 
         final Bitmap bm = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
         final android.graphics.Canvas canvas = new android.graphics.Canvas(bm);
-        final String info = Units.formatElevation((float) altitude);
 
         final float textWidth = elevationTextPaint.measureText(info) + 10;
         final float yPos = height - 0.45f * textSizeInPx;

--- a/main/src/main/java/cgeo/geocaching/models/geoitem/GeoIcon.java
+++ b/main/src/main/java/cgeo/geocaching/models/geoitem/GeoIcon.java
@@ -9,6 +9,7 @@ import android.graphics.Typeface;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Pair;
+import android.util.SparseArray;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
@@ -116,6 +117,90 @@ public class GeoIcon implements Parcelable {
         @NonNull
         public String toString() {
             return bitmap == null ? "<empty>" : (bitmap.getWidth() + "x" + bitmap.getHeight() + "px, hash:" + bitmap.hashCode());
+        }
+    }
+
+    /**
+     * A bitmap provider which keeps the rotated variants of its bitmap, rounded to full degrees.
+     * <br>
+     * Meant for markers whose rotation changes permanently (e.g. the own-position indicator): without
+     * caching, every single update would allocate a new bitmap via {@link ImageUtils#rotateBitmap}.
+     */
+    public static class RotatedBitmapProvider implements BitmapProvider {
+
+        private final Bitmap bitmap;
+        private final SparseArray<Bitmap> rotatedBitmaps = new SparseArray<>();
+
+        public RotatedBitmapProvider(final Bitmap bitmap) {
+            this.bitmap = bitmap;
+        }
+
+        @Override
+        public Bitmap getBitmap() {
+            return bitmap;
+        }
+
+        @Override
+        public Bitmap getRotatedBitmap(final float angleInDegree) {
+            if (bitmap == null) {
+                return null;
+            }
+            final int angle = Math.floorMod(Math.round(angleInDegree), 360);
+            Bitmap rotated = rotatedBitmaps.get(angle);
+            if (rotated == null) {
+                rotated = ImageUtils.rotateBitmap(bitmap, angle);
+                rotatedBitmaps.put(angle, rotated);
+            }
+            return rotated;
+        }
+
+        // Parcelable stuff
+
+        public RotatedBitmapProvider(final Parcel in) {
+            this.bitmap = in.readParcelable(Bitmap.class.getClassLoader());
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(final Parcel dest, final int flags) {
+            dest.writeParcelable(bitmap, flags);
+        }
+
+        public static final Creator<RotatedBitmapProvider> CREATOR = new Creator<RotatedBitmapProvider>() {
+            @Override
+            public RotatedBitmapProvider createFromParcel(final Parcel in) {
+                return new RotatedBitmapProvider(in);
+            }
+
+            @Override
+            public RotatedBitmapProvider[] newArray(final int size) {
+                return new RotatedBitmapProvider[size];
+            }
+        };
+
+        // equals/hashCode stuff
+
+        @Override
+        public boolean equals(final Object o) {
+            if (!(o instanceof RotatedBitmapProvider)) {
+                return false;
+            }
+            return Objects.equals(bitmap, ((RotatedBitmapProvider) o).bitmap);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(bitmap);
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return bitmap == null ? "<empty>" : (bitmap.getWidth() + "x" + bitmap.getHeight() + "px, hash:" + bitmap.hashCode() + ", rotations:" + rotatedBitmaps.size());
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionLayer.java
@@ -28,6 +28,8 @@ public class PositionLayer {
     private static final String KEY_ELEVATION = "elevation";
 
     private final Bitmap markerPosition = ImageUtils.convertToBitmap(ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), R.drawable.my_location_chevron, null));
+    /** caches the rotated variants of the position marker, which would otherwise be recreated on every update */
+    private final GeoIcon.BitmapProvider markerPositionProvider = new GeoIcon.RotatedBitmapProvider(markerPosition);
 
     private final GeoStyle accuracyStyle = GeoStyle.builder()
             .setStrokeWidth(1.0f)
@@ -49,9 +51,11 @@ public class PositionLayer {
             // always update position indicator, no matter if it's because of position or heading
             layer.put(KEY_POSITION,
                     GeoPrimitive.createMarker(new Geopoint(locationWrapper.location), GeoIcon.builder()
-                                    .setRotation(locationWrapper.heading)
+                                    // round to full degrees, so an unchanged heading results in an equal
+                                    // icon and the marker doesn't need to be redrawn at all
+                                    .setRotation(Math.round(locationWrapper.heading))
                                     .setFlat(true)
-                                    .setBitmap(markerPosition).build())
+                                    .setBitmapProvider(markerPositionProvider).build())
                             .buildUpon().setZLevel(LayerHelper.ZINDEX_POSITION).build());
 
             if (locationWrapper.location.hasAltitude() && Settings.showElevation()) {


### PR DESCRIPTION
## Description
Caches position bitmaps in PositionLayer. Created with AI.

Elevation text gets cached in a small LRU cache keyed by elevation, heading icon gets cached by degrees (rounded to non-decimal values).