### PR TITLE
Fix elevation chart infobox positioning

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChart.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChart.java
@@ -12,7 +12,6 @@ import cgeo.geocaching.models.geoitem.GeoIcon;
 import cgeo.geocaching.models.geoitem.GeoItem;
 import cgeo.geocaching.models.geoitem.GeoPrimitive;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemLayer;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
@@ -24,7 +23,6 @@ import static cgeo.geocaching.utils.DisplayUtils.getDimensionInDp;
 import android.content.res.Resources;
 import android.view.View;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -34,8 +32,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-
-import javax.annotation.Nullable;
 
 import info.appdev.charting.charts.LineChart;
 import info.appdev.charting.components.Legend;
@@ -62,7 +58,7 @@ public class ElevationChart {
     private boolean expanded = Settings.getBoolean(R.string.pref_elevationChartExpanded, false);
     private final MarkerView mv;
 
-    private static class Data {
+    static class Data {
         Geopoint point;
         int upRemaining;
         int downRemaining;
@@ -82,7 +78,8 @@ public class ElevationChart {
         this.geoItemLayer = geoItemLayer;
         toolbar = activity.findViewById(R.id.toolbar);
         res = activity.getResources();
-        mv = new MarkerView(activity, R.layout.elevationchart_infobox);
+        mv = new ElevationChartMarkerView(activity, R.layout.elevationchart_infobox);
+        mv.setChartView(chart);
     }
 
     public void removeElevationChart() {
@@ -118,7 +115,6 @@ public class ElevationChart {
                             geoItemLayer.put(ELEVATIONCHART_MARKER, marker);
                         }
                     }
-                    updateInfoBox(e);
                 }
 
                 @Override
@@ -252,18 +248,6 @@ public class ElevationChart {
 
         final YAxis yAxis2 = chart.getAxisRight();
         yAxis2.setEnabled(false);
-    }
-
-    private void updateInfoBox(@Nullable final EntryFloat entry) {
-        final RelativeLayout info = mv.findViewById(R.id.elevation_infobox);
-        if (info == null || entry == null) {
-            return;
-        }
-        final Data data = (Data) entry.getData();
-        ViewUtils.setText(mv.findViewById(R.id.elevationText), Units.formatElevation(entry.getY()));
-        ViewUtils.setText(mv.findViewById(R.id.distanceText), data == null ? "" : Units.getDistanceFromMeters(data.distanceRemaining / 100f));
-        ViewUtils.setText(mv.findViewById(R.id.upText), data == null ? "" : Units.formatElevation(data.upRemaining / 100f));
-        ViewUtils.setText(mv.findViewById(R.id.downText), data == null ? "" : Units.formatElevation(data.downRemaining / 100f));
     }
 
     /** find position on track closest to given coords (max 100m) and highlight it */

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChartMarkerView.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChartMarkerView.java
@@ -1,0 +1,84 @@
+package cgeo.geocaching.unifiedmap.layers;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.location.Units;
+import cgeo.geocaching.ui.ViewUtils;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import info.appdev.charting.components.MarkerView;
+import info.appdev.charting.data.EntryFloat;
+import info.appdev.charting.highlight.Highlight;
+import info.appdev.charting.utils.PointF;
+import info.appdev.charting.utils.ViewPortHandler;
+
+@SuppressLint("ViewConstructor")
+public class ElevationChartMarkerView extends MarkerView {
+
+    private final TextView tvText, tvDistance, tvUp, tvDown;
+
+    public ElevationChartMarkerView(final Context context, final int layoutResource) {
+        super(context, layoutResource);
+
+        tvText = findViewById(R.id.elevationText);
+        tvDistance = findViewById(R.id.distanceText);
+        tvUp = findViewById(R.id.upText);
+        tvDown = findViewById(R.id.downText);
+    }
+
+    // Run custom text updates when a data point is selected
+    @Override
+    public void refreshContent(final EntryFloat entry, @NonNull final Highlight highlight) {
+        final ElevationChart.Data data = (ElevationChart.Data) entry.getData();
+        ViewUtils.setText(tvText, Units.formatElevation(entry.getY()));
+        ViewUtils.setText(tvDistance, data == null ? "" : Units.getDistanceFromMeters(data.distanceRemaining / 100f));
+        ViewUtils.setText(tvUp, data == null ? "" : Units.formatElevation(data.upRemaining / 100f));
+        ViewUtils.setText(tvDown, data == null ? "" : Units.formatElevation(data.downRemaining / 100f));
+
+        // Force the layout to recalculate its width and height based on the text
+        measure(MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED), MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+        layout(0, 0, getMeasuredWidth(), getMeasuredHeight());
+
+        super.refreshContent(entry, highlight);
+    }
+
+    @NonNull
+    @Override
+    public PointF getOffsetForDrawingAtPoint(final float posX, final float posY) {
+        final int markerWidth = getWidth();
+        final int markerHeight = getHeight();
+
+        // get Viewport handler to determine exact positions of axes
+        final ViewPortHandler viewPort = getChartView().getViewPortHandler();
+        final float axisLeft = viewPort.contentLeft();
+        final float axisRight = viewPort.contentRight();
+        final float axisTop = viewPort.contentTop();
+        final float axisBottom = viewPort.contentBottom();
+
+        // horizontal placement (default: left of data point, with spacing)
+        // flip to right of data point if infobox is cut off or hitting vertical axis
+        final float spacingX = 15f;
+        float offsetX = -markerWidth - spacingX;
+        if (posX + offsetX < axisLeft) {
+            offsetX = spacingX;
+            if (posX + offsetX + markerWidth > axisRight) {
+                offsetX = axisRight - posX - markerWidth;
+            }
+        }
+
+        // vertical placement (default: vertically centered)
+        float offsetY = -(markerHeight / 2f);
+        if (posY + offsetY < axisTop) {
+            offsetY = axisTop - posY;
+        } else if (posY + offsetY + markerHeight > axisBottom) {
+            offsetY = axisBottom - posY - markerHeight;
+        }
+
+        return new PointF(offsetX, offsetY);
+    }
+
+}


### PR DESCRIPTION
## Description
Currently the infobox in elevation chart strictly follows the current position, anchoring the box at the data point, which leads to the box being cut off for data points with low y or high x values. This PR fixes this by positioning the infobox following those rules:
- default x-positioning is left of data point (+ spacing), but flipping to right of data point, when y axis gets touched
- default y-positioning is centered at data point, but being adjusted when touching upper or lower chart limit
The PR was created with AI assistance, but reviewed and modified by me.

|start|middle|low|
|---|---|---|
|<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/c4b407a5-a39d-4bee-baad-90ae59b6b19a" />|<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/72b8aef3-78c6-46f1-a3a4-863023846acf" />|<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/f11665fa-d3c5-4483-8f4e-437ba7425f21" />|
|box flipped to right of data point|default positioning|box moved upwards|