### PR TITLE
Improve filter management (fix #18517, fix #18519)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -129,8 +129,8 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         }
 
         setTitle(LocalizationUtils.getString(filterContext.getType().titleId));
-        fillViewFromFilter(filterContext.get().toConfig(), false);
-        originalFilterConfig = getFilterFromView().toConfig();
+        originalFilterConfig = filterContext.get().toConfig();
+        fillViewFromFilter(originalFilterConfig, false);
 
         navUpHandler = ActivityMixin.registerBackNavigationInterceptor(this, this::onNavigationIntercepted);
 
@@ -169,9 +169,16 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     private void initializeNamedFilterButtons() {
         // Add Named Filter criterion button
+        Runnable showListSelection = () -> FilterUtils.openDialogSelectNamedFilter(
+                this, TextParam.id(R.string.named_filter_fill_with_named), null,
+                selected -> {
+                    originalFilterConfig = selected == null ? null : selected.toConfig();
+                    fillViewFromFilter(selected == null ? null : originalFilterConfig, false);
+                });
         binding.filterFillWithNamed.setOnClickListener(v -> {
-            FilterUtils.openDialogSelectNamedFilter(this, TextParam.id(R.string.named_filter_fill_with_named), null, selected ->
-                fillViewFromFilter(selected == null ? null : selected.toConfig(), false));
+            if (!askForUnsavedChanges(showListSelection)) {
+                showListSelection.run();
+            }
         });
         ViewUtils.setTooltip(binding.filterFillWithNamed, TextParam.id(R.string.named_filter_fill_with_named));
 
@@ -185,12 +192,12 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
         // Delete Named Filter button
         binding.filterStorageDelete.setOnClickListener(v -> {
-            final String filterName = binding.filterStorageName.getText().toString();
+            final String filterName = binding.filterDisplayName.getText().toString();
             SimpleDialog.of(this).setTitle(R.string.named_filter_delete)
                     .setMessage(R.string.named_filter_storage_delete_message, filterName)
                     .confirm(() -> {
-                        NamedFilter.delete(filterName);
-                        binding.filterStorageName.setText("");
+                        NamedFilter.delete(binding.filterStorageName.getText().toString());
+                        adjustNamedFilterReferenceViewFor(null);
                     });
         });
     }
@@ -245,7 +252,9 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     private void saveViewAsNamedFilter(final String newName, @Nullable final String markerId) {
         adjustNamedFilterReferenceViewFor(null);
-        final NamedFilter newNamedFilter = NamedFilter.addOrReplace(newName, getFilterFromView(), markerId);
+        final GeocacheFilter newFilter = getFilterFromView();
+        final NamedFilter newNamedFilter = NamedFilter.addOrReplace(newName, newFilter, markerId);
+        originalFilterConfig = newFilter.toConfig();
         adjustNamedFilterReferenceViewFor(newNamedFilter);
     }
 
@@ -387,9 +396,12 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
     }
 
     private void adjustNamedFilterReferenceViewFor(@Nullable final NamedFilter filter) {
-        final boolean unsavedFilter = this.filterContext.get().getTree() != null && filter != null && !this.filterContext.get().filtersSame(filter.getFilter());
-        binding.filterStorageName.setText(filter == null ? "" : unsavedFilter ? "(" + filter.getName() + ")*" : filter.getNameAndMarker());
-        binding.filterStorageName.setTypeface(null, unsavedFilter ? Typeface.ITALIC : Typeface.NORMAL);
+        // final boolean unsavedFilter = this.filterContext.get().getTree() != null && filter != null && !this.filterContext.get().filtersSame(filter.getFilter());
+        final GeocacheFilter originalFilter = filter == null ? null : GeocacheFilter.createFromConfig(originalFilterConfig);
+        final boolean unsavedFilter = originalFilter != null && !originalFilter.filtersSame(filter.getFilter());
+        binding.filterStorageName.setText(filter == null ? "" : filter.getName());
+        binding.filterDisplayName.setText(filter == null ? "" : unsavedFilter ? "(" + filter.getNameAndMarker() + ")*" : filter.getNameAndMarker());
+        binding.filterDisplayName.setTypeface(null, unsavedFilter ? Typeface.ITALIC : Typeface.NORMAL);
         binding.filterSaveAsNamed.setIconResource(unsavedFilter ? R.drawable.ic_menu_unsaved : R.drawable.ic_menu_save);
         binding.filterReferenceNamedFilterId.setText(filter == null ? "-1" : "" + filter.getId());
         binding.filterStorageDelete.setVisibility(filter == null ? View.GONE : View.VISIBLE);
@@ -406,6 +418,19 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         finish();
     }
 
+    private boolean askForUnsavedChanges(final Runnable onConfirm) {
+        if (originalFilterConfig != null) {
+            final GeocacheFilter newFilter = getFilterFromView();
+            final GeocacheFilter originalFilter = GeocacheFilter.createFromConfig(originalFilterConfig);
+            if (!originalFilter.filtersSame(newFilter)) {
+                SimpleDialog.of(this).setTitle(R.string.confirm_unsaved_changes_title).setMessage(R.string.confirm_discard_changes)
+                        .confirm(onConfirm);
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Called when the user attempts to leave via back press or navigate up.
      *
@@ -413,14 +438,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
      * @return true to STOP navigation (a confirmation dialog was shown), false to CONTINUE
      */
     private boolean onNavigationIntercepted(final Runnable navigationAction) {
-        final GeocacheFilter newFilter = getFilterFromView();
-        final boolean filterWasChanged = originalFilterConfig != null && !originalFilterConfig.equals(newFilter.toConfig());
-        if (filterWasChanged) {
-            SimpleDialog.of(this).setTitle(R.string.confirm_unsaved_changes_title).setMessage(R.string.confirm_discard_changes)
-                    .confirm(navigationAction);
-            return true;
-        }
-        return false;
+        return askForUnsavedChanges(navigationAction);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -169,7 +169,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     private void initializeNamedFilterButtons() {
         // Add Named Filter criterion button
-        Runnable showListSelection = () -> FilterUtils.openDialogSelectNamedFilter(
+        final Runnable showListSelection = () -> FilterUtils.openDialogSelectNamedFilter(
                 this, TextParam.id(R.string.named_filter_fill_with_named), null,
                 selected -> {
                     originalFilterConfig = selected == null ? null : selected.toConfig();

--- a/main/src/main/res/layout/cache_filter_activity.xml
+++ b/main/src/main/res/layout/cache_filter_activity.xml
@@ -41,6 +41,12 @@
 
             <TextView
                 android:id="@+id/filter_storage_name"
+                android:layout_width="1dp"
+                android:layout_height="1dp"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/filter_display_name"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
This PR fixes the following aspects:
* fix #18519
  * Culprit of the false modified marker was comparing the filter-config against an outdated / wrong one. 
* fix #18517
  * For deleting a filter a wrong name was used to identify the named filter (marker icon was added to name)
* ask for unsaved changes on filter select
