### PR TITLE
Averaging coordinates in coordinate input/edit dialog (fix #9398)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinateInputDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinateInputDialog.java
@@ -17,6 +17,7 @@ import cgeo.geocaching.sensors.LocationDataProvider;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.unifiedmap.DefaultMap;
+import cgeo.geocaching.utils.AveragedCoordsUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.EditUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
@@ -45,8 +46,10 @@ import androidx.appcompat.widget.Toolbar;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.google.android.material.textfield.TextInputLayout;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import org.apache.commons.lang3.StringUtils;
 
@@ -71,7 +74,7 @@ public class CoordinateInputDialog {
     private List<EditText> orderedInputs;
     private Geopoint gp;
     private static Geopoint cacheCoordinates;
-    private Disposable geoDisposable;
+    private final CompositeDisposable geoDisposable = new CompositeDisposable();
     private CoordinateDialogDisplayModeEnum waypointOptions = CoordinateDialogDisplayModeEnum.Normal;
     private final GeoDirHandler geoUpdate = new GeoDirHandler() {
         @Override
@@ -251,7 +254,7 @@ public class CoordinateInputDialog {
         final Button setFromMap = binding.map;
         final Button clearCoordinates = binding.clear;
 
-        // Do noy display any option buttons if simple mode
+        // Do not display any option buttons if simple mode
         if (waypointOptions == CoordinateDialogDisplayModeEnum.Simple) {
             useCurrentLocation.setVisibility(View.GONE);
             useCacheCoordinates.setVisibility(View.GONE);
@@ -261,8 +264,20 @@ public class CoordinateInputDialog {
             clearCoordinates.setVisibility(View.GONE);
         } else {
             useCurrentLocation.setOnClickListener(v -> {
-                gp = currentCoords();
-                updateGui();
+                useCurrentLocation.setEnabled(false);
+                final Geopoint savedCoords = gp;
+                final Disposable[] acuDisposable = new Disposable[1];
+                final AveragedCoordsUtils acu = new AveragedCoordsUtils(context, currentCoords(), binding.averagingPlaceholder, newCoords -> {
+                    gp = newCoords;
+                    updateGui();
+                }, newCoords -> {
+                    gp = newCoords == null ? savedCoords : newCoords;
+                    updateGui();
+                    useCurrentLocation.setEnabled(true);
+                    geoDisposable.remove(acuDisposable[0]);
+                });
+                acuDisposable[0] = acu.start(GeoDirHandler.UPDATE_GEODATA, 250, TimeUnit.MILLISECONDS);
+                geoDisposable.add(acuDisposable[0]);
             });
 
             // For waypoints only - option to select coordinates from map
@@ -340,7 +355,7 @@ public class CoordinateInputDialog {
 
         dialog.show();
 
-        geoDisposable = geoUpdate.start(GeoDirHandler.UPDATE_GEODATA);
+        geoDisposable.add(geoUpdate.start(GeoDirHandler.UPDATE_GEODATA));
     }
 
     // Close dialog and return selected coordinates to caller

--- a/main/src/main/java/cgeo/geocaching/utils/AveragedCoordsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/AveragedCoordsUtils.java
@@ -1,0 +1,99 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.AveragingBoxBinding;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.sensors.GeoData;
+import cgeo.geocaching.sensors.GeoDirHandler;
+import cgeo.geocaching.utils.functions.Action1;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.reactivex.rxjava3.disposables.Disposable;
+
+public class AveragedCoordsUtils extends GeoDirHandler {
+    private final WeakReference<Context> activityRef;
+    private final FrameLayout container;
+    private final Action1<Geopoint> averagingCallback;
+    private final Action1<Geopoint> resultCallback;
+    final AtomicBoolean isAveraging = new AtomicBoolean(true);
+    private long latitude;
+    private long longitude;
+    private long divisor;
+
+    public AveragedCoordsUtils(@NonNull final Context activity, @NonNull final Geopoint initialCoords, @NonNull final FrameLayout container, @NonNull final Action1<Geopoint> averagingCallback, @NonNull final Action1<Geopoint> resultCallback) {
+        this.activityRef = new WeakReference<>(activity);
+        this.container = container;
+        this.averagingCallback = averagingCallback;
+        this.resultCallback = resultCallback;
+
+        divisor = 1000;
+        latitude = initialCoords.getLatitudeE6() * divisor;
+        longitude = initialCoords.getLongitudeE6() * divisor;
+
+        // create layout
+        if (container.getChildCount() > 0) {
+            container.removeAllViews();
+        }
+        container.setVisibility(View.VISIBLE);
+        final AveragingBoxBinding binding = AveragingBoxBinding.inflate(LayoutInflater.from(activity), container, true);
+
+        // inject layout at given container
+        binding.averagingCancel.setOnClickListener(v1 -> returnToCaller(false));
+        binding.averagingPause.setOnClickListener(v2 -> {
+            isAveraging.set(!isAveraging.get());
+            binding.averagingPause.setText(isAveraging.get() ? R.string.pause : R.string.resume);
+        });
+        binding.averagingOk.setOnClickListener(v3 -> returnToCaller(true));
+    }
+
+    private void returnToCaller(final boolean success) {
+        isAveraging.set(false);
+        container.setVisibility(View.GONE);
+        resultCallback.call(success ? getGeopoint() : null);
+    }
+
+    private Geopoint getGeopoint() {
+        return Geopoint.forE6((int) (latitude / divisor), (int) (longitude / divisor));
+    }
+
+    @Override
+    public Disposable start(final int flags, final long windowDuration, final TimeUnit unit) {
+        return super.start(flags, windowDuration, unit);
+    }
+
+    @Override
+    public void updateGeoData(final GeoData geoData) {
+        if (!isAveraging.get()) {
+            return;
+        }
+        final Context activity = activityRef.get();
+        if (activity == null) {
+            return;
+        }
+
+        long factor = 1000;
+        final float accuracy = geoData.getAccuracy();
+        if (accuracy > 0) {
+            factor = (long) (1000f / accuracy);
+            if (factor > 1000) {
+                factor = 1000;
+            }
+        }
+
+        divisor += factor;
+        latitude += (long) (geoData.getLatitude() * 1e6) * factor;
+        longitude += (long) (geoData.getLongitude() * 1e6) * factor;
+
+        averagingCallback.call(getGeopoint());
+    }
+}

--- a/main/src/main/res/layout/averaging_box.xml
+++ b/main/src/main/res/layout/averaging_box.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/averaging_box"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="6dp"
+    android:layout_marginRight="6dp"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/averaging_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/text_label"
+        android:text="@string/averaging_my_coordinates" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/averaging_cancel"
+            style="@style/button"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/cancel" />
+
+        <Button
+            android:id="@+id/averaging_pause"
+            style="@style/button"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginLeft="2dp"
+            android:layout_marginRight="2dp"
+            android:text="@string/pause" />
+
+        <Button
+            android:id="@+id/averaging_ok"
+            style="@style/button"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/ok" />
+
+    </LinearLayout>
+</LinearLayout>

--- a/main/src/main/res/layout/coordinate_input_dialog.xml
+++ b/main/src/main/res/layout/coordinate_input_dialog.xml
@@ -241,6 +241,10 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:text="@string/waypoint_my_coordinates" />
+    <FrameLayout
+        android:id="@+id/averaging_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
 		<Button
 			android:id="@+id/cache"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1938,6 +1938,7 @@
     <string name="cc_hint_seconds">seconds</string>
     <string name="cc_hint_fraction">fraction</string>
     <string name="hash_symbol">#</string>
+    <string name="averaging_my_coordinates">Averaging my coordinates…</string>
 
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Loading caches from %1$s</string>
@@ -3179,6 +3180,8 @@
     <string name="delete">Delete</string>
     <string name="play">Play</string>
     <string name="copy" tools:ignore="PrivateResource">Copy</string>
+    <string name="pause">Pause</string>
+    <string name="resume">Resume</string>
 
     <!-- Multi-Selections -->
     <string name="multiselect_selectall">Select All</string>


### PR DESCRIPTION
## Description
Adds averaging of current position to "My coordinates" selection in coordinate input/edit dialog.


## Additional context
- On tapping "my coordinates" averaging automatically starts. User can confirm, pause/resume or cancel the averaging.
- Each position is weighted by accuracy. Accuracy <= 1m means weight 1, everything else is weighted by 1/accuracy.
- Works in both "setting coordinates for UDC" as well as "Create WP". Have not added it to "selected position", as that is exactly that: a manually selected specific position.

## Screenshots
<img width="356" height="791" alt="image" src="https://github.com/user-attachments/assets/1c5af059-7106-420f-a3b3-bb7f96ff65a8" />.<img width="356" height="791" alt="image" src="https://github.com/user-attachments/assets/7cdcf367-e291-42bd-a07f-c0b8845a5bf6" />
