### PR TITLE
Fix #18520: make emoji drawable copies + fix: dont refresh cachelist on constant coords

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.activity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.ViewUtils;
@@ -235,7 +236,8 @@ public class AbstractActionBarActivity extends AbstractActivity {
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayShowHomeEnabled(true);
-            actionBar.setIcon(MapMarkerUtils.getCacheMarker(getResources(), cache, CacheListType.OFFLINE, Settings.getIconScaleEverywhere()).getDrawable());
+            final CacheMarker marker = MapMarkerUtils.getCacheMarker(getResources(), cache, CacheListType.OFFLINE, Settings.getIconScaleEverywhere());
+            actionBar.setIcon(marker.getDrawable());
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/filters/NamedFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/NamedFilter.java
@@ -384,11 +384,12 @@ public class NamedFilter {
      * Returns an empty pair if {@code cache} is null.
      */
     @NonNull
-    public static synchronized ImmutablePair<List<NamedFilter>, List<NamedFilter>> getFiltersMatchingCache(@Nullable final Geocache cache, final boolean onlyActive) {
+    public static synchronized ImmutablePair<List<NamedFilter>, List<NamedFilter>> getFiltersMatchingCache(@Nullable final Geocache cache, final boolean onlyActive, final int maxResults) {
         if (cache == null) {
             return new ImmutablePair<>(Collections.emptyList(), Collections.emptyList());
         }
         ensureCache();
+        int count = 0;
         final List<NamedFilter> active = new ArrayList<>();
         final List<NamedFilter> passive = !onlyActive ? new ArrayList<>() : Collections.emptyList();
         for (final NamedFilter nf : namedFiltersSortedByPrioAndName) {
@@ -402,6 +403,10 @@ public class NamedFilter {
                 } else {
                     passive.add(nf);
                 }
+                count++;
+                if (maxResults > 0 && count >= maxResults) {
+                    break;
+                }
             }
         }
         return new ImmutablePair<>(active, passive);
@@ -409,11 +414,11 @@ public class NamedFilter {
 
     /**
      * Returns the marker ids (emoji code-points) of active matching filters for the given cache.
-     * Uses the first list from {@link #getFiltersMatchingCache(Geocache)}.
+     * Uses the active list from {@link #getFiltersMatchingCache(Geocache, boolean, int)}.
      */
     @NonNull
-    public static List<String> getMarkersForCache(@Nullable final Geocache cache) {
-        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> pair = getFiltersMatchingCache(cache, true);
+    public static List<String> getMarkersForCache(@Nullable final Geocache cache, final int maxResults) {
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> pair = getFiltersMatchingCache(cache, true, maxResults);
         final List<String> result = new ArrayList<>();
         for (final NamedFilter nf : pair.left) {
             if (StringUtils.isNotBlank(nf.markerId)) {

--- a/main/src/main/java/cgeo/geocaching/location/Geopoint.java
+++ b/main/src/main/java/cgeo/geocaching/location/Geopoint.java
@@ -273,6 +273,50 @@ public final class Geopoint implements ICoordinate, Parcelable {
     }
 
     /**
+     * Upper bound (worst case, WGS84) for the distance in meters represented by a difference of 1 in the
+     * E6 (microdegree) representation of either latitude or longitude. The real-world value is at most
+     * ~111.7m per degree (polar meridian), i.e. ~0.1117m per microdegree; rounded up slightly for safety.
+     */
+    private static final double MAX_METERS_PER_E6_DEGREE = 0.112;
+
+    /**
+     * Cheap, approximate check whether this Geopoint and <tt>other</tt> are at most <tt>toleranceMeters</tt> apart.
+     * <p>
+     * Method does not account for shrinking of longitude-degree-length towards the poles. The check is
+     * conservative: it never reports two points as "close" when they are actually farther apart than
+     * <tt>toleranceMeters</tt>. It may (rarely, at high latitudes, for a purely east-west offset) report
+     * "not close" for points that are in fact within tolerance. For a precise result, use {@link #distanceTo(ICoordinate)}.
+     *
+     * @param other           the other Geopoint, or <tt>null</tt>
+     * @param toleranceMeters maximum allowed distance in meters
+     * @return <tt>true</tt> if both points are (approximately, worst-case) within <tt>toleranceMeters</tt> of each other
+     */
+    public boolean isCloseTo(@Nullable final Geopoint other, final double toleranceMeters) {
+        if (other == null) {
+            return false;
+        }
+        if (this == other) {
+            return true;
+        }
+        final double toleranceE6 = toleranceMeters / MAX_METERS_PER_E6_DEGREE;
+        return Math.abs((double) latitudeE6 - other.latitudeE6) <= toleranceE6
+                && Math.abs((double) longitudeE6 - other.longitudeE6) <= toleranceE6;
+    }
+
+    /** convenience variant with tolerance of 1 meter */
+    public boolean isCloseTo(@Nullable final Geopoint other) {
+        return isCloseTo(other, 1.0);
+    }
+
+    public static boolean areCloseToEachOther(@Nullable final Geopoint p1, @Nullable final Geopoint p2, final double toleranceMeters) {
+        return p1 == null ? p2 == null : p1.isCloseTo(p2, toleranceMeters);
+    }
+
+    public static boolean areCloseToEachOther(@Nullable final Geopoint p1, @Nullable final Geopoint p2) {
+        return areCloseToEachOther(p1, p2, 1.0);
+    }
+
+    /**
      * Returns formatted coordinates.
      *
      * @param format the desired format

--- a/main/src/main/java/cgeo/geocaching/maps/CacheMarker.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CacheMarker.java
@@ -4,6 +4,8 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 
+import androidx.annotation.NonNull;
+
 public class CacheMarker {
 
     private final int hashCode;
@@ -11,6 +13,10 @@ public class CacheMarker {
     protected final Bitmap bitmap;
 
     public CacheMarker(final int hashCode, final Drawable drawable) {
+        this(hashCode, -1, drawable);
+    }
+
+    public CacheMarker(final int hashCode, final int id, final Drawable drawable) {
         this.hashCode = hashCode;
         this.drawable = drawable;
 
@@ -27,6 +33,10 @@ public class CacheMarker {
 
     public Bitmap getBitmap() {
         return bitmap;
+    }
+
+    public int getHashCode() {
+        return hashCode;
     }
 
     @Override
@@ -50,6 +60,15 @@ public class CacheMarker {
     @Override
     public int hashCode() {
         return hashCode == 0 ? drawable.hashCode() : hashCode;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "CacheMarker{" +
+                "hashCode=" + hashCode +
+                ", drawable=" + drawable +
+                '}';
     }
 }
 

--- a/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
@@ -357,6 +357,9 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
     }
 
     public void setActualCoordinates(@NonNull final Geopoint coords) {
+        if (Geopoint.areCloseToEachOther(this.coords, coords)) {
+            return;
+        }
         this.coords = coords;
         checkUpdateGlobalGPS(false);
 

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -73,6 +73,8 @@ import androidx.core.content.res.ResourcesCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.text.util.LinkifyCompat;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -927,4 +929,45 @@ public class ViewUtils {
             }
         });
     }
+
+    public static void debugDumpDrawable(final String  name, final Drawable drawable) {
+        if (drawable == null) {
+            return;
+        }
+
+        try {
+            final Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+            final Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
+            debugDumpBitmap(name, bitmap);
+        } catch (final Exception e) {
+            Log.e("DEBUG image dump (bitmap) failed for file " + name, e);
+        }
+    }
+
+    public static void debugDumpBitmap(final String  name, final Bitmap bitmap) {
+        if (bitmap == null) {
+            return;
+        }
+        try {
+            final File dir = CgeoApplication.getInstance().getExternalFilesDir("debug-dumpimages");
+            if (dir == null) {
+                return;
+            }
+            if (!dir.exists() && !dir.mkdirs()) {
+                Log.e("DEBUG image dump: could not create dir " + dir.getAbsolutePath());
+                return;
+            }
+            final File file = new File(dir, name + ".png");
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos);
+            }
+            Log.iForce("DEBUG image dump: wrote " + file.getAbsolutePath());
+        } catch (final Exception e) {
+            Log.e("DEBUG image dump failed for file " + name, e);
+        }
+    }
+
+
 }

--- a/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
+++ b/main/src/main/java/cgeo/geocaching/utils/CacheInfoBoxes.java
@@ -228,7 +228,7 @@ public class CacheInfoBoxes {
 
         final SpannableStringBuilder filtersBuilder = new SpannableStringBuilder();
 
-        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> matches = NamedFilter.getFiltersMatchingCache(cache, mode == Settings.NamedFilterDisplayMode.ACTIVE_ONLY);
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> matches = NamedFilter.getFiltersMatchingCache(cache, mode == Settings.NamedFilterDisplayMode.ACTIVE_ONLY, -1);
         final List<NamedFilter> activeFilters = matches.left;
         final List<NamedFilter> passiveFilters = matches.right;
         if (activeFilters.isEmpty() && passiveFilters.isEmpty()) {

--- a/main/src/main/java/cgeo/geocaching/utils/EmojiUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/EmojiUtils.java
@@ -3,7 +3,6 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.databinding.EmojiPickerDialogBinding;
-import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.extension.EmojiLRU;
 import cgeo.geocaching.ui.ImageParam;
@@ -94,7 +93,7 @@ public class EmojiUtils {
     public static final String GREEN_CHECK_BOXED = "✅";
     public static final String DOUBLE_RED_EXCLAMATION_MARK = "‼";
 
-    private static final SparseArray<CacheMarker> emojiCache = new SparseArray<>();
+    private static final SparseArray<BitmapDrawable> emojiCache = new SparseArray<>();
 
     private static final Map<Integer, EmojiPaint> EMOJI_PAINT_CACHE_PER_SIZE = new HashMap<>();
 
@@ -475,14 +474,15 @@ public class EmojiUtils {
     }
 
     /**
-     * builds a drawable the size of a marker with a given emoji string
+     * builds a drawable the size of a marker with a given emoji string.
+     * Warning: calling this method is not backed up by any caching.
      *
      * @param paint - paint data structure for Emojis
      * @param emoji emoji String to display
      * @return drawable bitmap with the emoji on it
      */
     @NonNull
-    private static BitmapDrawable getEmojiDrawableHelper(final EmojiPaint paint, final String emoji) {
+    private static BitmapDrawable createEmojiDrawable(final EmojiPaint paint, final String emoji) {
         final Bitmap bm = Bitmap.createBitmap(paint.bitmapDimensions.first, paint.bitmapDimensions.second, Bitmap.Config.ARGB_8888);
         final Canvas canvas = new Canvas(bm);
         final int singleCp = singleCodePoint(emoji);
@@ -498,7 +498,9 @@ public class EmojiUtils {
         lsLayout.draw(canvas);
         canvas.save();
         canvas.restore();
-        return new BitmapDrawable(paint.res, bm);
+        final BitmapDrawable bmd = new BitmapDrawable(paint.res, bm);
+        bmd.mutate();
+        return bmd;
     }
 
     public static String getFlagEmojiFromCountry(final String countryCode) {
@@ -529,12 +531,20 @@ public class EmojiUtils {
                 .toHashCode();
 
         synchronized (emojiCache) {
-            CacheMarker marker = emojiCache.get(hashcode);
+            BitmapDrawable marker = emojiCache.get(hashcode);
             if (marker == null) {
-                marker = new CacheMarker(hashcode, getEmojiDrawableHelper(paint, emoji));
+                marker = createEmojiDrawable(paint, emoji);
                 emojiCache.put(hashcode, marker);
             }
-            return (BitmapDrawable) marker.getDrawable();
+            // fix #18520: return a COPY of the drawable and make it mutable.
+            // --> this way bounds, alignment and other things can be set on drawable w/o affecting other places
+            if (marker.getConstantState() != null) {
+                marker = (BitmapDrawable) marker.getConstantState().newDrawable(CgeoApplication.getInstance().getResources()).mutate();
+            } else {
+                Log.w("EmojiUtils.getEmojiDrawable: marker.getConstantState() is null for emoji " + emoji);
+            }
+
+            return marker;
         }
     }
 
@@ -548,14 +558,6 @@ public class EmojiUtils {
     @NonNull
     public static BitmapDrawable getEmojiDrawable(final int wantedSize, final String emoji) {
         return getEmojiDrawable(paintForSize(wantedSize), emoji);
-    }
-
-    /**
-     * int-based bridge kept for built-in emoji constants (e.g. {@link #RED_FLAG}) used via {@code ImageParam.emoji(int)}
-     */
-    @NonNull
-    public static BitmapDrawable getEmojiDrawable(final int wantedSize, final int emoji) {
-        return getEmojiDrawable(wantedSize, new String(Character.toChars(emoji)));
     }
 
     private static EmojiPaint paintForSize(final int wantedSize) {
@@ -587,6 +589,17 @@ public class EmojiUtils {
             this.availableSize = availableSize;
             this.offsetTop = offsetTop;
             this.fontsize = fontsize;
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return "EmojiPaint{" +
+                    "bitmapDimensions=" + bitmapDimensions +
+                    ", availableSize=" + availableSize +
+                    ", offsetTop=" + offsetTop +
+                    ", fontsize=" + fontsize +
+                    '}';
         }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -48,14 +48,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public final class MapMarkerUtils {
 
+    public static final int FAILING_MARKER = -1834520755;
+    public static final int TRIGGERING_MARKER = -1890745585;
+    public static final AtomicInteger ID_GIVER = new AtomicInteger(1);
+
     private static final String CACHE_WAYPOINT_HIGHLIGHTER_BACKGROUND = "cacheWaypointHighlighterBackground";
     private static final String CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM = "cacheWaypointHighlighterGeoitem";
+
+    private static final int MAX_MARKERS = 2;
 
     private static final Map<Integer, String> list2marker = new TreeMap<>();
     private static Boolean listsRead = false;
@@ -132,10 +139,13 @@ public final class MapMarkerUtils {
                 .append(applyScaling)
                 .toHashCode();
 
+
         synchronized (overlaysCache) {
             CacheMarker marker = overlaysCache.get(hashcode);
+            final int id = ID_GIVER.addAndGet(1);
             if (marker == null) {
-                marker = new CacheMarker(hashcode, createCacheMarker(res, cache, cacheListType, assignedMarkers, applyScaling));
+                final Drawable dr = createCacheMarker(hashcode, id, res, cache, cacheListType, assignedMarkers, applyScaling);
+                marker = new CacheMarker(hashcode, id, dr);
                 overlaysCache.put(hashcode, marker);
             }
             return marker;
@@ -153,17 +163,19 @@ public final class MapMarkerUtils {
     @NonNull
     // method readability will not improve by splitting it up
     @SuppressWarnings("PMD.NPathComplexity")
-    private static LayerDrawable createCacheMarker(final Resources res, final Geocache cache, @Nullable final CacheListType cacheListType, final ArrayList<String> assignedMarkers, final boolean applyScaling) {
+    private static LayerDrawable createCacheMarker(final int hash, final int id, final Resources res, final Geocache cache, @Nullable final CacheListType cacheListType, final ArrayList<String> assignedMarkers, final boolean applyScaling) {
         final String useEmoji = cache.getAssignedEmoji();
 
         // marker shape
         final Drawable marker = new ScalableDrawable(ResourcesCompat.getDrawable(res, cache.getMapMarkerId(), null), getCacheScalingFactor(applyScaling));
         final InsetsBuilder insetsBuilder = new InsetsBuilder(res, true);
+        //checkStep(hash,id,  "1");
         if (showPin(cacheListType)) {
             insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_pin, getCacheScalingFactor(applyScaling)));
         }
         insetsBuilder.withInset(new InsetBuilder(marker));
 
+        //checkStep(hash, id, "2");
         // marker foreground
         final int mainMarkerId = getMainMarkerId(cache, cacheListType);
 
@@ -185,6 +197,7 @@ public final class MapMarkerUtils {
             // main icon (type icon / custom cache icon)
             insetsBuilder.withInset(new InsetBuilder(mainMarkerId, Gravity.CENTER, getCacheScalingFactor(applyScaling)));
         }
+        //checkStep(hash, id, "3");
 
         // overlays
         // center: archived
@@ -227,10 +240,12 @@ public final class MapMarkerUtils {
         if (cache.getPersonalNote() != null) {
             insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_personalnote, Gravity.BOTTOM | Gravity.LEFT, getCacheScalingFactor(applyScaling)));
         }
-        // center-left/center-right: list markers
-        addListMarkers(res, insetsBuilder, assignedMarkers, true, applyScaling);
+        //checkStep(hash, id, "4");
 
-        return buildLayerDrawable(insetsBuilder, 12, 13);
+        // center-left/center-right: list markers
+        addListMarkers(hash, id, res, insetsBuilder, assignedMarkers, true, applyScaling);
+
+        return buildLayerDrawable(hash, id, insetsBuilder, 12, 13);
     }
 
     /**
@@ -333,7 +348,7 @@ public final class MapMarkerUtils {
             } else if (forMap) {
                 insetsBuilder.withInset(new InsetBuilder(getTypeMarker(res, cache, true, applyScaling, false), Gravity.TOP | Gravity.LEFT));
             }
-            addListMarkers(res, insetsBuilder, getAssignedMarkers(cache), false, applyScaling);
+            addListMarkers(0, 0, res, insetsBuilder, getAssignedMarkers(cache), false, applyScaling);
         }
         final LayerDrawable ld = buildLayerDrawable(insetsBuilder, 8, 8);
         if ((waypoint.isVisited() || (cache != null && cache.isFound())) && Settings.getVisitedWaypointsSemiTransparent()) {
@@ -567,10 +582,14 @@ public final class MapMarkerUtils {
     }
 
     private static LayerDrawable buildLayerDrawable(final InsetsBuilder insetsBuilder, final int layersInitialCapacity, final int insetsInitialCapacity) {
+        return buildLayerDrawable(0, 0, insetsBuilder, layersInitialCapacity, insetsInitialCapacity);
+    }
+
+    private static LayerDrawable buildLayerDrawable(final int hash, final int id, final InsetsBuilder insetsBuilder, final int layersInitialCapacity, final int insetsInitialCapacity) {
+
         // Set initial capacities to the maximum of layers and insets to avoid dynamic reallocation
         final List<Drawable> layers = new ArrayList<>(layersInitialCapacity);
         final List<int[]> insets = new ArrayList<>(insetsInitialCapacity);
-
         insetsBuilder.build(layers, insets);
         final LayerDrawable ld = new LayerDrawable(layers.toArray(new Drawable[0]));
 
@@ -632,7 +651,7 @@ public final class MapMarkerUtils {
     /**
      * adds list markers to drawable given by insetsBuilder
      */
-    private static void addListMarkers(final Resources res, final InsetsBuilder insetsBuilder, final ArrayList<String> assignedMarkers, final boolean forCaches, final boolean applyScaling) {
+    private static void addListMarkers(final int hash, final int id, final Resources res, final InsetsBuilder insetsBuilder, final ArrayList<String> assignedMarkers, final boolean forCaches, final boolean applyScaling) {
         if (!assignedMarkers.isEmpty()) {
             insetsBuilder.withInset(new InsetBuilder(getScaledEmojiDrawable(res, assignedMarkers.get(0), forCaches ? "listMarkerForCache" : "listMarkerForWaypoint", applyScaling), Gravity.CENTER_VERTICAL | Gravity.LEFT));
             if (assignedMarkers.size() > 1) {
@@ -681,19 +700,27 @@ public final class MapMarkerUtils {
     private static ArrayList<String> getAssignedMarkers(final Geocache cache) {
         final ArrayList<String> result = new ArrayList<>();
 
+        //filter markers
         if (Settings.isConditionalCacheMarkersEnabled()) {
-            // Named filter markers are prepended so they appear first
-            result.addAll(NamedFilter.getMarkersForCache(cache));
+            result.addAll(NamedFilter.getMarkersForCache(cache, MAX_MARKERS));
+            if (result.size() >= MAX_MARKERS) {
+                return result;
+            }
         }
 
+        //list markers
         readLists();
         final Set<Integer> lists = cache.getLists();
         for (final Integer list : lists) {
             final String markerId = list2marker.get(list);
             if (markerId != null) {
                 result.add(markerId);
+                if (result.size() >= MAX_MARKERS) {
+                    break;
+                }
             }
         }
+
         return result;
     }
 
@@ -929,5 +956,4 @@ public final class MapMarkerUtils {
         nonClickableItemsLayer.remove(CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM);
         nonClickableItemsLayer.remove(CACHE_WAYPOINT_HIGHLIGHTER_BACKGROUND);
     }
-
 }

--- a/main/src/test/java/cgeo/geocaching/filters/NamedFilterTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/NamedFilterTest.java
@@ -176,7 +176,7 @@ public class NamedFilterTest {
 
         NamedFilter.storeAll(Arrays.asList(activeNf, passiveNf));
 
-        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false);
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false, 0);
         assertThat(result.getLeft()).containsExactly(activeNf);
         assertThat(result.getRight()).containsExactly(passiveNf);
     }
@@ -192,7 +192,7 @@ public class NamedFilterTest {
         NamedFilter.storeAll(Collections.singletonList(
                 new NamedFilter("NoMatch", gf, EMOJI_SMILEY, true, 0).setId(1)));
 
-        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false);
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false, 0);
         assertThat(result.getLeft()).isEmpty();
         assertThat(result.getRight()).isEmpty();
     }
@@ -206,7 +206,7 @@ public class NamedFilterTest {
         final NamedFilter passiveNf = new NamedFilter("AllPassive", null, EMOJI_HEART, false, 0).setId(2);
         NamedFilter.storeAll(Arrays.asList(activeNf, passiveNf));
 
-        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false);
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false, 0);
         assertThat(result.getLeft()).containsExactly(activeNf);
         assertThat(result.getRight()).containsExactly(passiveNf);
     }
@@ -214,10 +214,90 @@ public class NamedFilterTest {
     @Test
     public void testGetFiltersMatchingCacheNullCacheReturnsEmptyPair() {
         NamedFilter.addOrReplace("Test", null, EmojiUtils.NO_EMOJI);
-        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(null, false);
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(null, false, 0);
         assertThat(result.getLeft()).isEmpty();
         assertThat(result.getRight()).isEmpty();
     }
+
+    @Test
+    public void testGetFiltersMatchingCacheMaxResultsLimitsCombinedCount() {
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.TRADITIONAL);
+
+        final TypeGeocacheFilter tf = new TypeGeocacheFilter();
+        tf.setValues(Collections.singletonList(CacheType.TRADITIONAL));
+        final GeocacheFilter gf = GeocacheFilter.create(false, false, tf);
+
+        // all same priority -> sorted alphabetically: A1, A2 (active), P1, P2 (passive)
+        final NamedFilter a1 = new NamedFilter("A1", gf, EMOJI_SMILEY, true, 0).setId(1);
+        final NamedFilter a2 = new NamedFilter("A2", gf, EMOJI_SMILEY, true, 0).setId(2);
+        final NamedFilter p1 = new NamedFilter("P1", gf, EMOJI_HEART, false, 0).setId(3);
+        final NamedFilter p2 = new NamedFilter("P2", gf, EMOJI_HEART, false, 0).setId(4);
+        NamedFilter.storeAll(Arrays.asList(a1, a2, p1, p2));
+
+        // maxResults counts across active+passive combined, in priority/name order
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false, 3);
+        assertThat(result.getLeft()).containsExactly(a1, a2);
+        assertThat(result.getRight()).containsExactly(p1);
+    }
+
+    @Test
+    public void testGetFiltersMatchingCacheMaxResultsZeroMeansUnlimited() {
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.TRADITIONAL);
+
+        final TypeGeocacheFilter tf = new TypeGeocacheFilter();
+        tf.setValues(Collections.singletonList(CacheType.TRADITIONAL));
+        final GeocacheFilter gf = GeocacheFilter.create(false, false, tf);
+
+        final NamedFilter a1 = new NamedFilter("A1", gf, EMOJI_SMILEY, true, 0).setId(1);
+        final NamedFilter p1 = new NamedFilter("P1", gf, EMOJI_HEART, false, 0).setId(2);
+        NamedFilter.storeAll(Arrays.asList(a1, p1));
+
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false, 0);
+        assertThat(result.getLeft()).containsExactly(a1);
+        assertThat(result.getRight()).containsExactly(p1);
+    }
+
+    @Test
+    public void testGetFiltersMatchingCacheMaxResultsNegativeMeansUnlimited() {
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.TRADITIONAL);
+
+        final TypeGeocacheFilter tf = new TypeGeocacheFilter();
+        tf.setValues(Collections.singletonList(CacheType.TRADITIONAL));
+        final GeocacheFilter gf = GeocacheFilter.create(false, false, tf);
+
+        final NamedFilter a1 = new NamedFilter("A1", gf, EMOJI_SMILEY, true, 0).setId(1);
+        final NamedFilter p1 = new NamedFilter("P1", gf, EMOJI_HEART, false, 0).setId(2);
+        NamedFilter.storeAll(Arrays.asList(a1, p1));
+
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false, -1);
+        assertThat(result.getLeft()).containsExactly(a1);
+        assertThat(result.getRight()).containsExactly(p1);
+    }
+
+    @Test
+    public void testGetFiltersMatchingCacheMaxResultsWithOnlyActive() {
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.TRADITIONAL);
+
+        final TypeGeocacheFilter tf = new TypeGeocacheFilter();
+        tf.setValues(Collections.singletonList(CacheType.TRADITIONAL));
+        final GeocacheFilter gf = GeocacheFilter.create(false, false, tf);
+
+        final NamedFilter a1 = new NamedFilter("A1", gf, EMOJI_SMILEY, true, 0).setId(1);
+        final NamedFilter a2 = new NamedFilter("A2", gf, EMOJI_SMILEY, true, 0).setId(2);
+        final NamedFilter a3 = new NamedFilter("A3", gf, EMOJI_SMILEY, true, 0).setId(3);
+        final NamedFilter p1 = new NamedFilter("P1", gf, EMOJI_HEART, false, 0).setId(4);
+        NamedFilter.storeAll(Arrays.asList(a1, a2, a3, p1));
+
+        // onlyActive=true skips passive filters entirely, so maxResults only limits the active ones
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, true, 2);
+        assertThat(result.getLeft()).containsExactly(a1, a2);
+        assertThat(result.getRight()).isEmpty();
+    }
+
 
     @Test
     public void testGetMarkersForCacheUsesActiveFromPair() {
@@ -232,8 +312,43 @@ public class NamedFilterTest {
         final NamedFilter passiveNf = new NamedFilter("P", gf, EMOJI_HEART, false, 0).setId(2);
         NamedFilter.storeAll(Arrays.asList(activeNf, passiveNf));
 
-        final List<String> markers = NamedFilter.getMarkersForCache(cache);
+        final List<String> markers = NamedFilter.getMarkersForCache(cache, 0);
         assertThat(markers).containsExactly(EMOJI_SMILEY);
+    }
+
+    @Test
+    public void testGetMarkersForCacheMaxResultsLimitsMarkers() {
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.TRADITIONAL);
+
+        final TypeGeocacheFilter tf = new TypeGeocacheFilter();
+        tf.setValues(Collections.singletonList(CacheType.TRADITIONAL));
+        final GeocacheFilter gf = GeocacheFilter.create(false, false, tf);
+
+        final NamedFilter a1 = new NamedFilter("A1", gf, EMOJI_SMILEY, true, 0).setId(1);
+        final NamedFilter a2 = new NamedFilter("A2", gf, EMOJI_HEART, true, 0).setId(2);
+        final NamedFilter a3 = new NamedFilter("A3", gf, EMOJI_SMILEY, true, 0).setId(3);
+        NamedFilter.storeAll(Arrays.asList(a1, a2, a3));
+
+        final List<String> markers = NamedFilter.getMarkersForCache(cache, 2);
+        assertThat(markers).containsExactly(EMOJI_SMILEY, EMOJI_HEART);
+    }
+
+    @Test
+    public void testGetMarkersForCacheMaxResultsZeroReturnsAll() {
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.TRADITIONAL);
+
+        final TypeGeocacheFilter tf = new TypeGeocacheFilter();
+        tf.setValues(Collections.singletonList(CacheType.TRADITIONAL));
+        final GeocacheFilter gf = GeocacheFilter.create(false, false, tf);
+
+        final NamedFilter a1 = new NamedFilter("A1", gf, EMOJI_SMILEY, true, 0).setId(1);
+        final NamedFilter a2 = new NamedFilter("A2", gf, EMOJI_HEART, true, 0).setId(2);
+        NamedFilter.storeAll(Arrays.asList(a1, a2));
+
+        final List<String> markers = NamedFilter.getMarkersForCache(cache, 0);
+        assertThat(markers).containsExactly(EMOJI_SMILEY, EMOJI_HEART);
     }
 
     @Test
@@ -276,7 +391,7 @@ public class NamedFilterTest {
 
         // This should not throw or hang
         final Geocache cache = new Geocache();
-        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false);
+        final ImmutablePair<List<NamedFilter>, List<NamedFilter>> result = NamedFilter.getFiltersMatchingCache(cache, false, 0);
         // No specific assertion about result content — just verify no infinite loop
         assertThat(result).isNotNull();
     }

--- a/main/src/test/java/cgeo/geocaching/location/GeopointTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeopointTest.java
@@ -62,6 +62,30 @@ public class GeopointTest {
     }
 
     @Test
+    public void testIsCloseTo() {
+        final Geopoint gp1 = new Geopoint(48.2, 2.31);
+
+        // identical point
+        assertThat(gp1.isCloseTo(gp1)).isTrue();
+        assertThat(gp1.isCloseTo(new Geopoint(48.2, 2.31))).isTrue();
+
+        // null is never close
+        assertThat(gp1.isCloseTo(null)).isFalse();
+
+        // a tiny offset (a few E6 units, well below 1m) should be considered close
+        final Geopoint gpNear = Geopoint.forE6(gp1.getLatitudeE6() + 3, gp1.getLongitudeE6() + 3);
+        assertThat(gp1.isCloseTo(gpNear)).isTrue();
+
+        // a clearly bigger offset (tens of meters) should not be considered close
+        final Geopoint gpFar = Geopoint.forE6(gp1.getLatitudeE6() + 1000, gp1.getLongitudeE6() + 1000);
+        assertThat(gp1.isCloseTo(gpFar)).isFalse();
+
+        // custom tolerance
+        assertThat(gp1.isCloseTo(gpFar, 200.0)).isTrue();
+        assertThat(gp1.isCloseTo(gpFar, 1.0)).isFalse();
+    }
+
+    @Test
     public void testEqualsFormatted() {
         final Geopoint gp1 = new Geopoint(48.559984, 2.713871);
         final Geopoint gp2 = new Geopoint(48.559981, 2.713873);


### PR DESCRIPTION
rel to #18520: dont refresh cachelist when coordinates are not changing

while investigating #18520 on an emulator with nonchanging GPS coordinate, I noticed that the cache list is regularly refreshed (and markers for all caches are re-requested from mapmarkerutils, thus I presume they are also redrawn). This is caused by regular location update checks. This PR introduces a check so the cache list is not redrawn when location has not changed (or changed insignificantly, meaning less than 1m, conservatively calculated)