### PR TITLE
fix #18504: Use cursor.getColumnIndex in fileInfoFromCursor

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
@@ -217,25 +217,27 @@ class DocumentContentAccessor extends AbstractContentAccessor {
 
         //using dir.listFiles() is FAR too slow. Thus we have to create an explicit query
 
-        return queryDir(dir, new String[]{
-                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
-                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
-                DocumentsContract.Document.COLUMN_MIME_TYPE,
-                DocumentsContract.Document.COLUMN_LAST_MODIFIED,
-                DocumentsContract.Document.COLUMN_SIZE,
-
-        }, c -> fileInfoFromCursor(c, null, dir, folder));
+        return queryDir(dir, FILE_INFO_COLUMNS, c -> fileInfoFromCursor(c, null, dir, folder));
     }
 
     /**
      * retrieves a FileInformation object from the current cursor row retrieved by using {@link #queryDir(Uri, String[], Func1)} columns
      */
     private static ContentStorage.FileInformation fileInfoFromCursor(final Cursor c, final Uri docUri, final Uri parentDirUri, final Folder parentFolder) {
-        final String documentId = c.getString(0);
-        final String name = c.getString(1);
-        final String mimeType = c.getString(2);
-        final long lastMod = c.getLong(3);
-        final long size = c.getLong(4);
+        final int documentIdColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID);
+        final String documentId = documentIdColumn < 0 ? "" : c.getString(documentIdColumn);
+
+        final int nameColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME);
+        final String name = nameColumn < 0 ? "" : c.getString(nameColumn);
+
+        final int mimeColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE);
+        final String mimeType = mimeColumn < 0 ? "" : c.getString(mimeColumn);
+
+        final int lastModColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
+        final long lastMod = lastModColumn < 0 ? -1 : c.getLong(lastModColumn);
+
+        final int sizeColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE);
+        final long size = sizeColumn < 0 ? -1 : c.getLong(sizeColumn);
 
         final boolean isDir = DocumentsContract.Document.MIME_TYPE_DIR.equals(mimeType);
         final Uri uri = docUri != null ? docUri :

--- a/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
@@ -224,26 +224,30 @@ class DocumentContentAccessor extends AbstractContentAccessor {
      * retrieves a FileInformation object from the current cursor row retrieved by using {@link #queryDir(Uri, String[], Func1)} columns
      */
     private static ContentStorage.FileInformation fileInfoFromCursor(final Cursor c, final Uri docUri, final Uri parentDirUri, final Folder parentFolder) {
-        final int documentIdColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID);
-        final String documentId = documentIdColumn < 0 ? "" : c.getString(documentIdColumn);
-
         final int nameColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME);
-        final String name = nameColumn < 0 ? "" : c.getString(nameColumn);
+        final String name = c.getString(nameColumn);
 
         final int mimeColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE);
-        final String mimeType = mimeColumn < 0 ? "" : c.getString(mimeColumn);
+        final String mimeType = c.getString(mimeColumn);
 
         final int lastModColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
-        final long lastMod = lastModColumn < 0 ? -1 : c.getLong(lastModColumn);
+        final long lastMod = c.getLong(lastModColumn);
 
         final int sizeColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE);
-        final long size = sizeColumn < 0 ? -1 : c.getLong(sizeColumn);
+        final long size = c.getLong(sizeColumn);
 
         final boolean isDir = DocumentsContract.Document.MIME_TYPE_DIR.equals(mimeType);
-        final Uri uri = docUri != null ? docUri :
-                (parentDirUri != null ? DocumentsContract.buildDocumentUriUsingTree(parentDirUri, documentId) : null);
+        final Uri uri;
+        if (docUri == null && parentDirUri != null) {
+            final int documentIdColumn = c.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID);
+            final String documentId = c.getString(documentIdColumn);
+            uri = DocumentsContract.buildDocumentUriUsingTree(parentDirUri, documentId);
+        } else {
+            uri = docUri;
+        }
 
-        return new ContentStorage.FileInformation(name, uri, parentFolder, isDir, isDir && parentFolder != null ? Folder.fromFolder(parentFolder, name) : null, mimeType, size, lastMod);
+        final Folder dirLocation = isDir && parentFolder != null ? Folder.fromFolder(parentFolder, name) : null;
+        return new ContentStorage.FileInformation(name, uri, parentFolder, isDir, dirLocation, mimeType, size, lastMod);
     }
 
     @Override


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Getting fileInfo from Cursor throwed an exception when invoked from an dropbox-uri.
This PR gets the values from cursor via fetching the columns instead of relying on fixed order

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #18504

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->