### PR TITLE
Fix Kotlin metadata version mismatch in gradle build

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -485,11 +485,11 @@ dependencies {
     implementation 'io.reactivex.rxjava3:rxjava:3.1.12'
     implementation "io.reactivex.rxjava3:rxandroid:3.0.2"
 
-    // avoid duplicate class, see e.g. https://stackoverflow.com/questions/75712899/duplicate-class-kotlin-random-jdk8-found-in-modules-jetified-kotlin-stdlib-1-8-1
-    constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.3.0") {
-            because 'align all versions of kotlin transitive dependencies'
-        }
+    // avoid duplicate classes
+    configurations.configureEach {
+        resolutionStrategy.force 'org.jetbrains.kotlin:kotlin-stdlib:2.2.10'
+        resolutionStrategy.force 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.10'
+        resolutionStrategy.force 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.2.10'
     }
 
     // Support Library Lifecycle Helpers
@@ -562,7 +562,7 @@ dependencies {
 
     // charting, based on com.github.PhilJay:MPAndroidChart
     // for detailed docs for the base library see https://weeklycoding.com/mpandroidchart/
-    implementation 'com.github.AppDevNext.AndroidChart:chartLib:5.2.3'
+    implementation 'com.github.AppDevNext.AndroidChart:chartLib:5.2.1'
 
     // For Wherigos: GIF support
     // ani gif support


### PR DESCRIPTION
The prepared solution in #18565 does not work as expected. Therefore another solution: downgrade chartlib and downgrade kotlin-stdlib strategy to 2.2.10.
