### PR TITLE
Avoid resetting GM to N0/W0 on mapping list

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
@@ -48,6 +48,7 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
     private LatLngBounds lastBounds = null;
 
     private boolean mapIsCurrentlyMoving;
+    private boolean mapIsInAnimation = false; // to suppress bearing updates temporarily
 
     public GoogleMapsFragment() {
         super(R.layout.unifiedmap_googlemaps_fragment);
@@ -224,7 +225,19 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
             final CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(new LatLngBounds(
                     new LatLng(bounds.bottomLeft.getLatitude(), bounds.bottomLeft.getLongitude()),
                     new LatLng(bounds.topRight.getLatitude(), bounds.topRight.getLongitude())), 50);
-            mMap.animateCamera(cu);
+            // block bearing updates while zooming
+            mapIsInAnimation = true;
+            mMap.animateCamera(cu, new GoogleMap.CancelableCallback() {
+                @Override
+                public void onFinish() {
+                    mapIsInAnimation = false;
+                }
+
+                @Override
+                public void onCancel() {
+                    mapIsInAnimation = false;
+                }
+            });
         }
     }
 
@@ -263,7 +276,7 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
 
     @Override
     public void setBearing(final float bearing) {
-        if (mMap != null) {
+        if (mMap != null && !mapIsInAnimation) {
             mMap.moveCamera(CameraUpdateFactory.newCameraPosition(new CameraPosition.Builder(mMap.getCameraPosition()).bearing(AngleUtils.normalize(bearing)).build()));
         }
     }


### PR DESCRIPTION
## Description
We had a user on support stating that every time the user maps a list of caches, position on Google Maps gets reset to N0/W0.
With the help of using the user's database I was finally able to track this down and fix it:
Culprit was that internal map position was still at 0/0 when we tried to zoom to the viewport required for mapping the list. Map animation got cancelled, though, due to setting a new bearing from sensor data. Thus the new map viewport never got set but always returned to (or stayed at) N0/W0.

Might be related to / having the same cause as #18304, but as I cannot reproduce that, I leave that issue untouched.