### PR TITLE
Release the infosheet's views when the sheet is removed (rel. to #18404)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -222,6 +222,19 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
         clearSheetInfo();
         final FragmentManager fm = getSupportFragmentManager();
         final Fragment f1 = fm.findFragmentByTag(TAG_MAPDETAILS_FRAGMENT);
+        // Drop the layout listener of the sheet being removed. It is held in a field of this
+        // activity and closes over the sheet's view, so without this the view stays reachable
+        // until the next sheet installs a new listener. Unregistering has to happen while the
+        // view is still attached, as a detached view hands out a different ViewTreeObserver.
+        synchronized (layoutListeners) {
+            if (layoutListeners[0] != null) {
+                final View listenerView = f1 == null ? null : f1.getView();
+                if (listenerView != null) {
+                    listenerView.getViewTreeObserver().removeOnGlobalLayoutListener(layoutListeners[0]);
+                }
+                layoutListeners[0] = null;
+            }
+        }
         if (f1 != null) {
             try {
                 fm.beginTransaction().remove(f1).commitNowAllowingStateLoss();

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -259,6 +259,13 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
                 b.setState(BottomSheetBehavior.STATE_HIDDEN); // close correctly as it will otherwise conflict with up-swipe behaviour implementation
             }
 
+            // The framework keeps the match_parent children of a FrameLayout in a list that is
+            // only rebuilt while measuring. Hiding the container stops it from ever measuring
+            // again, so the view of the sheet just removed would stay referenced from there
+            // until another sheet is opened. Measuring once while it is empty drops it.
+            v.measure(View.MeasureSpec.makeMeasureSpec(v.getWidth(), View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(v.getHeight(), View.MeasureSpec.EXACTLY));
+
             v.setVisibility(View.GONE);
             return true;
         }


### PR DESCRIPTION
## Description

Fixes two memory leaks around the cache/waypoint infosheet on the map. LeakCanary reports
both whenever a sheet is opened and closed again.

**1. The sheet's layout listener is never released.**
`AbstractNavigationBarMapActivity` keeps the `OnGlobalLayoutListener` in a field and only
replaces it when the next sheet opens. The listener closes over the sheet's view, so once a
sheet is closed that view stays reachable from the activity until another sheet takes its
place. Reported as `UnifiedMapActivity.layoutListeners`.

Fixed by clearing the field in `sheetRemoveFragment()`, which every path that takes the
sheet down already calls. The listener is also unregistered from the view while that view
is still attached - a detached view hands out a different `ViewTreeObserver`, so removing
it afterwards would silently do nothing. Clearing the field is what actually releases the
view; the unregister is hygiene.

**2. The removed view stays in the container's measure cache.**
`FrameLayout` keeps its `match_parent` children in `mMatchParentChildren`, a list it only
rebuilds while measuring. `sheetRemoveFragment()` hides the container right after removing
the fragments, and a `GONE` view is never measured again, so the view of the sheet just
removed stays referenced there until another sheet is opened. Reported as
`FrameLayout.mMatchParentChildren`, holding the `SwipeToOpenFragment` view.

Fixed by measuring the container once while it is empty, before hiding it. That runs
`onMeasure`, which clears the list, and there are no children left to put back.

Both are bounded - one stale view at a time, released as soon as the next sheet opens - but
they are retained for as long as the map stays open without another sheet being shown.

## Related issues

- rel. to #18404 (*Out of memory errors on map*). Not a fix for it, but the same area and
  the same kind of retention as #18443 and #18446.

## Additional context

The listener field was introduced in 9829a2a8f (2023-12-25, *"Remove old layout listener
before setting new one"*); the remove-on-replace behaviour has been there since, without a
remove-on-teardown counterpart. The surrounding code was last reworked in 767d74ec2
(2026-06-27). The file is identical on `release` and `master`.

Targeted at `release`, matching where #18443 and #18446 went.

No `onDestroy` teardown was added: every path that takes the sheet down already goes
through `sheetRemoveFragment()`, and once the activity dies the field is unreachable
anyway, so it would be code without an effect.

**Testing**: built and run on a Pixel (Android 17, API 37) with LeakCanary, by opening a
cache's infosheet from the map and closing it again. Checkstyle, lint and the unit test
suite pass locally.

**AI assistance**: this contribution was written with AI assistance (Claude Opus 5). I have
reviewed and tested everything submitted here.