### PR TITLE
rel to #18500: remain list when switching from map to list, handle named filter tag

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -1579,9 +1579,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         // apply filter settings (if there's a filter)
         final SearchResult searchToUse = getFilteredSearch();
         if (listId == 0) {
-            DefaultMap.startActivitySearch(this, searchToUse, title, listId);
+            DefaultMap.startActivitySearch(this, searchToUse, title, listId, namedFilterId);
         } else {
-            DefaultMap.startActivityList(this, listId, currentCacheFilterContext);
+            DefaultMap.startActivityList(this, listId, namedFilterId, currentCacheFilterContext);
         }
         ActivityMixin.overrideTransitionToFade(this);
     }

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -160,7 +160,7 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
 
     private boolean onMapLongClicked() {
         new StoredList.UserInterface(this).promptForListSelection(R.string.list_title, selectedListId -> {
-            DefaultMap.startActivityList(this, selectedListId, null);
+            DefaultMap.startActivityList(this, selectedListId, -1, null);
             ActivityMixin.overrideTransitionToFade(this);
         }, false, PseudoList.NEW_LIST.id);
         return true;

--- a/main/src/main/java/cgeo/geocaching/filters/NamedFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/NamedFilter.java
@@ -295,6 +295,12 @@ public class NamedFilter {
         return namedFilters.get(id);
     }
 
+    @Nullable
+    public static synchronized GeocacheFilter getFilterbyId(final int id) {
+        final NamedFilter nf = getById(id);
+        return nf != null ? nf.filter : null;
+    }
+
     /** Find any filter by its name; returns null if not found; returns any filter if multiple exists with that name */
     @Nullable
     public static synchronized NamedFilter getFirstByName(final String name) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/DefaultMap.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/DefaultMap.java
@@ -58,19 +58,19 @@ public final class DefaultMap {
         new UnifiedMapType(search, title).launchMap(fromActivity);
     }
 
-    public static void startActivitySearch(final Activity fromActivity, final SearchResult search, final String title, final int fromList) {
+    public static void startActivitySearch(final Activity fromActivity, final SearchResult search, final String title, final int fromList, final int fromNamedFilter) {
         if (fromList == 0) {
             final Geopoint referencePoint = fromActivity instanceof CacheListActivity ? ((CacheListActivity) fromActivity).getReferencePoint() : null;
             new UnifiedMapType(search, title, referencePoint).launchMap(fromActivity); // same as above
         } else {
             // no longer allowed / CacheListActivity directly launches into startActivityList in this case
-            startActivityList(fromActivity, fromList, null);
+            startActivityList(fromActivity, fromList, fromNamedFilter, null);
         }
     }
 
-    public static void startActivityList(final Activity fromActivity, final int fromList, final @Nullable GeocacheFilterContext filterContext) {
+    public static void startActivityList(final Activity fromActivity, final int fromList, final int fromNamedFilter, final @Nullable GeocacheFilterContext filterContext) {
         if (fromList != 0) {
-            final UnifiedMapType mapType = new UnifiedMapType(fromList, filterContext);
+            final UnifiedMapType mapType = new UnifiedMapType(fromList, fromNamedFilter, filterContext);
             mapType.launchMap(fromActivity);
         }
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -12,6 +12,7 @@ import cgeo.geocaching.activity.FilteredActivity;
 import cgeo.geocaching.downloader.DownloaderUtils;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.filters.FilterUtils;
+import cgeo.geocaching.filters.NamedFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
@@ -481,7 +482,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 // load list of caches belonging to list and scale map to see them all
                 final AtomicReference<Viewport> viewport3 = new AtomicReference<>();
                 AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
-                    final SearchResult searchResult = DataStore.getBatchOfStoredCaches(null, mapType.fromList, mapType.filterContext.get(), null, false, -1);
+                    final GeocacheFilter filter = GeocacheFilter.createAnd(mapType.filterContext.get(), NamedFilter.getFilterbyId(mapType.fromNamedFilter));
+                    final SearchResult searchResult = DataStore.getBatchOfStoredCaches(null, mapType.fromList, filter, null, false, -1);
                     viewport3.set(DataStore.getBounds(searchResult.getGeocodes(), Settings.getZoomIncludingWaypoints()));
                     replaceSearchResultByGeocaches(searchResult);
                 }, () -> {
@@ -755,7 +757,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         if (viewModel.mapType.fromList != 0) {
             //List
-            listChooser.setList(viewModel.mapType.fromList, -1, visibleCaches, false);
+            listChooser.setList(viewModel.mapType.fromList, viewModel.mapType.fromNamedFilter, visibleCaches, false);
         } else if (viewModel.mapType.type == UMTT_TargetGeocode) {
             //single cache
             final Geocache targetCache = getCurrentTargetCache();
@@ -1082,9 +1084,14 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 menu.show();
             }
         } else if (id == R.id.menu_as_list) {
-            final Collection<Geocache> caches = viewModel.caches.readWithResult(vmCaches ->
-                    mapFragment.getViewport().filter(vmCaches));
-            CacheListActivity.startActivityMap(this, new SearchResult(caches));
+            if (viewModel.mapType.type == UMTT_List) {
+                Settings.setLastDisplayedList(viewModel.mapType.fromList);
+                CacheListActivity.startActivityOffline(this, NamedFilter.getById(viewModel.mapType.fromNamedFilter));
+            } else {
+                final Collection<Geocache> caches = viewModel.caches.readWithResult(vmCaches ->
+                        mapFragment.getViewport().filter(vmCaches));
+                CacheListActivity.startActivityMap(this, new SearchResult(caches));
+            }
         } else if (id == R.id.menu_hillshading) {
             Settings.setMapShadingShowLayer(!Settings.getMapShadingShowLayer());
             item.setChecked(Settings.getMapShadingShowLayer());

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -38,6 +38,7 @@ public class UnifiedMapType implements Parcelable {
     public SearchResult searchResult = null;
     public String title = null;
     public int fromList = 0;
+    public int fromNamedFilter = -1;
     public int waypointId = 0;
     public GeocacheFilterContext filterContext = new GeocacheFilterContext(LIVE);
     public boolean followMyLocation = false;
@@ -85,14 +86,15 @@ public class UnifiedMapType implements Parcelable {
 
     /** show and scale to list content */
     public UnifiedMapType(final int fromList) {
-        this(fromList, null);
+        this(fromList, -1, null);
     }
 
     /** show and scale to list content with filter applied */
-    public UnifiedMapType(final int fromList, final GeocacheFilterContext filterContext) {
+    public UnifiedMapType(final int fromList, final int fromNamedFilter, final GeocacheFilterContext filterContext) {
         type = UnifiedMapTypeType.UMTT_List;
         this.filterContext = filterContext != null ? filterContext : new GeocacheFilterContext(OFFLINE);
         this.fromList = fromList;
+        this.fromNamedFilter = fromNamedFilter;
     }
 
     /** show and scale to search result */
@@ -158,6 +160,7 @@ public class UnifiedMapType implements Parcelable {
         searchResult = in.readParcelable(SearchResult.class.getClassLoader());
         title = in.readString();
         fromList = in.readInt();
+        fromNamedFilter = in.readInt();
         filterContext = in.readParcelable(GeocacheFilterContext.class.getClassLoader());
         followMyLocation = (in.readInt() > 0); // readBoolean available from SDK 29 on
         waypointId = in.readInt();
@@ -178,6 +181,7 @@ public class UnifiedMapType implements Parcelable {
         dest.writeParcelable(searchResult, 0);
         dest.writeString(title);
         dest.writeInt(fromList);
+        dest.writeInt(fromNamedFilter);
         dest.writeParcelable(filterContext, 0);
         dest.writeInt(followMyLocation ? 1 : 0);
         dest.writeInt(waypointId);


### PR DESCRIPTION
rel to #18500: remain list when switching from map to list, handle named filter tag

Fixed a bug in the aftermath: when switching with a selected named filter to map and vice versa, named filter got lost.

While I was at it I noticed another bug: when a list is selected in map, then "show as list is chosen" then the list context was dropped in cache list activity. It should stay in this case. This is fixed with this PR as well.

Bug:
<img width="476" height="778" alt="image" src="https://github.com/user-attachments/assets/727f1585-bb32-4ead-9a89-caa9ae08864f" />

Now when using "Options" -> "Show as list", list context remains (means: chosen list ":blume" is still selected):
<img width="490" height="307" alt="image" src="https://github.com/user-attachments/assets/1ee4852f-dbda-4390-aaeb-fddb1bd5cf3f" />

(Previously this lead to "Map" being displayed in header of cache list, and reference to list ":blume" was lost)
