### PR TITLE
Show list markers unconditionally (rel. to #18513)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -681,15 +681,12 @@ public final class MapMarkerUtils {
     private static ArrayList<String> getAssignedMarkers(final Geocache cache) {
         final ArrayList<String> result = new ArrayList<>();
 
-        if (!Settings.isConditionalCacheMarkersEnabled()) {
-            return result;
+        if (Settings.isConditionalCacheMarkersEnabled()) {
+            // Named filter markers are prepended so they appear first
+            result.addAll(NamedFilter.getMarkersForCache(cache));
         }
 
         readLists();
-
-        // Named filter markers are prepended so they appear first
-        result.addAll(NamedFilter.getMarkersForCache(cache));
-
         final Set<Integer> lists = cache.getLists();
         for (final Integer list : lists) {
             final String markerId = list2marker.get(list);


### PR DESCRIPTION
## Description
Always display applicable list markers on cache icons, independently from "show conditional filter markers" setting.
Fixes the issue mentioned in the opening post of #18513:

<img width="356" height="791" alt="image" src="https://github.com/user-attachments/assets/c814030f-27fe-458e-853b-39170c881582" />.<img width="356" height="791" alt="image" src="https://github.com/user-attachments/assets/c0a783d8-0f90-4c48-82f8-3f14678a0006" />
