### PR TITLE
Add safeguard for D/T icons with invalid values

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -751,6 +751,9 @@ public final class MapMarkerUtils {
     private static Drawable getDTRatingMarkerSection(final Resources res, final String packageName, final String ratingLetter, final float rating, final float scaling) {
         // ensure that rating is an integer between 0 and 50 in steps of 5
         final int r = Math.max(0, Math.min(Math.round(rating * 2) * 5, 50));
+        if (StringUtils.containsNone(ratingLetter, 'd', 't') || r < 5) {
+            return new ScalableDrawable(ResourcesCompat.getDrawable(res, R.drawable.marker_rating_notavailable, null), scaling);
+        }
         return new ScalableDrawable(ResourcesCompat.getDrawable(res, res.getIdentifier("marker_rating_" + ratingLetter + "_" + r, "drawable", packageName), null), scaling);
     }
 


### PR DESCRIPTION
## Description
We have tickets on support (latest is [369401](https://cgeosupport.droescher.eu/scp/tickets.php?id=10832)) showing c:geo trying to load an invalid image resource, the calls coming from `MapMarkerUtils.getDTRatingMarkerSection`, which implies an invalid D/T value. This PR adds a safeguard for this, will fallback to the "D/T not available" icon in such cases.