### PR TITLE
Add parsing and creation of stored list identifiers in personal notes

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -2915,12 +2915,18 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 userModifiedWaypoints.add(w);
             }
         }
-        if (userModifiedWaypoints.isEmpty() && cache.getVariables().isEmpty()) {
+        final List<String> listNames = new ArrayList<>();
+        for (final StoredList list : DataStore.getLists()) {
+            if (list.id != StoredList.STANDARD_LIST_ID && cache.getLists().contains(list.id)) {
+                listNames.add(list.getTitle());
+            }
+        }
+        if (userModifiedWaypoints.isEmpty() && cache.getVariables().isEmpty() && listNames.isEmpty()) {
             showShortToast(LocalizationUtils.getString(R.string.cache_personal_note_storewaypoints_nowaypoints));
             return;
         }
 
-        final String newNote = CacheArtefactParser.putParseableWaypointsInText(note, userModifiedWaypoints, cache.getVariables());
+        final String newNote = CacheArtefactParser.putParseableWaypointsInText(note, userModifiedWaypoints, cache.getVariables(), listNames);
         setNewPersonalNote(newNote);
         showShortToast(R.string.cache_personal_note_storewaypoints_success);
     }

--- a/main/src/main/java/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXParser.java
@@ -20,6 +20,7 @@ import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.CacheArtefactParser;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.models.Waypoint;
@@ -273,6 +274,10 @@ abstract class GPXParser extends FileParser {
                     }
                     // modify cache depending on the use case/connector
                     afterParsing(cache);
+
+                    //invalidate list tags in PN to avoid list creation
+                    cache.setPersonalNote(
+                        CacheArtefactParser.markListsAsIgnored(cache.getPersonalNote(), null));
 
                     // finally store the cache in the database
                     result.add(geocode);

--- a/main/src/main/java/cgeo/geocaching/models/CacheArtefactParser.java
+++ b/main/src/main/java/cgeo/geocaching/models/CacheArtefactParser.java
@@ -6,6 +6,8 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.location.GeopointParser;
 import cgeo.geocaching.location.GeopointWrapper;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.formulas.FormulaUtils;
 import cgeo.geocaching.utils.formulas.VariableList;
@@ -19,12 +21,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -63,6 +68,10 @@ public class CacheArtefactParser {
     private static final String PARSING_VAR_LETTERS_NUMERIC = "[^A-Za-z0-9]([A-Za-z]+)\\s*=\\s*([0-9]+(?:[,.][0-9]+)?)[^0-9]";
     private static final Pattern PARSING_VARS = Pattern.compile(PARSING_VAR_LETTERS_FULL + "|" + PARSING_VAR_LETTERS_NUMERIC);
 
+    //Constants for stored list parsing
+    private static final String PARSING_LIST_PREFIX = "#";
+    private static final String PARSING_LIST_PREFIX_IGNORE = "-";
+
     //general members
     private final Geocache cache;
     private final String namePrefix;
@@ -72,6 +81,9 @@ public class CacheArtefactParser {
 
     //parsed Variables
     private final Map<String, String> variables = new HashMap<>();
+
+    //parsed stored list names
+    private final Collection<String> listNames = new LinkedHashSet<>();
 
     /**
      * Detect coordinates in the given text and converts them to user-defined waypoints.
@@ -95,16 +107,19 @@ public class CacheArtefactParser {
     public CacheArtefactParser parse(@Nullable final String text) {
         waypoints.clear();
         variables.clear();
+        listNames.clear();
 
         if (text != null) {
             //if a backup is found, we parse it first
             for (final String backup : TextUtils.getAll(text, BACKUP_TAG_OPEN, BACKUP_TAG_CLOSE)) {
                 parseWaypointsFromString(backup);
                 parseVariablesFromString(backup, true);
+                parseListsFromString(backup);
             }
             final String remainder = TextUtils.replaceAll(text, BACKUP_TAG_OPEN, BACKUP_TAG_CLOSE, "");
             parseWaypointsFromString(remainder);
             parseVariablesFromString(remainder, false);
+            parseListsFromString(remainder);
         }
 
         return this;
@@ -120,6 +135,12 @@ public class CacheArtefactParser {
     @NonNull
     public Map<String, String> getVariables() {
         return variables;
+    }
+
+    /** returns names of stored lists previously parsed using {@link #parse(String)} */
+    @NonNull
+    public Collection<String> getListNames() {
+        return listNames;
     }
 
     private void parseWaypointsFromString(final String text) {
@@ -429,12 +450,24 @@ public class CacheArtefactParser {
      * @return new text, or null if waypoints could not be placed due to size restrictions
      */
     public static String putParseableWaypointsInText(final String text, final Collection<Waypoint> waypoints, final VariableList vars) {
+        return putParseableWaypointsInText(text, waypoints, vars, null);
+    }
+
+    /**
+     * Replaces waypoints (and stored list names) stored in text with the ones passed as parameter.
+     *
+     * @param text      text to search and replace waypoints in
+     * @param waypoints new waypoints to store
+     * @param listNames names of stored lists the cache belongs to
+     * @return new text, or null if waypoints could not be placed due to size restrictions
+     */
+    public static String putParseableWaypointsInText(final String text, final Collection<Waypoint> waypoints, final VariableList vars, final Collection<String> listNames) {
         String cleanText = removeParseableWaypointsFromText(text);
         if (!cleanText.isEmpty()) {
             cleanText = cleanText + "\n\n";
         }
 
-        final String newWaypoints = getParseableText(waypoints, vars, true);
+        final String newWaypoints = getParseableText(waypoints, vars, true, listNames);
         return cleanText + newWaypoints;
     }
 
@@ -447,6 +480,18 @@ public class CacheArtefactParser {
      * @return parseable text for wayppints, or null if maxsize cannot be met
      */
     public static String getParseableText(final Collection<Waypoint> waypoints, final VariableList vars, final boolean includeBackupTags) {
+        return getParseableText(waypoints, vars, includeBackupTags, null);
+    }
+
+    /**
+     * Tries to create a parseable text containing all information from given waypoints, variables
+     * and stored list names, meeting a given maximum text size. Different strategies are applied to meet
+     * that text size.
+     * if 'includeBackupTags' is set, then returned text is surrounded by tags
+     *
+     * @return parseable text for waypoints, or null if maxsize cannot be met
+     */
+    public static String getParseableText(final Collection<Waypoint> waypoints, final VariableList vars, final boolean includeBackupTags, final Collection<String> listNames) {
         //no streaming allowed
         final List<String> waypointsAsStrings = new ArrayList<>();
         for (final Waypoint wp : waypoints) {
@@ -454,6 +499,10 @@ public class CacheArtefactParser {
         }
         if (vars != null) {
             waypointsAsStrings.add(getParseableVariableString(vars.toMap()));
+        }
+        final String listsText = getParseableListString(listNames);
+        if (!listsText.isEmpty()) {
+            waypointsAsStrings.add(listsText);
         }
         return (includeBackupTags ? BACKUP_TAG_OPEN + "\n" : "") +
                 StringUtils.join(waypointsAsStrings, "\n") +
@@ -548,4 +597,100 @@ public class CacheArtefactParser {
             addVariable(varName, value, highPrio);
         }
     }
+
+    /**
+     * Parses given text for lines containing stored list names, prefixed with "#".
+     * A line may contain several lists, each one separated by an additional "#".
+     */
+    private void parseListsFromString(final String text) {
+        if (Settings.isPersonalNoteListExtractionDisabled()) {
+            return;
+        }
+        for (final String line : text.split("\n", -1)) {
+            final String trimmedLine = line.trim();
+            if (!trimmedLine.startsWith(PARSING_LIST_PREFIX)) {
+                continue;
+            }
+            for (final String part : trimmedLine.split(PARSING_LIST_PREFIX, -1)) {
+                if (part.startsWith(PARSING_LIST_PREFIX_IGNORE)) {
+                    continue;
+                }
+                final String listName = part.trim();
+                if (!listName.isEmpty()) {
+                    listNames.add(listName);
+                }
+            }
+        }
+    }
+
+    /**
+     * creates parseable text containing given stored list names, one line per name, prefixed with "#"
+     */
+    public static String getParseableListString(final Collection<String> listNames) {
+        if (listNames == null || listNames.isEmpty() || Settings.isPersonalNoteListExtractionDisabled()) {
+            return "";
+        }
+        final StringBuilder sb = new StringBuilder();
+        for (final String listName : listNames) {
+            if (StringUtils.isBlank(listName)) {
+                continue;
+            }
+            if (sb.length() > 0) {
+                sb.append("\n");
+            }
+            sb.append(PARSING_LIST_PREFIX).append(listName.trim());
+        }
+        return sb.toString();
+    }
+
+    public static Set<String> getListNamesLower(final Collection<Integer> listIds) {
+        if (listIds == null || listIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return DataStore.getLists().stream()
+            .filter(list -> listIds.contains(list.id))
+            .map(list -> list.title.toLowerCase())
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Marks lists as ignored in text (usually personal notes from caches)
+     *
+     * @param text     text to search and mark list occurrences in
+     * @param listNamesLower if not null, only occurrences of these (case-insensitively matched) list names are marked;
+     *                 if null, all list occurrences are marked
+     * @return new text with matching list occurrences marked as ignored
+     */
+    public static String markListsAsIgnored(final String text, @Nullable final Set<String> listNamesLower) {
+        if (text == null) {
+            return null;
+        }
+        final String[] lines = text.split("\n", -1);
+        for (int i = 0; i < lines.length; i++) {
+            lines[i] = markListsInLineAsIgnored(lines[i], listNamesLower);
+        }
+        return StringUtils.join(lines, "\n");
+    }
+
+    /** marks matching stored list occurrences as ignored in a single line of text, see {@link #markListsAsIgnored(String, Collection<String>)} */
+    private static String markListsInLineAsIgnored(final String line, @Nullable final Set<String> listNames) {
+        if (!line.trim().startsWith(PARSING_LIST_PREFIX)) {
+            return line;
+        }
+        final String[] parts = line.split(PARSING_LIST_PREFIX, -1);
+        final StringBuilder sb = new StringBuilder(parts[0]);
+        for (int i = 1; i < parts.length; i++) {
+            sb.append(PARSING_LIST_PREFIX);
+            final String part = parts[i];
+            if (!part.startsWith(PARSING_LIST_PREFIX_IGNORE)) {
+                final String name = part.trim();
+                if (!name.isEmpty() && (listNames == null || listNames.contains(name.toLowerCase()))) {
+                    sb.append(PARSING_LIST_PREFIX_IGNORE);
+                }
+            }
+            sb.append(part);
+        }
+        return sb.toString();
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -95,6 +95,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.reactivex.rxjava3.core.Scheduler;
@@ -1910,6 +1911,46 @@ public class Geocache implements INamedGeoCoordinate {
                 }
             }
             changeVariables(newVars);
+
+            changed |= assignToListsByName(cacheArtefactParser.getListNames());
+        }
+        return changed;
+    }
+
+    /**
+     * Assigns this cache to the stored lists with given names (case-insensitive match). If for a name no list exists yet,
+     * a new one is created (using the exact, case-sensitive name given).
+     *
+     * @return true if the cache was newly assigned to any list, false if it was not assigend
+     * (eg already assigned to all lists or names were blank)
+     */
+    private boolean assignToListsByName(final Collection<String> listNames) {
+        if (listNames == null || listNames.isEmpty()) {
+            return false;
+        }
+        final Map<String, String> uniqueNames = listNames.stream().map(StringUtils::trimToNull).filter(Objects::nonNull)
+            .collect(Collectors.toMap(String::toLowerCase, s -> s, (e, r) -> e, HashMap::new));
+        boolean changed = false;
+
+        //handle existing lists
+        for (final StoredList list : DataStore.getLists()) {
+            if (list.id == StoredList.STANDARD_LIST_ID || getLists().contains(list.id)) {
+                uniqueNames.remove(list.getTitle().toLowerCase());
+                continue;
+            }
+            if (uniqueNames.remove(list.getTitle().toLowerCase()) != null) {
+                DataStore.addToList(Collections.singletonList(this), list.id);
+                changed = true;
+            }
+        }
+        //new lists
+        for (final String name : uniqueNames.values()) {
+            final int newListId = DataStore.createList(name);
+            if (newListId >= 0) {
+                changed = true;
+                //make sure the newly created list is registered
+                DataStore.getList(newListId);
+            }
         }
         return changed;
     }

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1714,6 +1714,10 @@ public class Settings {
         return getBoolean(R.string.pref_personal_cache_note_merge_disable, false);
     }
 
+    public static boolean isPersonalNoteListExtractionDisabled() {
+        return getBoolean(R.string.pref_personal_note_list_extraction_disable, false);
+    }
+
     public static int getLastDetailsPage() {
         return getInt(R.string.pref_lastdetailspage, 1);
     }

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -30,6 +30,7 @@ import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.log.LogTypeTrackable;
 import cgeo.geocaching.log.OfflineLogEntry;
 import cgeo.geocaching.log.ReportProblemType;
+import cgeo.geocaching.models.CacheArtefactParser;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.INamedGeoCoordinate;
 import cgeo.geocaching.models.Image;
@@ -120,6 +121,7 @@ import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -5178,6 +5180,7 @@ public class DataStore {
         if (!list.isConcrete()) {
             return;
         }
+        final Set<String> oldListNamesLower = getListNamesLower(Collections.singleton(oldListId));
 
         withAccessLock(() -> {
 
@@ -5192,6 +5195,7 @@ public class DataStore {
                     remove.bindLong(1, oldListId);
                     remove.bindString(2, cache.getGeocode());
                     remove.execute();
+                    removeListsFromPersonalNotes(cache, oldListNamesLower);
 
                     add.bindLong(1, newListId);
                     add.bindString(2, cache.getGeocode());
@@ -5208,6 +5212,8 @@ public class DataStore {
     }
 
     public static void removeFromList(final Collection<Geocache> caches, final int oldListId) {
+        final Set<String> oldListNamesLower = getListNamesLower(Collections.singleton(oldListId));
+
         withAccessLock(() -> {
 
             init();
@@ -5220,6 +5226,7 @@ public class DataStore {
                     remove.bindLong(1, oldListId);
                     remove.bindString(2, cache.getGeocode());
                     remove.execute();
+                    removeListsFromPersonalNotes(cache, oldListNamesLower);
                     cache.getLists().remove(oldListId);
                 }
                 database.setTransactionSuccessful();
@@ -5279,6 +5286,11 @@ public class DataStore {
                 for (final Geocache cache : caches) {
                     remove.bindString(1, cache.getGeocode());
                     remove.execute();
+
+                    final Set<String> listNamesLower = getListNamesLower(
+                        cache.getLists().stream().filter(listId -> !listIds.contains(listId))
+                        .collect(Collectors.toSet()));
+                    removeListsFromPersonalNotes(cache, listNamesLower);
                     cache.getLists().clear();
 
                     for (final Integer listId : listIds) {
@@ -5551,6 +5563,7 @@ public class DataStore {
         HISTORY_COUNT("SELECT COUNT(*) FROM " + dbTableCaches + " WHERE visiteddate > 0 OR geocode IN (SELECT geocode FROM " + dbTableLogsOffline + ")"),
         MOVE_TO_STANDARD_LIST("UPDATE " + dbTableCachesLists + " SET list_id = " + StoredList.STANDARD_LIST_ID + " WHERE list_id = ? AND geocode NOT IN (SELECT DISTINCT (geocode) FROM " + dbTableCachesLists + " WHERE list_id = " + StoredList.STANDARD_LIST_ID + ")"),
         REMOVE_FROM_LIST("DELETE FROM " + dbTableCachesLists + " WHERE list_id = ? AND geocode = ?"),
+        UPDATE_PERSONAL_NOTE("UPDATE " + dbTableCaches + " SET personal_note = ? WHERE geocode = ?"),
         REMOVE_FROM_ALL_LISTS("DELETE FROM " + dbTableCachesLists + " WHERE geocode = ?"),
         REMOVE_ALL_FROM_LIST("DELETE FROM " + dbTableCachesLists + " WHERE list_id = ?"),
         UPDATE_VISIT_DATE("UPDATE " + dbTableCaches + " SET visiteddate = ? WHERE geocode = ?"),
@@ -5634,6 +5647,7 @@ public class DataStore {
             final SQLiteStatement remove = PreparedStatement.REMOVE_FROM_ALL_LISTS.getStatement();
             final Map<String, Set<Integer>> oldLists = new HashMap<>();
 
+
             database.beginTransaction();
             try {
                 final Set<String> geocodes = new HashSet<>(caches.size());
@@ -5642,6 +5656,7 @@ public class DataStore {
 
                     remove.bindString(1, cache.getGeocode());
                     remove.execute();
+                    removeListsFromPersonalNotes(cache, null);
                     geocodes.add(cache.getGeocode());
 
                     cache.getLists().clear();
@@ -5656,6 +5671,24 @@ public class DataStore {
 
             return oldLists;
         });
+    }
+
+    private static Set<String> getListNamesLower(final Collection<Integer> listIds) {
+        return CacheArtefactParser.getListNamesLower(listIds);
+    }
+
+    private static void removeListsFromPersonalNotes(final Geocache cache, final Set<String> listNamesLower) {
+        if (cache == null || StringUtils.isBlank(cache.getPersonalNote())) {
+            return;
+        }
+
+        final String newPersonalNote = CacheArtefactParser.markListsAsIgnored(cache.getPersonalNote(), listNamesLower);
+        cache.setPersonalNote(newPersonalNote);
+
+        final SQLiteStatement pn = PreparedStatement.UPDATE_PERSONAL_NOTE.getStatement();
+        pn.bindString(1, newPersonalNote);
+        pn.bindString(2, cache.getGeocode());
+        pn.execute();
     }
 
     @Nullable

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -192,6 +192,7 @@
     <string translatable="false" name="pref_livelist">livelist</string>
     <string translatable="false" name="pref_global_wp_extraction_disable">globalWpExtractionDisable</string>
     <string translatable="false" name="pref_personal_cache_note_merge_disable">personalCacheNoteMergeDisable</string>
+    <string translatable="false" name="pref_personal_note_list_extraction_disable">personalNoteListExtractionDisable</string>
     <string translatable="false" name="pref_customtabs_as_browser">customtabs_as_browser</string>
     <string translatable="false" name="pref_rot13_hint">pref_scramble_hint</string>
     <string translatable="false" name="pref_live_compass_in_navigation_action">live_compass_in_navigation_action</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1168,6 +1168,8 @@
     <string name="init_summary_global_wp_extraction_disable">Globally disable waypoint extraction from personal cache notes. It can still be enabled for individual caches by deactivating the checkbox below the personal cache note.</string>
     <string name="init_prevent_cache_note_merge">Overwrite Personal Cache Note</string>
     <string name="init_summary_prevent_cache_note_merge">If this setting is enabled c:geo will delete the locally stored note permanently and replace it by the personal note on the server. No merging will be done.</string>
+    <string name="init_personal_note_list_extraction_disable">Disable list extraction</string>
+    <string name="init_summary_personal_note_list_extraction_disable">Disable extraction from lists from personal note</string>
     <string name="init_customtabs_as_browser">Use Chrome WebView</string>
     <string name="init_summary_customtabs_as_browser">External websites will be displayed without leaving c:geo (only possible if Chrome is installed)</string>
     <string name="init_rot13_hint">Encrypt hint</string>

--- a/main/src/main/res/xml/preferences_cachedetails.xml
+++ b/main/src/main/res/xml/preferences_cachedetails.xml
@@ -70,6 +70,12 @@
             android:title="@string/init_prevent_cache_note_merge"
             android:summary="@string/init_summary_prevent_cache_note_merge"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_personal_note_list_extraction_disable"
+            android:title="@string/init_personal_note_list_extraction_disable"
+            android:summary="@string/init_summary_personal_note_list_extraction_disable"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
@@ -7,7 +7,9 @@ import cgeo.geocaching.location.GeopointFormatter;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -606,6 +608,108 @@ public class CacheArtefactParserTest {
         }
         final Map<String, String> vars = parser.getVariables();
         assertThat(vars).isEqualTo(expectedVarMap);
+    }
+
+    @Test
+    public void testParseListNames() {
+        final CacheArtefactParser parser = createParser("Praefix");
+        parser.parse("some note\n#My List\nmore note\n#List2#List3\nlast line");
+        assertThat(parser.getListNames()).containsExactly("My List", "List2", "List3");
+    }
+
+    @Test
+    public void testParseListNamesTrimmed() {
+        final CacheArtefactParser parser = createParser("Praefix");
+        parser.parse("  #  My List  #  List2  \n");
+        assertThat(parser.getListNames()).containsExactly("My List", "List2");
+    }
+
+    @Test
+    public void testParseListNamesNoHashNoList() {
+        final CacheArtefactParser parser = createParser("Praefix");
+        parser.parse("some note without any hash");
+        assertThat(parser.getListNames()).isEmpty();
+    }
+
+    @Test
+    public void testParseListNamesIgnoresHashInsideLine() {
+        final CacheArtefactParser parser = createParser("Praefix");
+        parser.parse("note with a # somewhere in the middle");
+        assertThat(parser.getListNames()).isEmpty();
+    }
+
+    @Test
+    public void testGetParseableListString() {
+        assertThat(CacheArtefactParser.getParseableListString(Arrays.asList("List1", "List2"))).isEqualTo("#List1\n#List2");
+        assertThat(CacheArtefactParser.getParseableListString(new ArrayList<>())).isEmpty();
+        assertThat(CacheArtefactParser.getParseableListString(null)).isEmpty();
+    }
+
+    @Test
+    public void putParseableWaypointsInTextWithLists() {
+        final Geopoint gp = new Geopoint("N 45°49.739 E 9°45.038");
+        final String gpStr = toParseableWpString(gp);
+
+        final String waypoints = "@wp1 (X) " + gpStr + " \"note\"";
+        final CacheArtefactParser cacheArtefactParser = createParser("Prefix");
+        final Collection<Waypoint> wps = cacheArtefactParser.parse(waypoints).getWaypoints();
+
+        final String note = "";
+        final String noteAfter = CacheArtefactParser.putParseableWaypointsInText(note, wps, null, Arrays.asList("List1", "List2"));
+        assertThat(noteAfter).isEqualTo("{c:geo-start}\n" + waypoints + "\n#List1\n#List2\n{c:geo-end}");
+
+        //check round trip: re-parsing yields the same list names
+        final CacheArtefactParser reparsed = createParser("Prefix").parse(noteAfter);
+        assertThat(reparsed.getListNames()).containsExactly("List1", "List2");
+    }
+
+    @Test
+    public void testMarkListAsIgnored() {
+        final String text = "some note\n#My List\nmore note\n#List2#List3\nlast line";
+        // case-insensitive match
+        final String marked = CacheArtefactParser.markListsAsIgnored(text, Collections.singleton("my list"));
+        assertThat(marked).isEqualTo("some note\n#-My List\nmore note\n#List2#List3\nlast line");
+
+        // re-parsing must no longer find the marked list, others remain untouched
+        final CacheArtefactParser parser = createParser("Praefix");
+        parser.parse(marked);
+        assertThat(parser.getListNames()).containsExactly("List2", "List3");
+    }
+
+    @Test
+    public void testMarkListAsIgnoredIsIdempotent() {
+        final String text = "#My List";
+        final String markedOnce = CacheArtefactParser.markListsAsIgnored(text, Collections.singleton("my list"));
+        final String markedTwice = CacheArtefactParser.markListsAsIgnored(text, Collections.singleton("my list"));
+        assertThat(markedTwice).isEqualTo(markedOnce);
+        assertThat(markedOnce).isEqualTo("#-My List");
+    }
+
+    @Test
+    public void testMarkListAsIgnoredNoMatch() {
+        final String text = "#My List#List2";
+        assertThat(CacheArtefactParser.markListsAsIgnored(text, Collections.singleton("Unknown"))).isEqualTo(text);
+    }
+
+    @Test
+    public void testMarkAllListsAsIgnored() {
+        final String text = "some note\n  #  My List  #  List2  \nmore note\n#-AlreadyIgnored#List3\nlast line";
+        final String marked = CacheArtefactParser.markListsAsIgnored(text, null);
+        assertThat(marked).isEqualTo("some note\n  #-  My List  #-  List2  \nmore note\n#-AlreadyIgnored#-List3\nlast line");
+
+        // re-parsing must find no list names at all anymore
+        final CacheArtefactParser parser = createParser("Praefix");
+        parser.parse(marked);
+        assertThat(parser.getListNames()).isEmpty();
+    }
+
+    @Test
+    public void testMarkListsAsIgnoredNullAndNoLists() {
+        assertThat(CacheArtefactParser.markListsAsIgnored(null, null)).isNull();
+
+        final String noListText = "just a normal note without any hash";
+        assertThat(CacheArtefactParser.markListsAsIgnored(noListText, Collections.singleton("List"))).isEqualTo(noListText);
+        assertThat(CacheArtefactParser.markListsAsIgnored(noListText, null)).isEqualTo(noListText);
     }
 
     @Test


### PR DESCRIPTION
Add parsing and creation of stored list identifiers in personal notes

Enhancing parsing and creating waypoint infos from/to PNs was one of my very first tasks at c:geo back then. This was extended years later with parsing/creating of variable information.

Even back then I wanted to add also parsing/creating of lists that the cache is associated with. Merging this PR would provide that functionaly. There might be an issue for this, not entirely sure.

Like prefix `@` is used for waypoints and `$` is used for variables, this PR will introduce `#` as prefix for list names

AI was used to create this PR initially, but I have reviewed it entirely and modified it by hand.