### PR TITLE
Mark OkapiClientTest as @Ignored temporarily (rel. to #18447)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/oc/OkapiClientTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/oc/OkapiClientTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OkapiClientTest {
 
     @Test
+    @Ignore("OC.US OKAPI currently failing (as of 2026-08-09)")
     public void testGetOCCache() {
         final String geoCode = "OU0331";
         Geocache cache = OkapiClient.getCache(geoCode);


### PR DESCRIPTION
## Description
OC.US OKAPI is temporarily down, see #18447. Mark the related test as non-breaking for the time being.
Needs to be restored when OC.US OKAPI is back running.