### PR TITLE
rel #18138: fix wrong log-type

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -436,7 +436,14 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     }
 
     public void setType(final LogType type) {
-        logType.set(type);
+        final List<LogType> availableLogTypes = logType.getValues();
+        if (availableLogTypes.contains(type)) {
+            logType.set(type);
+        } else if (availableLogTypes.contains(LogType.NOTE)) {
+            logType.set(LogType.NOTE);
+        } else {
+            logType.set(availableLogTypes.get(0));
+        }
         refreshGui();
     }
 
@@ -710,6 +717,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     }
 
     private void setLogTypeValues(final Collection<LogType> logTypes) {
+        final LogType currentLogType = logType.get();
         if (this.originalLogEntry != null && !logTypes.contains(this.originalLogEntry.logType)) {
             //log type of original entry must ALWAYS be available for selection
             final List<LogType> rLogTypes = new ArrayList<>();
@@ -719,6 +727,10 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
         } else {
             this.logType.setValues(logTypes);
         }
+
+        // keep current log type if still available,
+        // otherwise set to NOTE or first available log type
+        setType(currentLogType);
     }
 
     @Override


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
On updateing available log-types, keep current log type if still available, 
otherwise set to NOTE or first available log type


## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #18138

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
The fix does not deal with the fact, that two logs are send to the service, but maybe because of the different log-type a second log was send, which in a found case the server would have rejected...