### PR TITLE
Keep query parameters for user-defined VTM tile providers

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
@@ -29,7 +29,6 @@ public class UserDefinedMapsforgeVTMOnlineSource extends AbstractMapsforgeVTMOnl
             }
             final String query = fullUri.getQuery();
             setTilePath(tilePath + (StringUtils.isNotBlank(query) ? "?" + query : ""));
-            setTilePath(tilePath);
         }
         supportsHillshading = true;
     }


### PR DESCRIPTION
## Description

`UserDefinedMapsforgeVTMOnlineSource` set the tile path twice in a row, so the
second call discarded the query string the first one had just appended. A
user-defined tile provider whose Uri carries query parameters — an API key, for
example — lost them whenever the VTM variant was used.

This dates back to #17942 (fix for #15884): in `UserDefinedMapsforgeOnlineSource`
the existing `setTilePath(tilePath)` was *replaced* by the query-aware version,
while in the VTM class the new call was *added above* the old one rather than
replacing it. So the Mapsforge half of that fix works and the VTM half does not.

Removing the leftover call makes both implementations identical again.

## Related issues

No separate issue; found while reading this code. Related to #17942 and #15884.

## Additional context

Verified that the query survives on the VTM side: `UrlTileSource.makeTilePath()`
splits the path on `\{|\}` and `getTileUrl()` reassembles the segments onto the
base URL, so a trailing `?key=…` is carried through as the final literal segment.

Not reproduced against a live provider requiring a key — reasoning is from the
code and the vtm library, so a second opinion is welcome.

Written with AI assistance (Claude).