### PR TITLE
fix #18543 and adjust cachedetail marker button to global marker activation/deactivation

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/filters/FilterUtils.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import com.google.android.material.button.MaterialButton;
 import org.apache.commons.lang3.StringUtils;
 
 public class FilterUtils {
@@ -77,11 +78,13 @@ public class FilterUtils {
         final List<NamedFilter> filters = NamedFilter.getAllWithIcons();
 
         if (filters.isEmpty()) {
-            SimpleDialog.ofContext(context)
-                .setMessage(R.string.named_filter_no_icons_message)
-                .setNeutralButton(TextParam.id(R.string.named_filter_manage_filter))
-                .setNeutralAction(() -> FilterUtils.onClickFilterMenu((FilteredActivity) context))
-                .show();
+            final SimpleDialog dialog = SimpleDialog.ofContext(context)
+                .setMessage(R.string.named_filter_no_icons_message);
+            if (context instanceof FilteredActivity) {
+                dialog.setNeutralButton(TextParam.id(R.string.named_filter_manage_filter))
+                   .setNeutralAction(() -> FilterUtils.onClickFilterMenu((FilteredActivity) context));
+            }
+            dialog.show();
             return;
         }
 
@@ -102,6 +105,22 @@ public class FilterUtils {
             .setNeutralButton(TextParam.id(R.string.named_filter_reorder))
             .setNeutralAction(() -> NamedFilterPriorityActivity.startActivity(context))
             .selectMultiple(model, NamedFilter::activateMarker);
+    }
+
+    public static void registerFilterActivateDeactivateButton(final Activity activity, final View button) {
+        if (button instanceof MaterialButton) {
+            ((MaterialButton) button).setIconResource(Settings.isConditionalCacheMarkersEnabled() ? R.drawable.ic_menu_marker : R.drawable.ic_menu_marker_off);
+        }
+        button.setOnClickListener(v -> openDialogActivateMarkers(activity));
+        button.setOnLongClickListener(v -> {
+            final boolean newState = !Settings.isConditionalCacheMarkersEnabled();
+            Settings.setConditionalCacheMarkersEnabled(newState);
+            if (button instanceof MaterialButton) {
+                ((MaterialButton) button).setIconResource(Settings.isConditionalCacheMarkersEnabled() ? R.drawable.ic_menu_marker : R.drawable.ic_menu_marker_off);
+            }
+            GeocacheChangedBroadcastReceiver.sendBroadcast(GeocacheChangedBroadcastReceiver.NAMED_FILTER_CHANGED);
+            return true;
+        });
     }
 
     /** opens dialog to select a new filter among named filters. Includes options to clear and select previous (if GeocacheFilterContext is provided) */

--- a/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
+++ b/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
@@ -203,7 +203,7 @@ public class CacheInfoBoxes {
             final boolean enableMarkerButton = cacheDetailActivity != null && Settings.getNamedFilterDisplayMode() != Settings.NamedFilterDisplayMode.NONE;
             marker.setVisibility(enableMarkerButton ? View.VISIBLE : View.GONE);
             if (enableMarkerButton) {
-                marker.setOnClickListener(v -> FilterUtils.openDialogActivateMarkers(cacheDetailActivity));
+                FilterUtils.registerFilterActivateDeactivateButton(cacheDetailActivity, marker);
             }
         }
         appendMatchingNamedFilters(builder, cache, cacheDetailActivity);
@@ -226,19 +226,20 @@ public class CacheInfoBoxes {
             return;
         }
 
+        final SpannableStringBuilder filtersBuilder = new SpannableStringBuilder();
+
         final ImmutablePair<List<NamedFilter>, List<NamedFilter>> matches = NamedFilter.getFiltersMatchingCache(cache, mode == Settings.NamedFilterDisplayMode.ACTIVE_ONLY);
         final List<NamedFilter> activeFilters = matches.left;
         final List<NamedFilter> passiveFilters = matches.right;
         if (activeFilters.isEmpty() && passiveFilters.isEmpty()) {
-            return;
-        }
-
-        final SpannableStringBuilder filtersBuilder = new SpannableStringBuilder();
-        for (final NamedFilter filter : activeFilters) {
-            appendNamedFilter(filtersBuilder, filter, false, cacheDetailActivity);
-        }
-        for (final NamedFilter filter : passiveFilters) {
-            appendNamedFilter(filtersBuilder, filter, true, cacheDetailActivity);
+            filtersBuilder.append("-");
+        } else {
+            for (final NamedFilter filter : activeFilters) {
+                appendNamedFilter(filtersBuilder, filter, !Settings.isConditionalCacheMarkersEnabled(), cacheDetailActivity);
+            }
+            for (final NamedFilter filter : passiveFilters) {
+                appendNamedFilter(filtersBuilder, filter, true, cacheDetailActivity);
+            }
         }
         filtersBuilder.insert(0, LocalizationUtils.getString(R.string.filters_list_headline) + " ");
 


### PR DESCRIPTION
fix #18543 and adjust cachedetail marker button to global marker activation/deactivation

This PR contains two things related to the "marker activation/deactivation" button in Cachedetails, since both have to be done in same code area.

**Fixing ClassCastException when no filter with marker is defined (bug #18543):**
due to the team's decision to not have a dedicated dialog for named filter/marker/... definition, it is not possible to open such a dialog from cache-details. Trying to do this was the cause of the CCE. I disabled the option to open named filter/marker edit dialog when opened from cache-details.

**Make button consider the global activation/deactivation flag.**
Despite myself being not a fan of this feature, I feel that marker activation/deactivation buttons should behave the same across c:geo. Since such a global activation/deactivation doesn't make any sense IMHO in cache-details, I decided to still display the "active" filters but grayed out in case of global deactivation (see following screenshots).

Imagine following activation/deactivation situation:
<img width="400" height="417" alt="image" src="https://github.com/user-attachments/assets/1ecd08f3-5ba8-42f3-9f4e-7a66293de3cf" />

Then when global markers are active it looks like this:
<img width="491" height="664" alt="image" src="https://github.com/user-attachments/assets/6102465a-02d0-4d2a-8f24-8d4c9c80468a" />

On global DEactivation it looks like this ("active" markers still displayed but grayed out):
<img width="485" height="647" alt="image" src="https://github.com/user-attachments/assets/542d55a2-291c-4a6b-b44a-59249ad35d0e" />

