### PR TITLE
fix #17105: render numbered and unnumbered lists manually

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/html/HtmlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/html/HtmlUtils.java
@@ -37,8 +37,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Stack;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -57,9 +61,85 @@ public final class HtmlUtils {
     @ColorInt public static final int COLOR_LTBLUE = 0xFFADD8E6;
     @ColorInt public static final int COLOR_REDDISH = 0xFFFF5733;
 
-
     private HtmlUtils() {
         // utility class
+    }
+
+    /** Helper class to render HTML lists (numbered and unnumbered). Separated class to make unit-testable */
+    public static class HtmlListRenderHelper {
+
+        //Holds the list stack. null represents an unnumbered list, a positive integer represents the next number to be used
+        private Stack<Integer> listStack = new Stack<>();
+
+        public void startList(final boolean numbered) {
+            startList(numbered, 1);
+        }
+
+        public void startList(final boolean numbered, final int startNumber) {
+            listStack.push(numbered ? startNumber : null);
+        }
+
+        public void endList() {
+            if (!listStack.isEmpty()) {
+                listStack.pop();
+            }
+        }
+
+        // returns null on unnumbered lists, or number to use on numbered lists
+        public Integer listItem() {
+            if (listStack.isEmpty()) {
+                return null;
+            }
+            final Integer currentNumber = listStack.peek();
+            if (currentNumber == null) {
+                return null; // Unnumbered list
+            } else {
+                listStack.pop();
+                listStack.push(currentNumber + 1); // Increment the number for the next item
+                return currentNumber; // Numbered list
+            }
+        }
+
+        public int intend() {
+            return listStack.size();
+        }
+    }
+
+    // matches opening or closing ol/ul/li tags (with optional attributes), case-insensitive
+    private static final Pattern LIST_TAG_PATTERN = Pattern.compile("<(/?)\\s*(ol|ul|li)\\b([^>]*)>", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Replaces all occurrences of opening or closing {@code ol}, {@code ul} and {@code li} tags with the
+     * corresponding custom tags ({@link UnknownTagsHandler#CUSTOM_OL_TAG}, {@link UnknownTagsHandler#CUSTOM_UL_TAG},
+     * {@link UnknownTagsHandler#CUSTOM_LI_TAG}). Attributes on the tags are preserved, matching is case-insensitive.
+     */
+    @NonNull
+    public static String replaceListTagsWithCustomTags(final String html) {
+        if (StringUtils.isBlank(html)) {
+            return html == null ? StringUtils.EMPTY : html;
+        }
+        final Matcher matcher = LIST_TAG_PATTERN.matcher(html);
+        final StringBuffer result = new StringBuffer();
+        while (matcher.find()) {
+            final String slash = matcher.group(1);
+            final String tag = matcher.group(2).toLowerCase(Locale.US);
+            final String attributes = matcher.group(3);
+            final String customTag;
+            switch (tag) {
+                case "ol":
+                    customTag = UnknownTagsHandler.CUSTOM_OL_TAG;
+                    break;
+                case "ul":
+                    customTag = UnknownTagsHandler.CUSTOM_UL_TAG;
+                    break;
+                default:
+                    customTag = UnknownTagsHandler.CUSTOM_LI_TAG;
+                    break;
+            }
+            matcher.appendReplacement(result, Matcher.quoteReplacement("<" + slash + customTag + attributes + ">"));
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     /**
@@ -260,7 +340,8 @@ public final class HtmlUtils {
     }
 
     public static Pair<Spannable, Boolean> renderHtml(final String html, final Function<String, Drawable> imageGetter) {
-        final String preparedHtml = prepareParseBody(html);
+        String preparedHtml = prepareParseBody(html);
+        preparedHtml = replaceListTagsWithCustomTags(preparedHtml);
         final UnknownTagsHandler unknownTagsHandler = new UnknownTagsHandler();
         final SpannableStringBuilder description = new SpannableStringBuilder(HtmlCompat.fromHtml(preparedHtml, HtmlCompat.FROM_HTML_MODE_LEGACY, imageGetter::apply, unknownTagsHandler));
         return new Pair<>(description, unknownTagsHandler.isProblematicDetected());

--- a/main/src/main/java/cgeo/geocaching/utils/html/UnknownTagsHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/html/UnknownTagsHandler.java
@@ -12,17 +12,17 @@ import org.xml.sax.XMLReader;
 
 public class UnknownTagsHandler implements TagHandler {
 
-    private enum ListType {
-        Ordered, Unordered
-    }
+    public static final String CUSTOM_OL_TAG = "custom-ol";
+    public static final String CUSTOM_UL_TAG = "custom-ul";
+    public static final String CUSTOM_LI_TAG = "custom-li";
+
+    private final HtmlUtils.HtmlListRenderHelper htmlListRenderHelper = new HtmlUtils.HtmlListRenderHelper();
 
     private static final int UNDEFINED_POSITION = -1;
 
     private int countCells = 0;
     private int strikePos = UNDEFINED_POSITION;
     private boolean problematicDetected = false;
-    private int listIndex = 0;
-    private ListType listType = ListType.Unordered;
 
     @Override
     public void handleTag(final boolean opening, final String tag, final Editable output,
@@ -37,9 +37,11 @@ public class UnknownTagsHandler implements TagHandler {
             handleTr(opening, output);
         } else if ("pre".equalsIgnoreCase(tag)) {
             handleProblematic();
-        } else if ("ol".equalsIgnoreCase(tag)) {
+        } else if (CUSTOM_OL_TAG.equalsIgnoreCase(tag)) {
             handleOl(opening);
-        } else if ("li".equalsIgnoreCase(tag)) {
+        } else if (CUSTOM_UL_TAG.equalsIgnoreCase(tag)) {
+            handleUl(opening);
+        } else if (CUSTOM_LI_TAG.equalsIgnoreCase(tag)) {
             handleLi(opening, output);
         } else if ("dt".equalsIgnoreCase(tag)) {
             handleDT(opening, output);
@@ -87,10 +89,17 @@ public class UnknownTagsHandler implements TagHandler {
     // with no handling for alpha or Roman numbers or arbitrary numbering.
     private void handleOl(final boolean opening) {
         if (opening) {
-            listIndex = 1;
-            listType = ListType.Ordered;
+            htmlListRenderHelper.startList(true);
         } else {
-            listType = ListType.Unordered;
+            htmlListRenderHelper.endList();
+        }
+    }
+
+    private void handleUl(final boolean opening) {
+        if (opening) {
+            htmlListRenderHelper.startList(false);
+        } else {
+            htmlListRenderHelper.endList();
         }
     }
 
@@ -104,11 +113,12 @@ public class UnknownTagsHandler implements TagHandler {
 
     private void handleLi(final boolean opening, final Editable output) {
         if (opening) {
-            if (listType == ListType.Ordered) {
-                output.append("\n  ").append(String.valueOf(listIndex++)).append(". ");
-            } else {
-                output.append("\n  • ");
-            }
+            final Integer number = htmlListRenderHelper.listItem();
+            final String listSymbol = number == null ? "•" : number + ".";
+            final String intendCover = "                   ";
+            final int intendLength = Math.max(0, Math.min(intendCover.length(), (htmlListRenderHelper.intend() - 1) * 3));
+            final String intend = intendCover.substring(0, intendLength);
+            output.append("\n").append(intend).append(listSymbol).append(" ");
         }
     }
 

--- a/main/src/test/java/cgeo/geocaching/utils/html/HtmlUtilsJunitTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/html/HtmlUtilsJunitTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class HtmlUtilsJunitTest {
 
+
+
     @Test
     public void testFormattedHtml() {
         //check whether and how bad-formatted HTML is cleaned up
@@ -38,6 +40,151 @@ public class HtmlUtilsJunitTest {
             return null;
         });
         assertThat(annotatedSpan).isEqualTo(expectedResult);
+    }
+
+    @Test
+    public void testHtmlListRenderHelperFlatLists() {
+        final HtmlUtils.HtmlListRenderHelper helper = new HtmlUtils.HtmlListRenderHelper();
+
+        //before any list is started, there is no indentation and no item
+        assertThat(helper.intend()).isEqualTo(0);
+        assertThat(helper.listItem()).isNull();
+
+        //a simple numbered list
+        helper.startList(true);
+        assertThat(helper.intend()).isEqualTo(1);
+        assertThat(helper.listItem()).isEqualTo(1);
+        assertThat(helper.listItem()).isEqualTo(2);
+        assertThat(helper.listItem()).isEqualTo(3);
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(0);
+
+        //a simple unnumbered list
+        helper.startList(false);
+        assertThat(helper.intend()).isEqualTo(1);
+        assertThat(helper.listItem()).isNull();
+        assertThat(helper.listItem()).isNull();
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(0);
+
+        //a numbered list with a custom start number
+        helper.startList(true, 5);
+        assertThat(helper.listItem()).isEqualTo(5);
+        assertThat(helper.listItem()).isEqualTo(6);
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(0);
+    }
+
+    @Test
+    public void testHtmlListRenderHelperNestedEntangledLists() {
+        final HtmlUtils.HtmlListRenderHelper helper = new HtmlUtils.HtmlListRenderHelper();
+
+        //outer numbered list
+        helper.startList(true);
+        assertThat(helper.intend()).isEqualTo(1);
+        assertThat(helper.listItem()).isEqualTo(1);
+
+        //nested unnumbered list inside the numbered one
+        helper.startList(false);
+        assertThat(helper.intend()).isEqualTo(2);
+        assertThat(helper.listItem()).isNull();
+        assertThat(helper.listItem()).isNull();
+
+        //nested numbered list (custom start) inside the unnumbered one
+        helper.startList(true, 10);
+        assertThat(helper.intend()).isEqualTo(3);
+        assertThat(helper.listItem()).isEqualTo(10);
+        assertThat(helper.listItem()).isEqualTo(11);
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(2);
+
+        //back in unnumbered list, still not numbered
+        assertThat(helper.listItem()).isNull();
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(1);
+
+        //back in outer numbered list, numbering continues where it left off
+        assertThat(helper.listItem()).isEqualTo(2);
+
+        //another nested numbered list, restarting at 1
+        helper.startList(true);
+        assertThat(helper.intend()).isEqualTo(2);
+        assertThat(helper.listItem()).isEqualTo(1);
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(1);
+
+        //outer list continues its own numbering unaffected by the nested one
+        assertThat(helper.listItem()).isEqualTo(3);
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(0);
+    }
+
+    @Test
+    public void testHtmlListRenderHelperEdgeCases() {
+        final HtmlUtils.HtmlListRenderHelper helper = new HtmlUtils.HtmlListRenderHelper();
+
+        //calling endList() without a started list must not throw and must not change indentation
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(0);
+
+        //calling listItem() without a started list returns null
+        assertThat(helper.listItem()).isNull();
+
+        //start and immediately end several lists, checking the depth at each step
+        helper.startList(true);
+        helper.startList(false);
+        helper.startList(true);
+        assertThat(helper.intend()).isEqualTo(3);
+        assertThat(helper.listItem()).isEqualTo(1);
+
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(2);
+        assertThat(helper.listItem()).isNull();
+
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(1);
+        assertThat(helper.listItem()).isEqualTo(1);
+        assertThat(helper.listItem()).isEqualTo(2);
+
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(0);
+
+        //list stack fully closed: further endList() calls are no-ops
+        helper.endList();
+        assertThat(helper.intend()).isEqualTo(0);
+        assertThat(helper.listItem()).isNull();
+    }
+
+    @Test
+    public void testReplaceListTagsWithCustomTagsBasic() {
+        assertThat(HtmlUtils.replaceListTagsWithCustomTags("<ol><li>Item1</li></ol>"))
+                .isEqualTo("<custom-ol><custom-li>Item1</custom-li></custom-ol>");
+        assertThat(HtmlUtils.replaceListTagsWithCustomTags("<ul><li>Item1</li><li>Item2</li></ul>"))
+                .isEqualTo("<custom-ul><custom-li>Item1</custom-li><custom-li>Item2</custom-li></custom-ul>");
+
+        //text without any list tags must remain unchanged
+        assertThat(HtmlUtils.replaceListTagsWithCustomTags("<p>no list here</p>")).isEqualTo("<p>no list here</p>");
+
+        //words containing "ol"/"ul"/"li" as part of an actual tag name must not be touched
+        assertThat(HtmlUtils.replaceListTagsWithCustomTags("<table><tr><td>cell</td></tr></table>"))
+                .isEqualTo("<table><tr><td>cell</td></tr></table>");
+    }
+
+    @Test
+    public void testReplaceListTagsWithCustomTagsPreservesAttributesAndCase() {
+        //attributes on opening tags must be preserved, matching is case-insensitive
+        assertThat(HtmlUtils.replaceListTagsWithCustomTags("<OL start=\"3\"><LI class='x'>Item</LI></OL>"))
+                .isEqualTo("<custom-ol start=\"3\"><custom-li class='x'>Item</custom-li></custom-ol>");
+        assertThat(HtmlUtils.replaceListTagsWithCustomTags("<Ul id=\"myList\" data-x='1'><Li>a</Li></Ul>"))
+                .isEqualTo("<custom-ul id=\"myList\" data-x='1'><custom-li>a</custom-li></custom-ul>");
+    }
+
+    @Test
+    public void testReplaceListTagsWithCustomTagsNestedLists() {
+        //nested/entangled lists: all ol/ul/li tags at any depth must be replaced consistently
+        final String html = "<ol><li>one<ul><li>nested1</li><li>nested2</li></ul></li><li>two</li></ol>";
+        final String expected = "<custom-ol><custom-li>one<custom-ul><custom-li>nested1</custom-li><custom-li>nested2</custom-li></custom-ul></custom-li><custom-li>two</custom-li></custom-ol>";
+        assertThat(HtmlUtils.replaceListTagsWithCustomTags(html)).isEqualTo(expected);
     }
 
 }


### PR DESCRIPTION
fix #17105: render numbered and unnumbered lists manually

This fix REPLACES all ol, ul and li tags with a custom tag and then handles all three custom tags in the unknowntagshandler. Supports nested lists, also when they are mixed (numbered/unnumbered). Does NOT support attributes of the list tags.

