### PR TITLE
Quick fix to raise targetSDK to 36

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -58,6 +58,7 @@
         android:supportsRtl="true"
         android:largeHeap="true"
         android:preserveLegacyExternalStorage="true"
+        android:enableOnBackInvokedCallback="false"
         >
 
         <!-- Samsung Multi-Window support -->

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -45,7 +45,7 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
 
         versionName = versionNameFromDate()
         versionCode = versionCodeFromDate(0)


### PR DESCRIPTION
## Description
- sets targetSDK to 36
- opts out of the new [predictive back gestures](https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back), which are enabled by default on Android 16+ devices (API 36)
