### PR TITLE
Prevent crash on loading waypoints of no longer existing target

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -689,7 +689,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 waypoints.addAll(viewModel.caches.readWithResult(caches -> {
                     final Set<Waypoint> wpSet = new HashSet<>();
                     final Geocache cache = DataStore.loadCache(viewModel.mapType.target, LoadFlags.LOAD_WAYPOINTS);
-                    wpSet.addAll(cache.getWaypoints());
+                    if (cache != null) {
+                        wpSet.addAll(cache.getWaypoints());
+                    }
                     return wpSet;
                 }));
             }


### PR DESCRIPTION
## Description
Fixes error reported by Play Store stats for current beta 2026.08.11-RC:

```
Exception java.lang.NullPointerException:
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity.$r8$lambda$lSx_OAp3WZtO36DAsQURNQUlajI (SourceFile:692)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity$$ExternalSyntheticLambda61.apply (SourceFile)
  at cgeo.geocaching.utils.livedata.CollectionLiveData.readWithResult (SourceFile:67)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity.$r8$lambda$MRUl1vr0SZsbx3tBD_obMTHSREA (SourceFile:689)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity$$ExternalSyntheticLambda84.run (SourceFile)
  at io.reactivex.rxjava3.core.Scheduler$DisposeTask.run (SourceFile:644)
  at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.run (SourceFile:80)
  at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.call (SourceFile:71)
  at java.util.concurrent.FutureTask.run (FutureTask.java:328)
  at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run (ScheduledThreadPoolExecutor.java:323)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1100)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
  at java.lang.Thread.run (Thread.java:1572)
```