### PR TITLE
Add WebView listing description style (fix #5986)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -144,6 +144,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -2045,21 +2049,34 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         /** re-renders the caches Listing (=description) in background and fills in the result. Includes handling of too long listings */
         private void reloadDescription(final Activity activity, final Geocache cache, final boolean restrictLength, final int initialScroll, final HtmlStyle descriptionStyle,
                            final ITranslatorImpl translator, final OfflineTranslateUtils.Status status, final Consumer<Exception> errorConsumer) {
+            final boolean useWebView = descriptionStyle == HtmlStyle.WEBVIEW && !useMarkdown(cache);
             binding.descriptionRenderFully.setVisibility(View.GONE);
-            binding.description.setText(TextUtils.setSpan(LocalizationUtils.getString(translator != null ? R.string.cache_description_translating_and_rendering : R.string.cache_description_rendering), new StyleSpan(Typeface.ITALIC)));
-            binding.description.setVisibility(View.VISIBLE);
+            if (useWebView) {
+                binding.description.setVisibility(View.GONE);
+                binding.descriptionWebview.setVisibility(View.VISIBLE);
+                binding.descriptionWebview.loadDataWithBaseURL(null, "<html><body><i>" + LocalizationUtils.getString(translator != null ? R.string.cache_description_translating_and_rendering : R.string.cache_description_rendering) + "</i></body></html>", "text/html", "utf-8", null);
+            } else {
+                binding.descriptionWebview.setVisibility(View.GONE);
+                binding.description.setText(TextUtils.setSpan(LocalizationUtils.getString(translator != null ? R.string.cache_description_translating_and_rendering : R.string.cache_description_rendering), new StyleSpan(Typeface.ITALIC)));
+                binding.description.setVisibility(View.VISIBLE);
+            }
             AndroidRxUtils.computationScheduler.scheduleDirect(() ->
-                    createDescriptionContent(activity, cache, restrictLength, binding.description, descriptionStyle, translator, status, p -> {
+                    createDescriptionContent(activity, cache, useWebView ? false : restrictLength, binding.description, descriptionStyle, translator, status, p -> {
                         if (activity.isFinishing() || activity.isDestroyed()) {
                             return;
                         }
-                        displayDescription(activity, cache, p.first, binding.description);
+                        if (useWebView) {
+                            displayDescriptionInWebView(activity, cache, p.first.toString(), binding.descriptionWebview);
+                        } else {
+                            displayDescription(activity, cache, p.first, binding.description);
+                        }
                         if (translator != null) {
                             binding.descriptionTranslateNote.setText(LocalizationUtils.getString(R.string.translator_translation_success, status.getSourceLanguage()));
                         }
 
                         if (status == null || Strings.CS.equals(status.getSourceLanguage().getCode(), OfflineTranslateUtils.LANGUAGE_INVALID)) {
-                            OfflineTranslateUtils.initializeListingTranslatorInTabbedViewPagerActivity((CacheDetailActivity) getActivity(), binding.descriptionTranslate, binding.description.getText().toString() + " " + binding.hint.getText().toString(), this::translateListing);
+                            final String languageDetectionText = useWebView ? p.first.toString() : binding.description.getText().toString();
+                            OfflineTranslateUtils.initializeListingTranslatorInTabbedViewPagerActivity((CacheDetailActivity) getActivity(), binding.descriptionTranslate, languageDetectionText + " " + binding.hint.getText().toString(), this::translateListing);
                         }
 
                         // we need to use post, so that the textview is layouted before scrolling gets called
@@ -2068,7 +2085,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                         } else if (initialScroll != 0) {
                             binding.detailScroll.post(() -> binding.detailScroll.setScrollY(initialScroll));
                         }
-                        if (p.second) {
+                        if (!useWebView && p.second) {
                             binding.descriptionRenderFully.post(() -> {
                                 binding.descriptionRenderFully.setVisibility(View.VISIBLE);
                                 binding.descriptionRenderFully.setOnClickListener(v -> reloadDescription(activity, cache, false, binding.detailScroll.getScrollY(), descriptionStyle, translator, status, errorConsumer));
@@ -2102,6 +2119,41 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 Log.e("Problem with description", ex);
                 ActivityMixin.showToast(activity, R.string.err_load_descr_failed);
             }
+        }
+
+        @SuppressLint("SetJavaScriptEnabled")
+        @MainThread
+        private static void displayDescriptionInWebView(final Activity activity, final Geocache cache, final String descriptionHtml, final WebView descriptionWebView) {
+            final WebSettings webSettings = descriptionWebView.getSettings();
+            webSettings.setJavaScriptEnabled(false);
+            webSettings.setAllowFileAccess(false);
+            webSettings.setAllowContentAccess(false);
+            webSettings.setDomStorageEnabled(false);
+            webSettings.setLoadWithOverviewMode(true);
+            webSettings.setUseWideViewPort(true);
+            webSettings.setBuiltInZoomControls(true);
+            webSettings.setDisplayZoomControls(false);
+            webSettings.setSupportZoom(true);
+            webSettings.setDefaultTextEncodingName("utf-8");
+            descriptionWebView.setBackgroundColor(Color.TRANSPARENT);
+            descriptionWebView.setWebViewClient(new WebViewClient() {
+                @Override
+                public boolean shouldOverrideUrlLoading(final WebView view, final WebResourceRequest request) {
+                    if (request != null && request.getUrl() != null) {
+                        ShareUtils.openUrl(activity, request.getUrl().toString());
+                    }
+                    return true;
+                }
+
+                @Override
+                public boolean shouldOverrideUrlLoading(final WebView view, final String url) {
+                    ShareUtils.openUrl(activity, url);
+                    return true;
+                }
+            });
+            final IConnector connector = ConnectorFactory.getConnector(cache);
+            final String baseUrl = connector == null ? null : connector.getHostUrl() + "/";
+            descriptionWebView.loadDataWithBaseURL(baseUrl, descriptionHtml, "text/html", "utf-8", null);
         }
 
         private static void displayDescriptionHelper(final Activity activity, final Geocache cache, final CharSequence renderedDescription, final TextView descriptionView) {
@@ -2147,6 +2199,9 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             try {
                 if (useMarkdown(cache)) {
                     return new Pair<>(descriptionText, textTooLong && restrictLength);
+                }
+                if (descriptionStyle == HtmlStyle.WEBVIEW) {
+                    return new Pair<>(descriptionText, false);
                 }
                 //Format to HTML. This takes time on long listings or those with e.g. many images...
                 final HtmlImage imageGetter = new HtmlImage(cache.getGeocode(), true, false, descriptionView, false);

--- a/main/src/main/java/cgeo/geocaching/utils/html/HtmlStyle.java
+++ b/main/src/main/java/cgeo/geocaching/utils/html/HtmlStyle.java
@@ -28,6 +28,7 @@ public enum HtmlStyle {
     DEFAULT(R.string.html_style_default, false, true, (ctx, text, isLightSkin, imageGetter) -> HtmlUtils.renderHtml(text, imageGetter)),
     DEFAULT_NO_CONTRAST_FIX(R.string.html_style_default_no_contrast_fix, false, false, (ctx, text, isLightSkin, imageGetter) -> HtmlUtils.renderHtml(text, imageGetter)),
     MONOCHROME(R.string.html_style_monochrome, true, false, (ctx, text, isLightSkin, imageGetter) -> HtmlUtils.renderHtml(text, imageGetter)),
+    WEBVIEW(R.string.html_style_webview, false, false, (ctx, text, isLightSkin, imageGetter) -> new Pair<>(new SpannableStringBuilder(text), false)),
     HTML_SOURCE_FORMATTED(R.string.html_style_source_formatted, false, false, (ctx, text, isLightSkin, imageGetter) -> new Pair<>(HtmlUtils.getFormattedHtml(text, true, true, isLightSkin), false)),
     HTML_SOURCE(R.string.html_style_source, false, false, (ctx, text, isLightSkin, imageGetter) -> {
         final Spannable span = new SpannableStringBuilder(text);

--- a/main/src/main/res/layout/cachedetail_description_page.xml
+++ b/main/src/main/res/layout/cachedetail_description_page.xml
@@ -28,6 +28,14 @@
             tools:text="This is the cache description. It might be very long..."
             tools:visibility="visible" />
 
+        <WebView
+            android:id="@+id/description_webview"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dip"
+            android:layout_marginBottom="12dip"
+            android:visibility="gone" />
+
         <Button
             android:id="@+id/description_render_fully"
             style="@style/button_full"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1929,6 +1929,7 @@
     <string name="html_style_default">Default</string>
     <string name="html_style_default_no_contrast_fix">Default w/o contrast fix</string>
     <string name="html_style_monochrome">Monochrome</string>
+    <string name="html_style_webview">WebView</string>
     <string name="html_style_source_formatted">HTML Source Formatted</string>
     <string name="html_style_source">HTML Source</string>
 


### PR DESCRIPTION
## Description
This PR adds a new listing description style that renders listing HTML in a `WebView` instead of the existing HTML parsing + `Spannable` pipeline. Existing styles remain unchanged and continue to use the current text rendering path.

- **Style surface**
  - Added `HtmlStyle.WEBVIEW` and exposed it in the existing description-style selector.

- **Description UI**
  - Added `@id/description_webview` to the description page layout.
  - Switched visibility between `TextView` and `WebView` based on selected style.

- **Rendering path split**
  - For `WEBVIEW`, bypasses `HtmlUtils.renderHtml(...)` / `Spannable` creation and loads raw listing HTML via `loadDataWithBaseURL(...)`.
  - Kept markdown/internal-connector behavior on the existing markdown path.
  - Preserved existing behavior for all non-WebView styles.

- **WebView behavior**
  - Configured conservative settings (no JS, no file/content access).
  - Routed clicked links out through `ShareUtils.openUrl(...)`.

```java
if (descriptionStyle == HtmlStyle.WEBVIEW) {
    return new Pair<>(descriptionText, false);
}
```

## Related issues
https://github.com/cgeo/cgeo/issues/17105#issuecomment-3021792865
https://github.com/cgeo/cgeo/issues/5986

## Additional context
The new style is additive and opt-in; users must explicitly select it from the “change description style” dialog.