### PR TITLE
Fix Kotlin metadata version mismatch in gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,13 @@
 buildscript {
     repositories {
         google()
+        maven { url 'https://storage.googleapis.com/r8-releases/raw' }
     }
     dependencies {
         // these dependencies are used by gradle plugins, not by our projects
+
+        // R8 engine override to support Kotlin 2.3.0 metadata
+        classpath 'com.android.tools:r8:9.4.17'
 
         // Android gradle plugin
         classpath 'com.android.tools.build:gradle:8.13.2'


### PR DESCRIPTION
On some Tasks `:main:lintAnalyzeBasicDebug*` we got errors like: 
`e: file:///home/jenkins/.gradle/caches/8.14.5/transforms/94ec4645bb1424a1995ad3e6f840a2ad/transformed/chartLib-5.2.4/jars/classes.jar!/META-INF/chartLib.kotlin_module Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.4.0, expected version is 2.2.0.`

So we need to configure the kotlin-d8-r8-version to a newer level until AGP/Gradle is migrated to version 9.x.
