### PR TITLE
fix #18500: aftermath: make filter links clickable (like lists)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -33,6 +33,7 @@ import cgeo.geocaching.export.GpxExport;
 import cgeo.geocaching.export.PersonalNoteExport;
 import cgeo.geocaching.files.GPXImporter;
 import cgeo.geocaching.filters.FilterUtils;
+import cgeo.geocaching.filters.NamedFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
@@ -161,6 +162,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     private static final String STATE_TYPE_PARAMETERS = "currentTypeParameters";
     private static final String STATE_LIST_ID = "currentListId";
     private static final String STATE_MARKER_ID = "currentMarkerId";
+    private static final String STATE_NAMED_FILTER_ID = "currentNamedFilterId";
     private static final String STATE_PREVENTASKFORDELETION = "preventAskForDeletion";
     private static final String STATE_CONTENT_STORAGE_ACTIVITY_HELPER = "contentStorageActivityHelper";
     private static final String STATE_OFFLINELISTLOADLIMIT_ID = "offlineListLoadLimit";
@@ -176,7 +178,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     private boolean checkForEmtpyList = true;
 
     private final CacheListActionBarChooser actionBarChooser =
-        new CacheListActionBarChooser(this, this::getSupportActionBar, this::switchListById);
+        new CacheListActionBarChooser(this, this::getSupportActionBar, this::switchListByIdFromActionBar);
     private CacheListAdapter adapter = null;
     private View listFooter = null;
     private TextView listFooterLine1 = null;
@@ -186,6 +188,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     private final AtomicInteger detailProgress = new AtomicInteger(0);
     private int listId = StoredList.TEMPORARY_LIST.id; // Only meaningful for the OFFLINE type
     @Nullable private String markerId = EmojiUtils.NO_EMOJI;
+    private int namedFilterId = 0;
     private boolean preventAskForDeletion = false;
     private int offlineListLoadLimit = getOfflineListInitialLoadLimit();
     private Menu toolbarMenu;
@@ -400,6 +403,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             typeParameters.putAll(savedInstanceState.getBundle(STATE_TYPE_PARAMETERS));
             listId = savedInstanceState.getInt(STATE_LIST_ID);
             markerId = savedInstanceState.getString(STATE_MARKER_ID);
+            namedFilterId = savedInstanceState.getInt(STATE_NAMED_FILTER_ID);
             preventAskForDeletion = savedInstanceState.getBoolean(STATE_PREVENTASKFORDELETION);
             offlineListLoadLimit = savedInstanceState.getInt(STATE_OFFLINELISTLOADLIMIT_ID);
             checkForEmtpyList = savedInstanceState.getBoolean(STATE_CHECKFOREMPTYLIST);
@@ -411,6 +415,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             if (currentCacheFilterContext == null) {
                 currentCacheFilterContext = new GeocacheFilterContext(type.filterContextType);
             }
+            namedFilterId = extras == null ? 0 : extras.getInt(Intents.EXTRA_NAMED_FILTER, 0);
             checkForEmtpyList = true;
         }
 
@@ -467,6 +472,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         savedInstanceState.putBundle(STATE_TYPE_PARAMETERS, typeParameters);
         savedInstanceState.putInt(STATE_LIST_ID, listId);
         savedInstanceState.putString(STATE_MARKER_ID, markerId);
+        savedInstanceState.putInt(STATE_NAMED_FILTER_ID, namedFilterId);
         savedInstanceState.putBoolean(STATE_PREVENTASKFORDELETION, preventAskForDeletion);
         savedInstanceState.putInt(STATE_OFFLINELISTLOADLIMIT_ID, offlineListLoadLimit);
         savedInstanceState.putBundle(STATE_CONTENT_STORAGE_ACTIVITY_HELPER, contentStorageActivityHelper.getState());
@@ -475,7 +481,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     private void refreshActionBarTitle() {
         if (type.canSwitch) {
-            actionBarChooser.setList(listId, adapter.getCount(), resultIsOfflineAndLimited());
+            actionBarChooser.setList(listId, namedFilterId, adapter.getCount(), resultIsOfflineAndLimited());
         }
     }
 
@@ -1449,6 +1455,11 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         return this::switchListById;
     }
 
+    private void switchListByIdFromActionBar(final int id) {
+        namedFilterId = 0; //clear
+        switchListById(id);
+    }
+
     private void switchListById(final int id) {
         switchListById(id, AfterLoadAction.NO_ACTION);
     }
@@ -1591,14 +1602,17 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         lph.setLastListPosition();
     }
 
-    public static Intent getActivityOfflineIntent(final Context context) {
+    public static Intent getActivityOfflineIntent(final Context context, final NamedFilter namedFilter) {
         final Intent cachesIntent = new Intent(context, CacheListActivity.class);
         Intents.putListType(cachesIntent, CacheListType.OFFLINE);
+        if (namedFilter != null) {
+            cachesIntent.putExtra(Intents.EXTRA_NAMED_FILTER, namedFilter.getId());
+        }
         return cachesIntent;
     }
 
-    public static void startActivityOffline(final Context context) {
-        context.startActivity(getActivityOfflineIntent(context));
+    public static void startActivityOffline(final Context context, final NamedFilter namedFilter) {
+        context.startActivity(getActivityOfflineIntent(context, namedFilter));
     }
 
     public static void startActivityOwner(final Context context, final String userName) {
@@ -1807,7 +1821,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                         preventAskForDeletion = list.preventAskForDeletion;
                     }
 
-                    loader = new OfflineGeocacheListLoader(this, coords, listId, currentCacheFilterContext.get(), sortContext.getSort().getComparator(), false, offlineListLoadLimit);
+                    loader = new OfflineGeocacheListLoader(this, coords, listId, namedFilterId, currentCacheFilterContext.get(), sortContext.getSort().getComparator(), false, offlineListLoadLimit);
 
                     break;
                 case HISTORY:
@@ -1825,7 +1839,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                         connectorAddFilter.setValues(Collections.singletonList(connector));
                         offlineFilter = GeocacheFilter.createEmpty().and(connectorAddFilter);
                     }
-                    loader = new OfflineGeocacheListLoader(this, coords, PseudoList.HISTORY_LIST.id, offlineFilter, VisitComparator.singleton, sortContext.getSort().isInverse(), offlineListLoadLimit);
+                    loader = new OfflineGeocacheListLoader(this, coords, PseudoList.HISTORY_LIST.id, -1, offlineFilter, VisitComparator.singleton, sortContext.getSort().isInverse(), offlineListLoadLimit);
                     break;
                 case NEAREST:
                     title = LocalizationUtils.getString(R.string.caches_nearby);

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -42,15 +42,8 @@ public class Intents {
     public static final String EXTRA_FILTER_CONTEXT = "filter_context";
     public static final String EXTRA_MESSAGE_CENTER_COUNTER = "mccounter";
 
-    public static final String EXTRA_WPTTYPE = PREFIX + "wpttype";
-    public static final String EXTRA_WPTPREFIX = PREFIX + "wptprefix";
-    public static final String EXTRA_MAPSTATE = PREFIX + "mapstate";
     public static final String EXTRA_TITLE = PREFIX + "title";
-    public static final String EXTRA_MAP_MODE = PREFIX + "mapMode";
-    public static final String EXTRA_LIVE_ENABLED = PREFIX + "liveEnabled";
-    public static final String EXTRA_STORED_ENABLED = PREFIX + "storedEnabled";
 
-    public static final String EXTRA_TARGET_INFO = PREFIX + "targetInfo";
     /**
      * list type to be used with the cache list activity. Be aware to use the String representation of the corresponding
      * enum.
@@ -63,6 +56,7 @@ public class Intents {
     public static final String EXTRA_USERNAME = PREFIX + "username";
     public static final String EXTRA_WAYPOINT_ID = PREFIX + "waypoint_id";
     public static final String EXTRA_POCKET_LIST = PREFIX + "pocket_list";
+    public static final String EXTRA_NAMED_FILTER = PREFIX + "named_filter";
 
     private static final String PREFIX_ACTION = "cgeo.geocaching.intent.action.";
     public static final String ACTION_GEOCACHE = PREFIX_ACTION + "GEOCACHE";

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -151,7 +151,7 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
                 startActivity(CacheListActivity.getHistoryIntent(this));
             } else {
                 Settings.setLastDisplayedList(selectedListId);
-                startActivity(CacheListActivity.getActivityOfflineIntent(this));
+                startActivity(CacheListActivity.getActivityOfflineIntent(this, null));
             }
             ActivityMixin.overrideTransitionToFade(this);
         }, false, PseudoList.NEW_LIST.id);
@@ -357,7 +357,7 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
         if (id == MENU_MAP) {
             return DefaultMap.getLiveMapIntent(fromActivity);
         } else if (id == MENU_LIST) {
-            return CacheListActivity.getActivityOfflineIntent(fromActivity);
+            return CacheListActivity.getActivityOfflineIntent(fromActivity, null);
         } else if (id == MENU_SEARCH) {
             return new Intent(fromActivity, SearchActivity.class);
         } else if (id == MENU_CUSTOM) {

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -196,6 +196,16 @@ public class GeocacheFilter implements Cloneable {
         return this;
     }
 
+    public static GeocacheFilter createAnd(final GeocacheFilter ... filters) {
+        final GeocacheFilter result = createEmpty();
+        for (final GeocacheFilter filter : filters) {
+            if (filter != null && filter.getTree() != null) {
+                result.and(filter.getTree());
+            }
+        }
+        return result;
+    }
+
     public String toUserDisplayableString() {
         final NamedFilter liveFilter = NamedFilter.getById(referencedNamedFilterId);
         if (liveFilter != null) {

--- a/main/src/main/java/cgeo/geocaching/loaders/OfflineGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OfflineGeocacheListLoader.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.loaders;
 
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.filters.NamedFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.sorting.CacheComparator;
@@ -20,11 +21,12 @@ public class OfflineGeocacheListLoader extends AbstractSearchLoader {
     private final boolean sortInverse;
     private final int limit;
 
-    public OfflineGeocacheListLoader(final Activity activity, final Geopoint searchCenter, final int listId, final GeocacheFilter filter, final CacheComparator sort, final boolean sortInverse, final int limit) {
+    public OfflineGeocacheListLoader(final Activity activity, final Geopoint searchCenter, final int listId, final int namedFilterId, final GeocacheFilter filter, final CacheComparator sort, final boolean sortInverse, final int limit) {
         super(activity);
         this.searchCenter = searchCenter;
         this.listId = listId;
-        this.filter = filter;
+        final NamedFilter namedFilter = NamedFilter.getById(namedFilterId);
+        this.filter = GeocacheFilter.createAnd(filter, namedFilter == null ? null : namedFilter.getFilter());
         this.sort = sort;
         this.sortInverse = sortInverse;
         this.limit = limit;

--- a/main/src/main/java/cgeo/geocaching/ui/CacheListActionBarChooser.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListActionBarChooser.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.ui;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.filters.NamedFilter;
 import cgeo.geocaching.list.AbstractList;
 import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.list.StoredList;
@@ -35,6 +36,7 @@ public class CacheListActionBarChooser {
     private final Supplier<ActionBar> actionBarSupplier;
     private final Action1<Integer> onSelectAction;
     private int listId = Integer.MIN_VALUE;
+    private int namedFilterId = Integer.MIN_VALUE;
     private int visibleCaches = 0;
     private boolean isLimited = false;
     private String title;
@@ -53,10 +55,11 @@ public class CacheListActionBarChooser {
     }
 
     /** Sets title to a stored list's data */
-    public void setList(final int listId, final int visibleCaches, final boolean isLimited) {
+    public void setList(final int listId, final int namedFilterId, final int visibleCaches, final boolean isLimited) {
         this.title = null;
         this.subtitle = null;
         this.listId = listId;
+        this.namedFilterId = namedFilterId;
         this.visibleCaches = visibleCaches;
         this.isLimited = isLimited;
         refreshActionBarTitle();
@@ -97,12 +100,12 @@ public class CacheListActionBarChooser {
             actionBar.setDisplayShowTitleEnabled(false);
             actionBar.setDisplayShowCustomEnabled(true);
             actionBar.getCustomView().setOnClickListener(v -> new StoredList.UserInterface(context).promptForListSelection(R.string.list_title, selectedListId -> {
-                if (selectedListId != listId) {
+                if (selectedListId != listId || namedFilterId >= 0) {
                     this.onSelectAction.call(selectedListId);
                     this.listId = selectedListId;
                     refreshActionBarTitle();
                 }
-            }, false, Collections.singleton(PseudoList.NEW_LIST.id), listId, null));
+            }, false, Collections.singleton(PseudoList.NEW_LIST.id), namedFilterId >= 0 ? -1 : listId, null));
         }
 
         final TextView titleTv = resultView.findViewById(android.R.id.text1);
@@ -111,7 +114,10 @@ public class CacheListActionBarChooser {
         final AbstractList list = AbstractList.getListById(listId);
         if (list != null) {
             final ImageParam ip = StoredList.UserInterface.getImageForList(list, false);
-            if (ip.isReferencedById()) { // see #15883
+            final NamedFilter namedFilter = NamedFilter.getById(namedFilterId);
+            if (namedFilter != null) {
+                TextParam.text(namedFilter.getNameAndMarker()).applyTo(titleTv);
+            } else if (ip.isReferencedById()) { // see #15883
                 TextParam.text(list.getTitle()).setImage(ip).setImageTint(ColorUtils.colorFromResource(R.color.colorTextActionBar)).applyTo(titleTv);
             } else {
                 TextParam.text(list.getTitle()).setImage(ip).applyTo(titleTv);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -755,7 +755,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         if (viewModel.mapType.fromList != 0) {
             //List
-            listChooser.setList(viewModel.mapType.fromList, visibleCaches, false);
+            listChooser.setList(viewModel.mapType.fromList, -1, visibleCaches, false);
         } else if (viewModel.mapType.type == UMTT_TargetGeocode) {
             //single cache
             final Geocache targetCache = getCurrentTargetCache();

--- a/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
+++ b/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.enumerations.CacheAttributeCategory;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.filters.FilterUtils;
 import cgeo.geocaching.filters.NamedFilter;
+import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
@@ -205,7 +206,7 @@ public class CacheInfoBoxes {
                 marker.setOnClickListener(v -> FilterUtils.openDialogActivateMarkers(cacheDetailActivity));
             }
         }
-        appendMatchingNamedFilters(builder, cache);
+        appendMatchingNamedFilters(builder, cache, cacheDetailActivity);
 
         final TextView offlineLists = view.findViewById(R.id.offline_lists);
         offlineLists.setText(builder);
@@ -216,9 +217,10 @@ public class CacheInfoBoxes {
     /**
      * Appends the named filters matching {@code cache} to {@code builder} (preceded by a line break if
      * {@code builder} is not empty), depending on {@link Settings#getNamedFilterDisplayMode()}.
-     * Active filters are shown in the default text color, inactive (passive) ones grayed out. Not clickable.
+     * Active filters are shown in the standard link color, inactive (passive) ones grayed out.
+     * The filter name is clickable (its optional marker prefix is not).
      */
-    private static void appendMatchingNamedFilters(final SpannableStringBuilder builder, final Geocache cache) {
+    private static void appendMatchingNamedFilters(final SpannableStringBuilder builder, final Geocache cache, final CacheDetailActivity cacheDetailActivity) {
         final Settings.NamedFilterDisplayMode mode = Settings.getNamedFilterDisplayMode();
         if (mode == Settings.NamedFilterDisplayMode.NONE) {
             return;
@@ -233,10 +235,10 @@ public class CacheInfoBoxes {
 
         final SpannableStringBuilder filtersBuilder = new SpannableStringBuilder();
         for (final NamedFilter filter : activeFilters) {
-            appendNamedFilter(filtersBuilder, filter, false);
+            appendNamedFilter(filtersBuilder, filter, false, cacheDetailActivity);
         }
         for (final NamedFilter filter : passiveFilters) {
-            appendNamedFilter(filtersBuilder, filter, true);
+            appendNamedFilter(filtersBuilder, filter, true, cacheDetailActivity);
         }
         filtersBuilder.insert(0, LocalizationUtils.getString(R.string.filters_list_headline) + " ");
 
@@ -246,12 +248,27 @@ public class CacheInfoBoxes {
         builder.append(filtersBuilder);
     }
 
-    private static void appendNamedFilter(final SpannableStringBuilder builder, final NamedFilter filter, final boolean inactive) {
+    private static void appendNamedFilter(final SpannableStringBuilder builder, final NamedFilter filter, final boolean inactive, final CacheDetailActivity cacheDetailActivity) {
         if (builder.length() > 0) {
             builder.append(", ");
         }
+
+        if (StringUtils.isNotBlank(filter.getMarkerId())) {
+            builder.append(filter.getMarkerId()).append(" ");
+        }
         final int start = builder.length();
-        builder.append(filter.getNameAndMarker());
+        builder.append(filter.getName());
+        builder.setSpan(new ClickableSpan() {
+            @Override
+            public void onClick(@NonNull final View widget) {
+                Settings.setLastDisplayedList(PseudoList.ALL_LIST.id);
+                if (cacheDetailActivity != null) {
+                    cacheDetailActivity.setNeedsRefresh();
+                }
+                CacheListActivity.startActivityOffline(widget.getContext(), filter);
+            }
+        }, start, builder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
         if (inactive) {
             builder.setSpan(new ForegroundColorSpan(ContextCompat.getColor(CgeoApplication.getInstance(), R.color.colorTextHint)), start, builder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
@@ -271,7 +288,7 @@ public class CacheInfoBoxes {
                 if (cacheDetailActivity != null) {
                     cacheDetailActivity.setNeedsRefresh();
                 }
-                CacheListActivity.startActivityOffline(view.getContext());
+                CacheListActivity.startActivityOffline(view.getContext(), null);
             }
         }, start, builder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }


### PR DESCRIPTION
fix #18500: aftermath: make filter links clickable (like lists)

<img width="346" height="157" alt="image" src="https://github.com/user-attachments/assets/d6cf3563-cf5d-4710-995e-bd4cf2c21b41" />
