### PR TITLE
Detach VTM tile layers on map source change (rel. to #18404)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -234,6 +234,10 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
                 } catch (IndexOutOfBoundsException ignore) {
                     // ignored
                 }
+                if (layer instanceof TileLayer) {
+                    // dispose the loader threads, they keep a back reference to the layer
+                    ((TileLayer) layer).onDetach();
+                }
             }
             layers.clear();
         }


### PR DESCRIPTION
## Description

Fixes a memory leak when the map source is changed on the VTM map.

`MapsforgeVtmFragment.prepareForTileSourceChange()` removes the layers of the current map
source from the layer list and disables them, but never calls `TileLayer.onDetach()`. The
tile loader threads of those layers keep running and hold a reference back to the layer,
which keeps the VTM map, its `MapView` and the fragment's view alive. LeakCanary reports it
along this path:

```
GC Root: Thread object
  -> BitmapTileLoader.mLayer          (thread 'TileLoader8')
  -> BitmapTileLayer -> Layer.mMap
  -> MapView$AndroidMap -> MapView -> View.mParent
  -> RelativeLayout (R.id.unifiedmap_vtm)
     Leaking: YES (MapsforgeVtmFragment received Fragment#onDestroyView())
```

Calling `onDetach()` on the layers that are tile layers, as they are removed, disposes
those loaders.

This is not limited to switching between map sources by hand - every toggle that goes
through `changeMapSource()` rebuilds the layers, so hillshading and the mbtiles background
maps hit it too.

## Related issues

- rel. to #18404 (*Out of memory errors on map*). Not a fix for it, but the same area and
  the same kind of retention as #18443 and #18446.

## Additional context

Targeted at `release`, matching where #18443 and #18446 went. The file is identical on
`release` and `master`.

Found with LeakCanary while working on an unrelated map feature: toggling anything that
rebuilds the map source reproduced it every time.

**Testing**: built and run on a Pixel (Android 17, API 37) with LeakCanary, switching
between map sources and toggling map layers repeatedly. Checkstyle, lint and the unit test
suite pass locally.

**AI assistance**: this contribution was written with AI assistance (Claude Opus 5). I have
reviewed and tested everything submitted here.