### PR TITLE
fix #18518: select multiple named filter instead of marker

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -957,7 +957,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
      */
     @Override
     public boolean showSavedFilterList() {
-        FilterUtils.openDialogSelectNamedFilter(this,
+        FilterUtils.openDialogSelectGeocacheFilter(this,
             TextParam.id(R.string.cache_filter_storage_select_title),
             currentCacheFilterContext,
             selectedFilter -> {

--- a/main/src/main/java/cgeo/geocaching/filters/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/filters/FilterUtils.java
@@ -146,6 +146,24 @@ public class FilterUtils {
             });
     }
 
+    /**
+     * opens dialog to select multi @NamedFilter among named filters.
+     */
+    public static void openDialogMultiSelectNamedFilter(@NonNull final Context context, @Nullable final TextParam title, @Nullable final Consumer<Set<NamedFilter>> onFiltersSelected, final Set<NamedFilter> exceptFilters) {
+        final List<NamedFilter> namedFilters = NamedFilter.getAll().stream()
+                .filter(f -> !exceptFilters.contains(f)).collect(Collectors.toList());
+        final SimpleDialog.ItemSelectModel<NamedFilter> model = buildGroupedModel(namedFilters);
+        model.setChoiceMode(SimpleItemListModel.ChoiceMode.MULTI_CHECKBOX);
+
+        SimpleDialog.ofContext(context)
+                .setTitle(title != null ? title : TextParam.id(R.string.named_filter_select_title))
+                .selectMultiple(model, selectedNamedFilter -> {
+                    if (onFiltersSelected != null) {
+                        onFiltersSelected.accept(selectedNamedFilter);
+                    }
+                });
+    }
+
     /** Returns the sorted list of unique parent group names extracted from all existing named filters. */
     public static List<String> getNamedFilterGroups() {
         return NamedFilter.getAll().stream()

--- a/main/src/main/java/cgeo/geocaching/filters/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/filters/FilterUtils.java
@@ -105,7 +105,7 @@ public class FilterUtils {
     }
 
     /** opens dialog to select a new filter among named filters. Includes options to clear and select previous (if GeocacheFilterContext is provided) */
-    public static void openDialogSelectNamedFilter(@NonNull final Context context, @Nullable final TextParam title, @Nullable final GeocacheFilterContext filterContext, @Nullable final Consumer<GeocacheFilter> onFilterSelected) {
+    public static void openDialogSelectGeocacheFilter(@NonNull final Context context, @Nullable final TextParam title, @Nullable final GeocacheFilterContext filterContext, @Nullable final Consumer<GeocacheFilter> onFilterSelected) {
         final GeocacheFilter currentFilter = filterContext == null ? null : filterContext.get();
         final boolean isFilterActive = currentFilter != null && currentFilter.isFiltering();
         final GeocacheFilter previousFilter = filterContext == null ? null : filterContext.getPreviousFilter();

--- a/main/src/main/java/cgeo/geocaching/filters/gui/CheckboxFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/CheckboxFilterViewHolder.java
@@ -130,14 +130,16 @@ public class CheckboxFilterViewHolder<T, F extends IGeocacheFilter> extends Base
                     .setDisplayMapper((s) -> TextParam.text(filterAccessor.getDisplayText(s)));
 
             SimpleDialog.of(getActivity()).setTitle(TextParam.id(R.string.cache_filter_checkboxlist_add_items_dialog_title))
-                    .selectMultiple(model, s -> {
-                        visibleValues.addAll(s);
-                        for (T value : s) {
-                            getValueCheckbox(value).right.setChecked(true);
-                        }
-                        relayout();
-                    });
+                    .selectMultiple(model, this::addItems);
         };
+    }
+
+    protected void addItems(final Set<T> values) {
+        visibleValues.addAll(values);
+        for (T value : values) {
+            getValueCheckbox(value).right.setChecked(true);
+        }
+        relayout();
     }
 
     private View createAddItemButton(final ViewGroup vg) {

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -169,7 +169,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     private void initializeNamedFilterButtons() {
         // Add Named Filter criterion button
-        final Runnable showListSelection = () -> FilterUtils.openDialogSelectNamedFilter(
+        final Runnable showListSelection = () -> FilterUtils.openDialogSelectGeocacheFilter(
                 this, TextParam.id(R.string.named_filter_fill_with_named), null,
                 selected -> {
                     originalFilterConfig = selected == null ? null : selected.toConfig();

--- a/main/src/main/java/cgeo/geocaching/filters/gui/NamedFilterFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/NamedFilterFilterViewHolder.java
@@ -1,21 +1,25 @@
 package cgeo.geocaching.filters.gui;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.filters.FilterUtils;
+import cgeo.geocaching.filters.NamedFilter;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.ui.TextParam;
 
 import android.view.View;
 
 import java.util.Collections;
 
 
-public class NamedFilterFilterViewHolder<T, F extends IGeocacheFilter> extends CheckboxFilterViewHolder<T, F> {
+public class NamedFilterFilterViewHolder<F extends IGeocacheFilter> extends CheckboxFilterViewHolder<NamedFilter, F> {
 
-        public NamedFilterFilterViewHolder(final ValueGroupFilterAccessor<T, F> filterAccessor) {
+    public NamedFilterFilterViewHolder(final ValueGroupFilterAccessor<NamedFilter, F> filterAccessor) {
             super(filterAccessor, 1, Collections.emptySet(), false);
         }
 
         @Override
         protected View.OnClickListener getAddItemButtonCallback() {
-            return v -> FilterUtils.openDialogActivateMarkers(getActivity());
-    }
+            return v -> FilterUtils.openDialogMultiSelectNamedFilter(getActivity(),
+                    TextParam.id(R.string.cache_filter_storage_select_title), this::addItems, visibleValues);
+        }
 }

--- a/main/src/main/java/cgeo/geocaching/filters/gui/StoredListsFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/StoredListsFilterViewHolder.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.filters.gui;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.list.ListNameMemento;
 import cgeo.geocaching.list.StoredList;
 
 import android.view.View;
@@ -10,21 +11,23 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class StoredListsFilterViewHolder<T, F extends IGeocacheFilter> extends CheckboxFilterViewHolder<T, F> {
-    public StoredListsFilterViewHolder(final ValueGroupFilterAccessor<T, F> filterAccessor) {
+public class StoredListsFilterViewHolder<F extends IGeocacheFilter> extends CheckboxFilterViewHolder<StoredList, F> {
+    public StoredListsFilterViewHolder(final ValueGroupFilterAccessor<StoredList, F> filterAccessor) {
         super(filterAccessor, 1, Collections.emptySet(), false);
     }
 
     @Override
     protected View.OnClickListener getAddItemButtonCallback() {
-        return v -> new StoredList.UserInterface(getActivity()).promptForMultiListSelection(R.string.lists_title,
+        return v -> {
+            final Set<Integer> exceptListIds = visibleValues.stream()
+                    .map(item -> item.id).collect(Collectors.toSet());
+
+            new StoredList.UserInterface(getActivity()).promptForMultiListSelection(R.string.lists_title,
         s -> {
-            final Set<T> selectedListsSet = filterAccessor.getSelectableValues().stream().filter(list -> s.contains(((StoredList) list).id)).collect(Collectors.toSet());
-            visibleValues.addAll(selectedListsSet);
-            for (T value : selectedListsSet) {
-                getValueCheckbox(value).right.setChecked(true);
-            }
-            relayout();
-        }, true, Collections.emptySet(), false);
+            final Set<StoredList> selectableValues = filterAccessor.getSelectableValues().stream()
+                    .filter(list -> s.contains(list.id)).collect(Collectors.toSet());
+            addItems(selectableValues);
+        }, true, exceptListIds, Collections.emptySet(), ListNameMemento.EMPTY, false);
+        };
     }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1187,7 +1187,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     @Override
     public boolean showSavedFilterList() {
-        FilterUtils.openDialogSelectNamedFilter(this,
+        FilterUtils.openDialogSelectGeocacheFilter(this,
                 TextParam.id(R.string.cache_filter_storage_select_title),
                 viewModel.mapType.filterContext,
                 selectedFilter -> {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
PR shows an dialog for selecting multiple NamedFilter for adding them to a filter.

Already visible entries in the view holder are not shown in the selection-dialog as in e.g. origin-view-holder: 
for namedfilter-view-holder as well as for storedlist-view-holder (old behaviour was showing all)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #18518

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
| new | marker list (for reference)|old (wrong content)| 
| --- | --- | --- |
|<img height="600" alt="grafik" src="https://github.com/user-attachments/assets/a6b8394f-8241-4f44-82a2-37ab3777d5b2" /> | <img height="400" alt="grafik" src="https://github.com/user-attachments/assets/bfcc263d-45c5-4fae-9ea1-bb27012dc8f6" /> |<img height="600" alt="grafik" src="https://github.com/user-attachments/assets/c5d5b595-2971-4ea1-85fc-b295b3ff4c13" />| 
