### PR TITLE
rel to #8928: add edit personal note button to waypoint popup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/WaypointPopupFragment.java
@@ -151,6 +151,11 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
 
             binding.edit.setOnClickListener(arg0 -> EditWaypointActivity.startActivityEditWaypoint(getActivity(), cache, waypoint.getId()));
 
+            binding.editPersonalnote.setOnClickListener(arg0 -> {
+                CacheDetailActivity.startActivityForEditNote(getActivity(), geocode);
+                ((AbstractNavigationBarMapActivity) requireActivity()).sheetRemoveFragment();
+            });
+
             binding.moreDetails.setOnClickListener(arg0 -> {
                 CacheDetailActivity.startActivity(getActivity(), geocode);
                 ((AbstractNavigationBarMapActivity) requireActivity()).sheetRemoveFragment();

--- a/main/src/main/res/layout/waypoint_popup.xml
+++ b/main/src/main/res/layout/waypoint_popup.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
@@ -64,8 +65,14 @@
                 <Button
                     android:id="@+id/edit"
                     style="@style/button_small_popups"
-                    android:layout_alignParentRight="true"
+                    android:layout_toLeftOf="@id/edit_personalnote"
                     android:text="@string/waypoint_edit" />
+                <Button
+                    android:id="@+id/edit_personalnote"
+                    style="@style/button_icon"
+                    android:layout_alignParentRight="true"
+                    android:tooltipText="@string/cache_personal_note_edit_pn"
+                    app:icon="@drawable/ic_menu_note_edit" />
 
             </RelativeLayout>
 


### PR DESCRIPTION
Closes #8928

## What
Adds an "Edit personal note" button to the **waypoint popup**, mirroring the
existing button in the cache popup. Implements the entry point proposed by
moving-bits (reuse the existing note button, not a hidden three-dot item).

## How
- `waypoint_popup.xml`: add the `edit_personalnote` icon button (same icon and
  tooltip as the cache popup) next to the existing "Edit waypoint" button.
- `WaypointPopupFragment`: wire it to
  `CacheDetailActivity.startActivityForEditNote(getActivity(), geocode)` for the
  parent cache and close the sheet. Delegating to the detail activity also loads
  the full cache first, covering the earlier "ensure cache is fully loaded" note.

No layout change to the cache popup; no new strings (reuses
`cache_personal_note_edit_pn`).

## Tests
- Gates green locally: `assembleBasicDebug`, `testBasicDebug`, `checkstyle`.
- Manual GUI verification on emulator (API 35): waypoint popup shows the new
  button → tapping it opens the parent cache's personal-note editor.
  (screenshots below)

## Notes
Implemented with AI assistance and reviewed by me.

## Documentation
User-visible: new "edit personal note" button in the waypoint popup.
Optional one-line update to the map/popup page on manual.cgeo.org after release
(English page only). No changelog entry from my side.

<table><tr>
<td><img width="270" alt="map" src="https://github.com/user-attachments/assets/2cc440da-4f9c-461c-a5db-d0a5b502131e" /></td>
<td><img width="270" alt="popup" src="https://github.com/user-attachments/assets/a15421ee-4852-4149-adc9-30e8db0a2759" /></td>
<td><img width="270" alt="note-editor" src="https://github.com/user-attachments/assets/b91c53a5-83d9-4933-a250-af86306f5401" /></td>
</tr></table>