### PR TITLE
fix #16206: diacritic-insensitive top search bar

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -512,6 +512,8 @@ public class MainActivity extends AbstractNavigationBarActivity {
             cLog.add("perm");
 
             init();
+
+            DataStore.migrateNormalizedColumnsIfNeeded(this);
         }
 
         if (Log.isEnabled(Log.LogLevel.DEBUG)) {

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.DBInspectionActivity;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.internal.InternalConnector;
@@ -91,6 +92,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteStatement;
 import android.location.Location;
 import android.net.Uri;
+import android.os.PowerManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -269,7 +271,7 @@ public class DataStore {
     private static final CacheCache cacheCache = new CacheCache();
     private static volatile SQLiteDatabase database = null;
     private static final ReentrantReadWriteLock databaseLock = new ReentrantReadWriteLock();
-    private static final int dbVersion = 111;
+    private static final int dbVersion = 112;
     public static final int customListIdOffset = 10;
 
     /**
@@ -316,7 +318,8 @@ public class DataStore {
             108, // add health_score column to cg_caches
             109,  // add favorite column to cg_logs
             110,  // migrate markers/emojis datatype from int to string
-            111  // correct a problem in name filter migration: reference by id instead of name
+            111, // correct a problem in name filter migration: reference by id instead of name
+            112  // add diacritic-normalized shadow columns to cg_caches/cg_trackables (nullable, re-runnable)
             ));
 
     @NonNull private static final String dbTableCaches = "cg_caches";
@@ -332,6 +335,9 @@ public class DataStore {
     @NonNull public static final String dbFieldCaches_inventoryunknown = "inventoryunknown";
     @NonNull public static final String dbFieldCaches_onWatchList = "onWatchList";
     @NonNull public static final String dbFieldCaches_coordsChanged = "coordsChanged";
+    @NonNull public static final String dbFieldCaches_nameNormalized = "name_normalized";
+    @NonNull public static final String dbFieldCaches_ownerNormalized = "owner_normalized";
+    @NonNull public static final String dbFieldTrackables_titleNormalized = "title_normalized";
     @NonNull public static final String dbTableLists = "cg_lists";
     @NonNull public static final String dbTableCachesLists = "cg_caches_lists";
     @NonNull public static final String dbFieldCachesLists_list_id = "list_id";
@@ -431,7 +437,9 @@ public class DataStore {
             + "emojiString TEXT,"
             + "alcMode INTEGER DEFAULT 0,"
             + "tier TEXT,"
-            + "health_score INTEGER"
+            + "health_score INTEGER,"
+            + dbFieldCaches_nameNormalized + " TEXT,"
+            + dbFieldCaches_ownerNormalized + " TEXT"
             + "); ";
     private static final String dbCreateLists = "CREATE TABLE IF NOT EXISTS " + dbTableLists + " ("
             + "_id INTEGER PRIMARY KEY AUTOINCREMENT, "
@@ -576,7 +584,8 @@ public class DataStore {
             + "geocode TEXT, "
             + "log_date LONG, "
             + "log_type INTEGER, "
-            + "log_guid TEXT "
+            + "log_guid TEXT, "
+            + dbFieldTrackables_titleNormalized + " TEXT "
             + "); ";
 
     private static final String dbCreateSearchDestinationHistory = "CREATE TABLE IF NOT EXISTS " + dbTableSearchDestinationHistory + " ("
@@ -2069,6 +2078,17 @@ public class DataStore {
                         }
                     }
 
+                    // add diacritic-normalized shadow columns for the search bar (#16206); filled lazily by a background task
+                    if (oldVersion < 112) {
+                        try {
+                            createColumnIfNotExists(db, dbTableCaches, dbFieldCaches_nameNormalized + " TEXT");
+                            createColumnIfNotExists(db, dbTableCaches, dbFieldCaches_ownerNormalized + " TEXT");
+                            createColumnIfNotExists(db, dbTableTrackables, dbFieldTrackables_titleNormalized + " TEXT");
+                        } catch (final SQLException e) {
+                            onUpgradeError(e, 112);
+                        }
+                    }
+
                 }
 
                 //at the very end of onUpgrade: rewrite downgradeable versions in database
@@ -2714,7 +2734,8 @@ public class DataStore {
             values.put("type", cache.getType().id);
             values.put("name", cache.getName());
             values.put("owner", cache.getOwnerDisplayName());
-            values.put("owner_real", cache.getOwnerUserId());
+            values.put(dbFieldCaches_nameNormalized, TextUtils.foldDiacritics(cache.getName()));
+            values.put(dbFieldCaches_ownerNormalized, TextUtils.foldDiacritics(cache.getOwnerDisplayName()));            values.put("owner_real", cache.getOwnerUserId());
             final Date hiddenDate = cache.getHiddenDate();
             if (hiddenDate == null) {
                 values.put("hidden", 0);
@@ -3197,6 +3218,7 @@ public class DataStore {
                 values.put("tbcode", tbCode);
                 values.put("guid", trackable.getGuid());
                 values.put("title", trackable.getName());
+                values.put(dbFieldTrackables_titleNormalized, TextUtils.foldDiacritics(trackable.getName()));
                 values.put("owner", trackable.getOwner());
                 final Date releasedDate = trackable.getReleased();
                 if (releasedDate != null) {
@@ -4643,6 +4665,123 @@ public class DataStore {
         });
     }
 
+    private static volatile boolean diacriticsMigrationChecked = false;
+
+    private static final int NORMALIZE_MIGRATION_CHUNK_SIZE = 2000;
+    private static final long NORMALIZE_MIGRATION_MIN_DELAY_MS = 20L;
+    private static final long NORMALIZE_MIGRATION_MAX_DELAY_MS = 500L;
+    private static final double NORMALIZE_MIGRATION_DUTY_CYCLE = 0.33;
+
+    /**
+     * Lazily fills the diacritic-normalized shadow columns (#16206) for rows carried over from an older
+     * database version. Runs once per process, in the background, in throttled chunks, and shows a toast
+     * once it has actually migrated something.
+     */
+    public static void migrateNormalizedColumnsIfNeeded(final Context context) {
+        final Context appContext = context.getApplicationContext();
+        withAccessLock(() -> {
+            if (diacriticsMigrationChecked) {
+                return;
+            }
+            diacriticsMigrationChecked = true;
+            Schedulers.io().scheduleDirect(() -> runNormalizedColumnsMigration(appContext));
+        });
+    }
+
+    private static void runNormalizedColumnsMigration(final Context context) {
+        try {
+            boolean migratedAny = false;
+            migratedAny |= migrateNormalizedTable(context, dbTableCaches, "geocode",
+                    new String[]{"name", "owner"}, new String[]{dbFieldCaches_nameNormalized, dbFieldCaches_ownerNormalized});
+            migratedAny |= migrateNormalizedTable(context, dbTableTrackables, "tbcode",
+                    new String[]{"title"}, new String[]{dbFieldTrackables_titleNormalized});
+            if (migratedAny) {
+                Log.iForce("[DB] search-index normalization migration finished");
+                ActivityMixin.showApplicationToast(LocalizationUtils.getString(R.string.search_index_updated));
+            }
+        } catch (final Exception e) {
+            Log.w("DataStore.runNormalizedColumnsMigration", e);
+        }
+    }
+
+    private static boolean migrateNormalizedTable(final Context context, final String table, final String idColumn,
+                                                  final String[] sourceColumns, final String[] targetColumns) {
+        boolean migratedAny = false;
+        final String[] queryColumns = new String[sourceColumns.length + 1];
+        queryColumns[0] = idColumn;
+        System.arraycopy(sourceColumns, 0, queryColumns, 1, sourceColumns.length);
+        final String selection = targetColumns[0] + " IS NULL";
+
+        final StringBuilder setClause = new StringBuilder();
+        for (int i = 0; i < targetColumns.length; i++) {
+            setClause.append(i == 0 ? "" : ", ").append(targetColumns[i]).append(" = ?");
+        }
+        final String updateSql = "UPDATE " + table + " SET " + setClause + " WHERE " + idColumn + " = ?";
+
+        while (true) {
+            final long start = System.currentTimeMillis();
+
+            // read the raw chunk (short read lock), then fold OUTSIDE any lock
+            final List<String[]> foldedRows = new ArrayList<>();
+            final Cursor cursor = database.query(table, queryColumns, selection, null, null, null, null,
+                    String.valueOf(NORMALIZE_MIGRATION_CHUNK_SIZE));
+            try {
+                while (cursor.moveToNext()) {
+                    final String[] row = new String[targetColumns.length + 1];
+                    for (int i = 0; i < sourceColumns.length; i++) {
+                        row[i] = TextUtils.foldDiacritics(cursor.getString(i + 1));
+                    }
+                    row[targetColumns.length] = cursor.getString(0);
+                    foldedRows.add(row);
+                }
+            } finally {
+                cursor.close();
+            }
+            if (foldedRows.isEmpty()) {
+                break;
+            }
+
+            // write the whole chunk in one transaction with a single reused compiled statement (minimal write-lock hold)
+            final SQLiteStatement statement = database.compileStatement(updateSql);
+            database.beginTransaction();
+            try {
+                for (final String[] row : foldedRows) {
+                    statement.clearBindings();
+                    for (int i = 0; i < row.length; i++) {
+                        if (row[i] == null) {
+                            statement.bindNull(i + 1);
+                        } else {
+                            statement.bindString(i + 1, row[i]);
+                        }
+                    }
+                    statement.executeUpdateDelete();
+                }
+                database.setTransactionSuccessful();
+            } finally {
+                database.endTransaction();
+                statement.close();
+            }
+            migratedAny = true;
+
+            sleepBetweenMigrationChunks(context, System.currentTimeMillis() - start);
+        }
+        return migratedAny;
+    }
+
+    private static void sleepBetweenMigrationChunks(final Context context, final long chunkWorkMillis) {
+        long delay = Math.round(chunkWorkMillis * (1.0 / NORMALIZE_MIGRATION_DUTY_CYCLE - 1.0));
+        final PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+        if (pm != null && pm.isPowerSaveMode()) {
+            delay = NORMALIZE_MIGRATION_MAX_DELAY_MS;
+        }
+        delay = Math.max(NORMALIZE_MIGRATION_MIN_DELAY_MS, Math.min(NORMALIZE_MIGRATION_MAX_DELAY_MS, delay));
+        try {
+            Thread.sleep(delay);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     private static void deleteOrphanedRecords() {
         Log.d("Database clean: removing non-existing lists");
         database.delete(dbTableCachesLists, "list_id <> " + StoredList.STANDARD_LIST_ID + " AND list_id NOT IN (SELECT _id + " + customListIdOffset + " FROM " + dbTableLists + ")", null);
@@ -5718,8 +5857,9 @@ public class DataStore {
             final GeocacheSearchSuggestionCursor resultCursor = new GeocacheSearchSuggestionCursor();
             try {
                 final String selectionArg = getSuggestionArgument(searchTerm);
-                findCaches(resultCursor, selectionArg);
-                findTrackables(resultCursor, selectionArg);
+                final String normalizedArg = getSuggestionArgument(TextUtils.foldDiacritics(searchTerm));
+                findCaches(resultCursor, selectionArg, normalizedArg);
+                findTrackables(resultCursor, selectionArg, normalizedArg);
             } catch (final Exception e) {
                 Log.e("DataStore.loadBatchOfStoredGeocodes", e);
             }
@@ -5727,12 +5867,16 @@ public class DataStore {
         });
     }
 
-    private static void findCaches(final GeocacheSearchSuggestionCursor resultCursor, final String selectionArg) {
+    private static void findCaches(final GeocacheSearchSuggestionCursor resultCursor, final String selectionArg, final String normalizedArg) {
         final Cursor cursor = database.query(
                 dbTableCaches,
                 new String[]{"geocode", "name", "type"},
-                "geocode IS NOT NULL AND geocode != '' AND (geocode LIKE ? OR name LIKE ? OR owner LIKE ?)",
-                new String[]{selectionArg, selectionArg, selectionArg},
+                "geocode IS NOT NULL AND geocode != '' AND (geocode LIKE ?"
+                        + " OR " + dbFieldCaches_nameNormalized + " LIKE ? OR " + dbFieldCaches_ownerNormalized + " LIKE ?"
+                        // fall back to the raw columns for rows not yet processed by the background normalization migration
+                        + " OR (" + dbFieldCaches_nameNormalized + " IS NULL AND name LIKE ?)"
+                        + " OR (" + dbFieldCaches_ownerNormalized + " IS NULL AND owner LIKE ?))",
+                new String[]{selectionArg, normalizedArg, normalizedArg, selectionArg, selectionArg},
                 null,
                 null,
                 "name");
@@ -5750,12 +5894,15 @@ public class DataStore {
         return "%" + StringUtils.trim(input) + "%";
     }
 
-    private static void findTrackables(final MatrixCursor resultCursor, final String selectionArg) {
+    private static void findTrackables(final MatrixCursor resultCursor, final String selectionArg, final String normalizedArg) {
         final Cursor cursor = database.query(
                 dbTableTrackables,
                 new String[]{"tbcode", "title"},
-                "tbcode IS NOT NULL AND tbcode != '' AND (tbcode LIKE ? OR title LIKE ?)",
-                new String[]{selectionArg, selectionArg},
+                "tbcode IS NOT NULL AND tbcode != '' AND (tbcode LIKE ?"
+                        + " OR " + dbFieldTrackables_titleNormalized + " LIKE ?"
+                        // fall back to the raw column for rows not yet processed by the background normalization migration
+                        + " OR (" + dbFieldTrackables_titleNormalized + " IS NULL AND title LIKE ?))",
+                new String[]{selectionArg, normalizedArg, selectionArg},
                 null,
                 null,
                 "title");

--- a/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
@@ -21,6 +21,7 @@ import androidx.core.text.HtmlCompat;
 
 import java.nio.charset.StandardCharsets;
 import java.text.Collator;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,6 +54,8 @@ public final class TextUtils {
     private static final Pattern PATTERN_REMOVE_NONPRINTABLE = Pattern.compile("\\p{Cntrl}");
 
     private static final Pattern PATTERN_REMOVE_SPECIAL = Pattern.compile("[^a-z0-9]");
+
+    private static final Pattern PATTERN_COMBINING_MARKS = Pattern.compile("\\p{M}+");
 
     private static final Pattern PATTERN_CONTAINS_HTML = Pattern.compile(
             "<(/\\s*)?[a-zA-Z]+\\s*([a-zA-Z]+\\s*=\\s*['\"][^'\"]*['\"]\\s*)*(/\\s*)?>|&#?[a-zA-Z0-9]{1,10};");
@@ -536,6 +539,34 @@ public final class TextUtils {
             return null;
         }
         return PATTERN_REMOVE_SPECIAL.matcher(value.toLowerCase(Locale.US)).replaceAll("");
+    }
+
+    /**
+     * Folds a string to a lower-case, diacritic-insensitive form for search collation:
+     * atomic letters without canonical decomposition are mapped to their base letter(s),
+     * then combining marks (accents) are stripped after NFD decomposition.
+     * Example: {@code la duş} and {@code straße} become {@code la dus} and {@code strasse}.
+     */
+    @Nullable
+    public static String foldDiacritics(@Nullable final String value) {
+        if (value == null) {
+            return null;
+        }
+        final String mapped = value.toLowerCase(Locale.ROOT)
+                .replace("ß", "ss").replace("ø", "o").replace("æ", "ae").replace("œ", "oe")
+                .replace("ł", "l").replace("đ", "d").replace("ð", "d").replace("þ", "th")
+                .replace("ħ", "h").replace("ŧ", "t").replace("ŋ", "n").replace("ĸ", "k")
+                .replace("ſ", "s").replace("ı", "i");
+        final String decomposed = Normalizer.normalize(mapped, Normalizer.Form.NFD);
+        return PATTERN_COMBINING_MARKS.matcher(decomposed).replaceAll("");
+    }
+
+    /** {@code true} if the diacritic-folded {@code haystack} contains the diacritic-folded {@code needle}. */
+    public static boolean containsIgnoreCaseAndDiacritics(@Nullable final String haystack, @Nullable final String needle) {
+        if (haystack == null || needle == null) {
+            return false;
+        }
+        return StringUtils.contains(foldDiacritics(haystack), foldDiacritics(needle));
     }
 
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2211,6 +2211,7 @@
     <string name="geo_search_label">Search caches nearby</string>
     <string name="search_bar_hint">Search caches/trackables</string>
     <string name="search_bar_hint_settings">Search settings</string>
+    <string name="search_index_updated">Search database updated</string>
     <string name="search_coordinates">Coordinates</string>
     <string name="search_address">Address</string>
     <string name="search_geo">Geocode</string>

--- a/main/src/test/java/cgeo/geocaching/utils/TextUtilsDiacriticsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/TextUtilsDiacriticsTest.java
@@ -1,0 +1,117 @@
+package cgeo.geocaching.utils;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pure-JVM tests for {@link TextUtils#foldDiacritics(String)} and
+ * {@link TextUtils#containsIgnoreCaseAndDiacritics(String, String)} (#16206).
+ */
+public class TextUtilsDiacriticsTest {
+
+    @Test
+    public void foldsCombiningMarkDiacriticsToBaseLetter() {
+        // Western European
+        assertThat(TextUtils.foldDiacritics("àáâãäåā")).isEqualTo("aaaaaaa");
+        assertThat(TextUtils.foldDiacritics("èéêëēĕėẽ")).isEqualTo("eeeeeeee");
+        assertThat(TextUtils.foldDiacritics("ìíîïī")).isEqualTo("iiiii");
+        assertThat(TextUtils.foldDiacritics("òóôõöōő")).isEqualTo("ooooooo");
+        assertThat(TextUtils.foldDiacritics("ùúûüūůű")).isEqualTo("uuuuuuu");
+        assertThat(TextUtils.foldDiacritics("çñ")).isEqualTo("cn");
+        // Slavic (caron / acute / breve)
+        assertThat(TextUtils.foldDiacritics("šžčřě")).isEqualTo("szcre");
+        assertThat(TextUtils.foldDiacritics("ćńśźż")).isEqualTo("cnszz");
+        // Baltic / cedilla-below
+        assertThat(TextUtils.foldDiacritics("āēīūķļņģ")).isEqualTo("aeiuklng");
+    }
+
+    @Test
+    public void foldsBothRomanianSVariants() {
+        // U+015F (s with cedilla) and U+0219 (s with comma below) must both fold to "s"
+        assertThat(TextUtils.foldDiacritics("la du\u015f")).isEqualTo("la dus");
+        assertThat(TextUtils.foldDiacritics("la du\u0219")).isEqualTo("la dus");
+        // and the corresponding t variants
+        assertThat(TextUtils.foldDiacritics("\u0163\u021b")).isEqualTo("tt");
+    }
+
+    @Test
+    public void foldsAtomicLettersWithoutCanonicalDecomposition() {
+        assertThat(TextUtils.foldDiacritics("ß")).isEqualTo("ss");
+        assertThat(TextUtils.foldDiacritics("ø")).isEqualTo("o");
+        assertThat(TextUtils.foldDiacritics("æ")).isEqualTo("ae");
+        assertThat(TextUtils.foldDiacritics("œ")).isEqualTo("oe");
+        assertThat(TextUtils.foldDiacritics("ł")).isEqualTo("l");
+        assertThat(TextUtils.foldDiacritics("đ")).isEqualTo("d");
+        assertThat(TextUtils.foldDiacritics("ð")).isEqualTo("d");
+        assertThat(TextUtils.foldDiacritics("þ")).isEqualTo("th");
+        assertThat(TextUtils.foldDiacritics("ħ")).isEqualTo("h");
+        assertThat(TextUtils.foldDiacritics("ŧ")).isEqualTo("t");
+        assertThat(TextUtils.foldDiacritics("ŋ")).isEqualTo("n");
+        assertThat(TextUtils.foldDiacritics("ĸ")).isEqualTo("k");
+        assertThat(TextUtils.foldDiacritics("ſ")).isEqualTo("s");
+        assertThat(TextUtils.foldDiacritics("ı")).isEqualTo("i");
+    }
+
+    @Test
+    public void foldsUppercaseIncludingAtomicAndCapitalSharpS() {
+        assertThat(TextUtils.foldDiacritics("MÜLLER")).isEqualTo("muller");
+        assertThat(TextUtils.foldDiacritics("ZÜRICH")).isEqualTo("zurich");
+        assertThat(TextUtils.foldDiacritics("GROSSE STRAßE")).isEqualTo("grosse strasse");
+        assertThat(TextUtils.foldDiacritics("STRA\u1E9EE")).isEqualTo("strasse"); // capital sharp S U+1E9E
+        assertThat(TextUtils.foldDiacritics("ØÆŒŁÐÞ")).isEqualTo("oaeoeldth");
+    }
+
+    @Test
+    public void foldsViaNfdVietnameseHornAndDottedCapitalI() {
+        // Vietnamese horn letters have a canonical decomposition -> handled by NFD, no explicit mapping
+        assertThat(TextUtils.foldDiacritics("ơư")).isEqualTo("ou");
+        assertThat(TextUtils.foldDiacritics("Ơ\u01B0")).isEqualTo("ou");
+        // Turkish dotted capital I lowercases to "i" + combining dot, which NFD strips
+        assertThat(TextUtils.foldDiacritics("\u0130stanbul")).isEqualTo("istanbul");
+        // dotless lowercase i needs the explicit mapping
+        assertThat(TextUtils.foldDiacritics("\u0131stanbul")).isEqualTo("istanbul");
+    }
+
+    @Test
+    public void preservesAsciiDigitsPunctuationAndSpaces() {
+        assertThat(TextUtils.foldDiacritics("Fake Cache No 5")).isEqualTo("fake cache no 5");
+        assertThat(TextUtils.foldDiacritics("GC12345")).isEqualTo("gc12345");
+        assertThat(TextUtils.foldDiacritics("a-b_c.d (e)")).isEqualTo("a-b_c.d (e)");
+        assertThat(TextUtils.foldDiacritics("  keep  spaces  ")).isEqualTo("  keep  spaces  ");
+    }
+
+    @Test
+    public void handlesNullAndEmpty() {
+        assertThat(TextUtils.foldDiacritics(null)).isNull();
+        assertThat(TextUtils.foldDiacritics("")).isEqualTo("");
+    }
+
+    @Test
+    public void foldsRealWorldCacheAndOwnerNames() {
+        assertThat(TextUtils.foldDiacritics("straße")).isEqualTo("strasse");
+        assertThat(TextUtils.foldDiacritics("søen")).isEqualTo("soen");
+        assertThat(TextUtils.foldDiacritics("łódź")).isEqualTo("lodz");
+        assertThat(TextUtils.foldDiacritics("Þór")).isEqualTo("thor");
+        assertThat(TextUtils.foldDiacritics("æøå")).isEqualTo("aeoa");
+        assertThat(TextUtils.foldDiacritics("cœur")).isEqualTo("coeur");
+        assertThat(TextUtils.foldDiacritics("Ærøskøbing")).isEqualTo("aeroskobing");
+        assertThat(TextUtils.foldDiacritics("Þórsmörk")).isEqualTo("thorsmork");
+        assertThat(TextUtils.foldDiacritics("Ĉefa")).isEqualTo("cefa");
+        assertThat(TextUtils.foldDiacritics("Ħaġar Qim")).isEqualTo("hagar qim");
+        assertThat(TextUtils.foldDiacritics("kękę")).isEqualTo("keke");
+        assertThat(TextUtils.foldDiacritics("Åre")).isEqualTo("are");
+        assertThat(TextUtils.foldDiacritics("Řeka")).isEqualTo("reka");
+    }
+
+    @Test
+    public void containsIgnoreCaseAndDiacriticsMatchesFoldedSubstring() {
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics("la duş", "dus")).isTrue();
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics("la du\u0219", "DUS")).isTrue();
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics("Große Straße", "grosse strasse")).isTrue();
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics("Zürich", "ZUR")).isTrue();
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics("łódź", "lodz")).isTrue();
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics("Müller", "xyz")).isFalse();
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics(null, "a")).isFalse();
+        assertThat(TextUtils.containsIgnoreCaseAndDiacritics("a", null)).isFalse();
+    }
+}


### PR DESCRIPTION
**What**
The top search bar now matches diacritic- and case-insensitively across **cache names**, **cache owner names** and **trackable names**, e.g. `la dus` finds `la duş`/`la duș`, `strasse` finds `straße`, `zurich` finds `Zürich`. Closes #16206.

**How**
- New `TextUtils.foldDiacritics` (Unicode NFD + strip combining marks, plus an explicit map for atomic letters without decomposition: ß→ss, ø→o, æ→ae, œ→oe, ł→l, đ/ð→d, þ→th, ħ→h, ŧ→t, ŋ→n, ĸ→k, ſ→s, ı→i; both Romanian ş variants U+015F/U+0219 → s) and `containsIgnoreCaseAndDiacritics`.
- New normalized shadow columns `name_normalized` + `owner_normalized` (cg_caches) and `title_normalized` (cg_trackables), filled on write.
- `DataStore.findCaches()` matches cache name and owner, `findTrackables()` matches trackable name — both query the normalized columns, with a raw-`LIKE` fallback for rows not yet migrated so search stays correct during migration.
- Existing rows are filled by a throttled, chunked background task started from `MainActivity` (duty-cycle delay between chunks, power-save aware), showing a Toast on completion.
- @moving-bits : Just let me know if I should provide a complete conversion table if needed. 

**Tests**
- Pure unit test `TextUtilsDiacriticsTest` (combining diacritics, atomic letters, casing incl. capital ẞ, Vietnamese horn letters, dotted-İ, both ş variants, `containsIgnoreCaseAndDiacritics`).
- Frontend verified on the emulator (screenshots below).

**Screenshots**

Cache **name** match `!NameDemo Þórsmörk` **and** owner match `!OwnerDemo Iceland` for the ASCII query `thorsmork` (owner not shown in the drop-down):
<img width="540" alt="01_thorsmork" src="https://github.com/user-attachments/assets/10a4d4a0-8a36-497d-9ade-d7767824bed3" />


Opening `!OwnerDemo Iceland` reveals the owner `Þórsmörk` — i.e. the query matched via the owner name:
<img width="540" alt="02_ownerdemo_detail" src="https://github.com/user-attachments/assets/571bddbd-af67-4b75-b670-6272985dd528" />


Both Romanian ş variants (U+015F and U+0219) plus the œ ligature, for the original report's query `la dus`:
<img width="540" alt="03_la_dus" src="https://github.com/user-attachments/assets/522afb37-0a6a-4a0f-ad26-76ad15014e9d" />


Trackable **name** matches for `zurich` (trackable icon, TB codes):
<img width="540" alt="05_zurich_tb" src="https://github.com/user-attachments/assets/b6fca2ef-48ca-4406-be24-bb8852d28e6d" />


**Notes**
- DB version 112 is marked downward-compatible (nullable columns via `createColumnIfNotExists`, re-runnable — like 108/109).
Remark: after a downgrade an older version won't maintain the `*_normalized` columns, so a cache edited there keeps a stale folded value until re-saved (the NULL-driven migration only refills NULLs). 
Let me know to drop 112 from `DBVERSIONS_DOWNWARD_COMPATIBLE` if you'd rather block downgrades.
- AI-assisted, reviewed and tested by me.