### PR TITLE
Fix Mapsforge/VTM map event receiver lifecycle (rel. to #18404)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -62,6 +62,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
     private MapsforgeThemeHelper themeHelper;
     private View mapAttribution;
     private boolean doReapplyTheme = false;
+    private MapEventsReceiver mapEventsReceiver = null;
 
     public MapsforgeFragment() {
         super(R.layout.unifiedmap_mapsforge_fragment);
@@ -179,7 +180,10 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
             applyTheme(); // @todo: There must be a less resource-intensive way of applying style-changes...
             doReapplyTheme = false;
         }
-        mMapView.getLayerManager().getLayers().add(new MapEventsReceiver());
+        if (mapEventsReceiver == null) {
+            mapEventsReceiver = new MapEventsReceiver();
+            mMapView.getLayerManager().getLayers().add(mapEventsReceiver);
+        }
     }
 
     @Override
@@ -206,6 +210,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
     @Override
     public void onDestroyView() {
 //        themeHelper.disposeTheme();
+        mapEventsReceiver = null;
         mMapView.destroyAll();
         super.onDestroyView();
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -73,6 +73,7 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
     protected Map.UpdateListener mapUpdateListener;
     private View mapAttribution;
     private boolean doReapplyTheme = false;
+    private MapEventsReceiver mapEventsReceiver = null;
 
     private Event lastEvent = null;
 
@@ -185,7 +186,10 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
             applyTheme(); // @todo: There must be a less resource-intensive way of applying style-changes...
             doReapplyTheme = false;
         }
-        mMapLayers.add(new MapsforgeVtmFragment.MapEventsReceiver(mMap));
+        if (mapEventsReceiver == null) {
+            mapEventsReceiver = new MapsforgeVtmFragment.MapEventsReceiver(mMap);
+            mMapLayers.add(mapEventsReceiver);
+        }
     }
 
     @Override
@@ -203,6 +207,7 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
 
     @Override
     public void onDestroyView() {
+        mapEventsReceiver = null;
         mMapView.onDestroy();
         themeHelper.disposeTheme();
         super.onDestroyView();


### PR DESCRIPTION
## Description
MapEventReceivers got added on each `onStart`, but never removed, stacking up layers over time. 
The receivers are bound to the map's lifecycle, no need to add/remove it with every onStart/onStop cycle.