### PR TITLE
rel to #18400: re-initiate cache load after interrupted exception

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/LiveMapGeocacheLoader.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/LiveMapGeocacheLoader.java
@@ -248,9 +248,21 @@ public class LiveMapGeocacheLoader {
                 Log.iForce(LOGPRAEFIX + "END  " + logParams + ": cachedViewport:" + this.cachedResultAvailableViewport + ", state: " + stateData);
 
             } catch (Exception e) {
-                Log.e(LOGPRAEFIX + "UNEXPECTED ERROR" + logParams, e);
-                setState(LoadState.STOPPED, Collections.singletonMap("Overall",
-                    new ConnectorState("Overall", StatusCode.UNKNOWN_ERROR, null, 0, 0, 0, -1, "Exception: " + e.getMessage())));
+                if (isInterruptionException(e)) {
+                    //this happens regularly when the loader gets destroyed (e.g. activity/fragment teardown, screen rotation)
+                    //while an online request is still in progress
+                    Log.iForce(LOGPRAEFIX + "search interupted, will retry: " + logParams);
+                    //reset dirtytime so request is executed again (after PROCESS_DELAY grace period)
+                    synchronized (loader) {
+                        if (this.loader.dirtyTime < 0) {
+                            this.loader.dirtyTime = System.currentTimeMillis();
+                        }
+                    }
+                } else {
+                    Log.e(LOGPRAEFIX + "UNEXPECTED ERROR" + logParams, e);
+                    setState(LoadState.STOPPED, Collections.singletonMap("Overall",
+                        new ConnectorState("Overall", StatusCode.UNKNOWN_ERROR, null, 0, 0, 0, -1, "Exception: " + e.getMessage())));
+                }
             }
             //if we have just done an online request, ensure that there's a grace period for the next
             synchronized (loader) {
@@ -262,6 +274,22 @@ public class LiveMapGeocacheLoader {
 
         private void setState(final LoadState newState) {
             setState(newState, null);
+        }
+
+        /**
+         * Checks whether the given Exception (or one of its causes) indicates that the current thread was
+         * interrupted, e.g. because the {@link LiveMapGeocacheLoader} was destroyed while an online request
+         * was still running (see {@link #destroy()}). Such cases should not be treated as "real" errors.
+         */
+        private static boolean isInterruptionException(final Throwable t) {
+            Throwable cur = t;
+            while (cur != null) {
+                if (cur instanceof InterruptedException) {
+                    return true;
+                }
+                cur = cur.getCause();
+            }
+            return Thread.currentThread().isInterrupted();
         }
 
         private void setState(final LoadState newState, final Map<String, ConnectorState> connStates) {


### PR DESCRIPTION
rel to #18400: re-initiate cache load after interrupted exception

This solves the problem via InterruptedException as we saw it in one logfile:

```
08-03 16:11:47.846 19257 19257 D VRI[UnifiedMapActivity]: setWindowStopped stopped:true
08-03 16:11:47.847 19257 19285 D cgeo    : [looper callbacks] RotationProvider: unregistering listener {RotationProvider.$r8$lambda$oWMaLbuVN3zYf47gpVuLoyULh6A:76/RotationProvider$$ExternalSyntheticLambda0.run:0/HandlerScheduler$ScheduledRunnable.run:123/Handler.handleCallback:995/Handler.dispatchMessage:105/Looper.loopOnce:288/Looper.loop:393/HandlerThread.run:85}
08-03 16:11:47.845 19257 19257 D callGcSupression: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[])' on a null object reference
08-03 16:11:47.847 19257 19285 V SystemSensorManagerExtImpl: unRegisterListener by cgeo.geocaching.sensors.RotationProvider$1@4530caf and its name is Rotation Vector  Non-wakeup
08-03 16:11:47.847 19257 19257 D cgeo    : [main] [TransactionSize]UnifiedMapActivity.onSaveInstanceState: Bundle114548916/11.9 KB/6keys (android:viewHierarchyState=7.9 KB;androidx.lifecycle.BundlableSavedStateRegistry.key=3.4 KB;android:fragments=380 B;routetrackutils=120 B;backuputils=96 B;android:lastAutofillId=60 B) {TransactionSizeLogger$2.log:52/ActivitySavedStateLogger.logAndRemoveSavedState:50/ActivitySavedStateLogger.onActivityStopped:42/Application.dispatchActivityStopped:511/Activity.dispatchActivityStopped:1682/Activity.onStop:2900/FragmentActivity.onStop:369/AppCompatActivity.onStop:244}
08-03 16:11:47.847 19257 19257 D cgeo    : [main] [TransactionSize]MapsforgeVtmFragment.onSaveInstanceState: Bundle196753187/996 B/6keys (android:view_registry_state=320 B;android:view_state=304 B;androidx.lifecycle.BundlableSavedStateRegistry.key=244 B;android:support:fragments=64 B;zoomlevel=32 B;position=28 B) {TransactionSizeLogger$2.log:52/FragmentSavedStateLogger.logAndRemoveSavedState:35/FragmentSavedStateLogger.onFragmentStopped:23/FragmentLifecycleCallbacksDispatcher.dispatchOnFragmentStopped:236/FragmentStateManager.stop:640/FragmentStateManager.moveToExpectedState:299/FragmentStore.moveToExpectedState:113/FragmentManager.moveToState:1433}
08-03 16:11:47.850 19257 19257 D cgeo    : [main] brouter disconnected {Routing.disconnect:186/Routing$RoutingObserver.onDestroy:517/DefaultLifecycleObserverAdapter.onStateChanged:29/LifecycleRegistry$ObserverWithState.dispatchEvent:316/LifecycleRegistry.backwardPass:268/LifecycleRegistry.sync:287/LifecycleRegistry.moveToState:136/LifecycleRegistry.handleLifecycleEvent:119}
08-03 16:11:47.850 28670 28670 D cgeo    : [main] InternalRoutingServiceonDestroy() {InternalRoutingService.onDestroy:72/ActivityThread.handleStopService:5597/ActivityThread.-$$Nest$mhandleStopService:0/ActivityThread$H.handleMessage:2739/Handler.dispatchMessage:112/Looper.loopOnce:288/Looper.loop:393/ActivityThread.main:9564}
08-03 16:11:47.856 19257 28662 E cgeo    : [RxNewThreadScheduler-20] LiveMapGeocacheLoader:UNEXPECTED ERROR(vp=Viewport[N xxx'],f={"advanced":false,"inconclusive":false,"tree":{"type":"AND","children":[{"type":"type","config":{"values":["ADVLAB","CITO","COMMUN_CELEBRATION","EARTH","EVENT","LETTERBOX","MULTI","MYSTERY","TRADITIONAL","USER_DEFINED","VIRTUAL","WEBCAM","WHERIGO"]}},{"type":"difficulty_terrain","config":{"d":{},"t":{}}},{"type":"status","config":{}}]}}) {LiveMapGeocacheLoader$Action.run:251/Scheduler$PeriodicDirectTask.run:596/Scheduler$Worker$PeriodicTask.run:543/ScheduledRunnable.run:80/ScheduledRunnable.call:71/FutureTask.run:328/ScheduledThreadPoolExecutor$ScheduledFutureTask.run:323/ThreadPoolExecutor.runWorker:1100}
08-03 16:11:47.856 19257 28662 E cgeo    : java.lang.RuntimeException: java.lang.InterruptedException
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.internal.util.ExceptionHelper.wrapOrThrow(SourceFile:46)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.internal.observers.BlockingMultiObserver.blockingGet(SourceFile:89)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.core.Single.blockingGet(SourceFile:3645)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at cgeo.geocaching.utils.AndroidRxUtils.executeParallelThenCombine(SourceFile:193)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at cgeo.geocaching.SearchResult.parallelCombineActive(SourceFile:415)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at cgeo.geocaching.connector.ConnectorFactory.searchByViewport(SourceFile:360)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at cgeo.geocaching.unifiedmap.LiveMapGeocacheLoader$Action.run(SourceFile:209)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.core.Scheduler$PeriodicDirectTask.run(SourceFile:596)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.core.Scheduler$Worker$PeriodicTask.run(SourceFile:543)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.run(SourceFile:80)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.call(SourceFile:71)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at java.util.concurrent.FutureTask.run(FutureTask.java:328)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:323)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1100)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at java.lang.Thread.run(Thread.java:1572)
08-03 16:11:47.856 19257 28662 E cgeo    : Caused by: java.lang.InterruptedException
08-03 16:11:47.856 19257 28662 E cgeo    : 	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1140)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:230)
08-03 16:11:47.856 19257 28662 E cgeo    : 	at io.reactivex.rxjava3.internal.observers.BlockingMultiObserver.blockingGet(SourceFile:86)
08-03 16:11:47.856 19257 28662 E cgeo    : 	... 14 more
08-03 16:11:47.860 19257 28662 D cgeo    : [RxNewThreadScheduler-20] LiveMapGeocacheLoader:set state to STOPPED/vp:Viewport[N xxx']/conStates:{Overall=[Overall:UNKNOWN_ERROR,v=null, #:0,0,0;-1ms;msg=Exception: java.lang.InterruptedException]}/conError:[Overall] {LiveMapGeocacheLoader$Action.setState:272/LiveMapGeocacheLoader$Action.run:252/Scheduler$PeriodicDirectTask.run:596/Scheduler$Worker$PeriodicTask.run:543/ScheduledRunnable.run:80/ScheduledRunnable.call:71/FutureTask.run:328/ScheduledThreadPoolExecutor$ScheduledFutureTask.run:323}

```