### PR TITLE
Add beta update info to changelog

### DIFF
--- a/main/src/main/java/cgeo/geocaching/AboutActivity.java
+++ b/main/src/main/java/cgeo/geocaching/AboutActivity.java
@@ -232,6 +232,11 @@ public class AboutActivity extends TabbedViewPagerActivity {
             final String changelogBugfix = prepareChangelogBugfix(activity);
             if (BranchDetectionHelper.isProductionBuild()) {
                 // we are on release branch
+                if (BranchDetectionHelper.isReleaseCandidate()) {
+                    final String changelogBetaUpdate = FileUtils.getChangelogBetaUpdate(activity);
+                    markwon.setMarkdown(binding.changelogBetaupdate, "## " + LocalizationUtils.getString(R.string.about_changelog_betaupdate) + "\n\n" + changelogBetaUpdate);
+                    binding.changelogBetaupdate.setVisibility(View.VISIBLE);
+                }
                 if (StringUtils.isNotEmpty(changelogBugfix) && (!changelogBugfix.equals("##"))) {
                     markwon.setMarkdown(binding.changelogMaster, (changelogBugfix.startsWith("##") ? "" : "## " + LocalizationUtils.getString(R.string.about_changelog_next_release) + "\n\n") + changelogBugfix);
                 } else {

--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -37,6 +37,7 @@ import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.DebugUtils;
@@ -360,7 +361,7 @@ public class MainActivity extends AbstractNavigationBarActivity {
     private void checkChangedInstall() {
         try {
             final long lastChecksum = Settings.getLastChangelogChecksum();
-            final long checksum = TextUtils.checksum(FileUtils.getChangelogMaster(this) + FileUtils.getChangelogRelease(this));
+            final long checksum = TextUtils.checksum((BranchDetectionHelper.isReleaseCandidate() ? FileUtils.getChangelogBetaUpdate(this) : "") + FileUtils.getChangelogMaster(this) + FileUtils.getChangelogRelease(this));
             Settings.setLastChangelogChecksum(checksum);
 
             if (lastChecksum == 0) {

--- a/main/src/main/java/cgeo/geocaching/utils/BranchDetectionHelper.java
+++ b/main/src/main/java/cgeo/geocaching/utils/BranchDetectionHelper.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.BuildConfig;
+import cgeo.geocaching.CgeoApplication;
 
 public class BranchDetectionHelper {
 
@@ -40,6 +41,13 @@ public class BranchDetectionHelper {
     @SuppressWarnings("ConstantConditions")
     public static boolean isFossBuild() {
         return BuildConfig.FLAVOR.equals("foss");
+    }
+
+    /**
+     * @return true, if version string ends with "-RC"
+     */
+    public static boolean isReleaseCandidate() {
+        return Version.getVersionName(CgeoApplication.getInstance()).endsWith("-RC");
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/utils/FileUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FileUtils.java
@@ -435,6 +435,10 @@ public final class FileUtils {
         return getRawResourceAsString(context, R.raw.changelog_bugfix);
     }
 
+    public static String getChangelogBetaUpdate(final Context context) {
+        return getRawResourceAsString(context, R.raw.changelog_betaupdate);
+    }
+
     @NonNull
     public static String replaceNonFilenameChars(@Nullable final String text) {
         if (StringUtils.isBlank(text)) {

--- a/main/src/main/res/layout/about_changes_page.xml
+++ b/main/src/main/res/layout/about_changes_page.xml
@@ -13,6 +13,12 @@
         android:orientation="vertical" >
 
         <TextView
+            android:id="@+id/changelog_betaupdate"
+            style="@style/about_changes"
+            android:paddingBottom="20dip"
+            android:visibility="gone" />
+
+        <TextView
             android:id="@+id/changelog_master"
             style="@style/about_changes"
             android:paddingBottom="20dip" />

--- a/main/src/main/res/raw/changelog_betaupdate.md
+++ b/main/src/main/res/raw/changelog_betaupdate.md
@@ -1,0 +1,8 @@
+This update includes the following fixes and changes since last beta release:
+
+- Not able to save filters under existing name/ID ([#18450](https://github.com/cgeo/cgeo/issues/18450))
+- Loading errors on live map ([#18400](https://github.com/cgeo/cgeo/issues/18400))
+- Trackables not visible in log dialog ([#18187](https://github.com/cgeo/cgeo/issues/18187))
+- High memory consumption on map ([#18404](https://github.com/cgeo/cgeo/issues/18404))
+- Layer and event receiver stacking on Mapsforge map ([#18404](https://github.com/cgeo/cgeo/issues/18404))
+- Crashes on Google Maps ([#18415](https://github.com/cgeo/cgeo/issues/18415))

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -334,4 +334,7 @@
 
     <!-- default marker -->
     <string translatable="false" name="hyphen">-</string>
+
+    <!-- about: changelog -->
+    <string translatable="false" name="about_changelog_betaupdate">Beta release update</string>
 </resources>


### PR DESCRIPTION
## Description
Adds a beta update info section to beginning of changelog (optional, non-translated) to give our beta users some info at hand what to expect from a beta update. Will be included automatically for production builds if version string ends with "-RC".