### PR TITLE
Add rename option to filter save dialog (rel. to #18503)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -236,7 +236,8 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
                         .setMessage(R.string.named_filter_config_exists_message, existing.getName())
                         .confirm(
                             () -> saveViewAsNamedFilter(name, marker),
-                            () -> openSaveFilterDialog(name, marker));
+                            () -> openSaveFilterDialog(name, marker),
+                            () -> renameNamedFilter(existing.getName(), name, marker), TextParam.id(R.string.rename));
             } else {
                 saveViewAsNamedFilter(name, marker);
             }
@@ -247,6 +248,11 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         adjustNamedFilterReferenceViewFor(null);
         final NamedFilter newNamedFilter = NamedFilter.addOrReplace(newName, getFilterFromView(), markerId);
         adjustNamedFilterReferenceViewFor(newNamedFilter);
+    }
+
+    private void renameNamedFilter(final String oldName, final String newName, @Nullable final String markerId) {
+        NamedFilter.delete(oldName);
+        saveViewAsNamedFilter(newName, markerId);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -21,6 +21,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
@@ -427,7 +428,11 @@ public class SimpleDialog {
      * A confirm dialog always has at least a positive action and shows at least a positive and a negative button.
      * Provide up to two listeners to define actions for 'positive' and 'negative'.
      */
-    public void confirm(final Runnable positive, final Runnable negative) {
+    public void confirm(@NonNull final Runnable positive, @NonNull final Runnable negative) {
+        confirm(positive, negative, null, null);
+    }
+
+    public void confirm(final Runnable positive, final Runnable negative, @Nullable final Runnable neutral, @Nullable final TextParam neutralButtonText) {
         //"confirm" always needs at least "OK" and "cancel"
         if (positiveButton == null) {
             setPositiveButton(TextParam.id(R.string.ok));
@@ -435,10 +440,13 @@ public class SimpleDialog {
         if (negativeButton == null) {
             setNegativeButton(TextParam.id(R.string.cancel));
         }
-        showInternal(positive, negative);
+        if (neutral != null) {
+            setNeutralButton(neutralButtonText);
+        }
+        showInternal(positive, negative, neutral);
     }
 
-    private void showInternal(final Runnable positive, final Runnable negative) {
+    private void showInternal(@Nullable final Runnable positive, @Nullable final Runnable negative, @Nullable final Runnable neutral) {
         final AlertDialog dialog = constructCommons().first;
         if (negative != null) {
             dialog.setOnCancelListener(dialogInterface -> negative.run());
@@ -460,6 +468,13 @@ public class SimpleDialog {
                         return true;
                     }
                     break;
+                case DialogInterface.BUTTON_NEUTRAL:
+                    if (neutral != null) {
+                        neutral.run();
+                        dialog.dismiss();
+                        return true;
+                    }
+                    break;
                 default:
                     //do nothing
                     break;
@@ -477,7 +492,7 @@ public class SimpleDialog {
      */
     public void show(final Runnable positive) {
         setNegativeButton(null);
-        showInternal(positive, null);
+        showInternal(positive, null, null);
     }
 
     public void show() {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3189,6 +3189,7 @@
     <string name="copy" tools:ignore="PrivateResource">Copy</string>
     <string name="pause">Pause</string>
     <string name="resume">Resume</string>
+    <string name="rename">Rename</string>
 
     <!-- Multi-Selections -->
     <string name="multiselect_selectall">Select All</string>


### PR DESCRIPTION
## Description
Adds a "rename" option to filter save dialog, as proposed in https://github.com/cgeo/cgeo/pull/18430#issuecomment-5337991746 / https://github.com/cgeo/cgeo/issues/18493#issuecomment-5338494484 / https://github.com/cgeo/cgeo/issues/18503#issuecomment-5464201747