### PR TITLE
Introducing a new unified gpx parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,7 @@ captures/
 # ignore Claude internal files
 .claude/
 
+# allow for temp local filees
+temp/
+
 main/usage.txt

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ org.gradle.daemon=true
 
 # build addons in parallel to main app
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true
 
 # Use more memory to benefit from in-process dexing
 # Use the parallel garbage collector
@@ -31,3 +32,4 @@ android.useAndroidX=true
 
 # For local instrumented tests: leave original c:geo installation intact on device
 android.injected.androidTest.leaveApksInstalledAfterRun=true
+

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -187,7 +187,8 @@ android {
             setRoot("src/test/java")
             manifest.srcFile 'src/test/AndroidManifest.xml'
             java.srcDir 'src/test/java'
-            resources.srcDirs = ['src/test/res']
+            // include src/androidTest/res/raw for unit tests to access gpx sample files without duplicating them.
+            resources.srcDirs = ['src/test/res', 'src/androidTest/res/raw']
             res.srcDirs = ['src/test/res']
         }
         // device/emulator based instrumentation tests in source set "androidTest"

--- a/main/src/main/java/cgeo/geocaching/files/unifiedgpxparser/UnifiedGPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/files/unifiedgpxparser/UnifiedGPXParser.java
@@ -1,6 +1,5 @@
 package cgeo.geocaching.files.unifiedgpxparser;
 
-import cgeo.geocaching.files.InvalidXMLCharacterFilterReader;
 import cgeo.geocaching.files.ParserException;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
@@ -14,12 +13,8 @@ import cgeo.geocaching.utils.xml.XmlUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -71,13 +66,8 @@ public final class UnifiedGPXParser {
 
     @NonNull
     public static Result parse(@NonNull final InputStream stream) throws IOException, ParserException {
-        final Reader reader = new InvalidXMLCharacterFilterReader(
-                new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)));
         try {
             final XmlPullParser parser = XmlUtils.createParser(stream, true);
-            // XmlUtils.createParser sets the stream as input; replace it with our filtered reader
-            // so that invalid XML chars are stripped (same behaviour as the SAX-based parsers).
-            parser.setInput(reader);
 
             final Result result = new Result();
             findAndParseGpxRoot(parser, result);

--- a/main/src/main/java/cgeo/geocaching/models/NamedGeoCoordinate.java
+++ b/main/src/main/java/cgeo/geocaching/models/NamedGeoCoordinate.java
@@ -19,6 +19,10 @@ public class NamedGeoCoordinate implements INamedGeoCoordinate, Parcelable {
     private String name;
     private String geocode;
 
+    public NamedGeoCoordinate() {
+        this.geocode = "";
+    }
+
     protected NamedGeoCoordinate(final Parcel in) {
         coords = in.readParcelable(Geopoint.class.getClassLoader());
         elevation = in.readFloat();

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
@@ -1,0 +1,40 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.utils.EmojiUtilsLegacyMigration;
+import cgeo.geocaching.utils.xml.XmlNode;
+
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class CgeoGPXExtension implements IGPXExtension {
+
+    //Namespaces of extensions
+    private static final Set<String> CGEO_NS = Set.of(
+            "http://www.cgeo.org/wptext/1/0"
+    );
+
+    @Override
+    public void enrichGeocache(final XmlNode wptNode, final Geocache cache) {
+        final String assignedEmojiText = GPXUtils.gpxNodeChildText(GPXUtils.gpxNodeChild(wptNode, "cacheExtension", CGEO_NS), "assignedEmoji", CGEO_NS);
+        if (StringUtils.isNotBlank(assignedEmojiText)) {
+            cache.setAssignedEmoji(EmojiUtilsLegacyMigration.parseGpxAssignedEmoji(assignedEmojiText));
+        }
+    }
+
+    @Override
+    public void enrichWaypoint(final XmlNode wptNode, final Waypoint waypoint) {
+        for (final XmlNode child : wptNode.getChildrenInOrder()) {
+            if ("visited".equals(child.getLocalName())) {
+                waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
+            } else if ("originalCoordsEmpty".equals(child.getLocalName())) {
+                waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
+            }
+        }
+    }
+
+
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
@@ -18,7 +18,7 @@ public class CgeoGPXExtension implements IGPXExtension {
 
     @Override
     public void enrichGeocache(final XmlNode wptNode, final Geocache cache) {
-        final String assignedEmojiText = GPXUtils.gpxNodeChildText(GPXUtils.gpxNodeChild(wptNode, "cacheExtension", CGEO_NS), "assignedEmoji", CGEO_NS);
+        final String assignedEmojiText = GPXUtils.gpxChildText(GPXUtils.gpxChild(wptNode, "cacheExtension", CGEO_NS), "assignedEmoji", CGEO_NS);
         if (StringUtils.isNotBlank(assignedEmojiText)) {
             cache.setAssignedEmoji(EmojiUtilsLegacyMigration.parseGpxAssignedEmoji(assignedEmojiText));
         }
@@ -26,15 +26,15 @@ public class CgeoGPXExtension implements IGPXExtension {
 
     @Override
     public void enrichWaypoint(final XmlNode wptNode, final Waypoint waypoint) {
-        final Boolean visited = GPXUtils.gpxNodeChildBoolean(wptNode, "visited", CGEO_NS, null);
+        final Boolean visited = GPXUtils.gpxChildBoolean(wptNode, "visited", CGEO_NS, null);
         if (visited != null) {
             waypoint.setVisited(visited);
         }
-        final Boolean originalCoordsEmpty = GPXUtils.gpxNodeChildBoolean(wptNode, "originalCoordsEmpty", CGEO_NS, null);
+        final Boolean originalCoordsEmpty = GPXUtils.gpxChildBoolean(wptNode, "originalCoordsEmpty", CGEO_NS, null);
         if (originalCoordsEmpty != null) {
             waypoint.setOriginalCoordsEmpty(originalCoordsEmpty);
         }
-        final Boolean userdefined = GPXUtils.gpxNodeChildBoolean(wptNode, "userdefined", CGEO_NS, Boolean.FALSE);
+        final Boolean userdefined = GPXUtils.gpxChildBoolean(wptNode, "userdefined", CGEO_NS, Boolean.FALSE);
         if (userdefined != null && userdefined) {
             waypoint.setUserDefined();
         }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
@@ -26,15 +26,18 @@ public class CgeoGPXExtension implements IGPXExtension {
 
     @Override
     public void enrichWaypoint(final XmlNode wptNode, final Waypoint waypoint) {
-        for (final XmlNode child : wptNode.getChildrenInOrder()) {
-            if ("visited".equals(child.getLocalName())) {
-                waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
-            } else if ("originalCoordsEmpty".equals(child.getLocalName())) {
-                waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
-            }
+        final String visited = GPXUtils.gpxNodeChildText(wptNode, "visited", CGEO_NS);
+        if (visited != null) {
+            waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(visited)));
+        }
+        final String originalCoordsEmpty = GPXUtils.gpxNodeChildText(wptNode, "originalCoordsEmpty", CGEO_NS);
+        if (originalCoordsEmpty != null) {
+            waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(originalCoordsEmpty)));
+        }
+        final String userdefined = GPXUtils.gpxNodeChildText(wptNode, "userdefined", CGEO_NS);
+        if (Boolean.parseBoolean(StringUtils.trim(userdefined))) {
+            waypoint.setUserDefined();
         }
     }
-
-
 
 }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/CgeoGPXExtension.java
@@ -26,16 +26,16 @@ public class CgeoGPXExtension implements IGPXExtension {
 
     @Override
     public void enrichWaypoint(final XmlNode wptNode, final Waypoint waypoint) {
-        final String visited = GPXUtils.gpxNodeChildText(wptNode, "visited", CGEO_NS);
+        final Boolean visited = GPXUtils.gpxNodeChildBoolean(wptNode, "visited", CGEO_NS, null);
         if (visited != null) {
-            waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(visited)));
+            waypoint.setVisited(visited);
         }
-        final String originalCoordsEmpty = GPXUtils.gpxNodeChildText(wptNode, "originalCoordsEmpty", CGEO_NS);
+        final Boolean originalCoordsEmpty = GPXUtils.gpxNodeChildBoolean(wptNode, "originalCoordsEmpty", CGEO_NS, null);
         if (originalCoordsEmpty != null) {
-            waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(originalCoordsEmpty)));
+            waypoint.setOriginalCoordsEmpty(originalCoordsEmpty);
         }
-        final String userdefined = GPXUtils.gpxNodeChildText(wptNode, "userdefined", CGEO_NS);
-        if (Boolean.parseBoolean(StringUtils.trim(userdefined))) {
+        final Boolean userdefined = GPXUtils.gpxNodeChildBoolean(wptNode, "userdefined", CGEO_NS, Boolean.FALSE);
+        if (userdefined != null && userdefined) {
             waypoint.setUserDefined();
         }
     }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
@@ -105,7 +105,7 @@ final class GPXFullWptParser {
     ICoordinate parse(@NonNull final XmlNode wptNode, @Nullable final String scriptUrl) {
         parsedLogs = null;
         parsedParentGeocode = null;
-        final Geopoint coords = GPXUtils.gpxNodeReadLatLon(wptNode);
+        final Geopoint coords = GPXUtils.gpxGeopoint(wptNode);
 
         final String rawName = normalizeName(wptNode.getChildValue("name"), scriptUrl);
         final String desc = wptNode.getChildValue("desc");
@@ -129,12 +129,11 @@ final class GPXFullWptParser {
         final boolean wasTerraChildWaypoint = this.terraChildWaypoint;
         final boolean isTerraChildWaypointMarker = "GC_WayPoint1".equals(StringUtils.trim(desc));
 
-        final XmlNode base = GPXUtils.extensionsBase(wptNode);
         final boolean isGeocache = Strings.CI.contains(type, "geocache")
                 || Strings.CI.contains(sym, "geocache")
                 || Strings.CI.contains(sym, "waymark")
                 || (!wasTerraChildWaypoint && (Strings.CI.contains(sym, "terracache")
-                    || base.hasChild("cache") || base.hasChild("terracache")));
+                || GPXUtils.gpxChild(wptNode, "cache", null) != null || GPXUtils.gpxChild(wptNode, "terracache", null) != null));
         final boolean isWaypoint = !isGeocache && (Strings.CI.contains(type, "waypoint") || wasTerraChildWaypoint);
 
         if (isTerraChildWaypointMarker) {
@@ -153,8 +152,8 @@ final class GPXFullWptParser {
 
     /** Parses an entry without geocache or waypoint classification. */
     private static ICoordinate parseFallbackCoordinate(final String rawName, final XmlNode wptNode) {
-        final Geopoint coords = XmlUtils.parseGeopoint(GPXUtils.gpxNodeAttrValue(wptNode, "lat", null), GPXUtils.gpxNodeAttrValue(wptNode, "lon", null), true);
-        final Float elevation = GPXUtils.gpxNodeChildFloat(wptNode, "ele", null, null);
+        final Geopoint coords = XmlUtils.parseGeopoint(GPXUtils.gpxAttrValue(wptNode, "lat", null), GPXUtils.gpxAttrValue(wptNode, "lon", null), true);
+        final Float elevation = GPXUtils.gpxChildFloat(wptNode, "ele", null, null);
         if (StringUtils.isBlank(rawName) && elevation == null) {
             return coords;
         }
@@ -190,7 +189,7 @@ final class GPXFullWptParser {
         if (StringUtils.isNotBlank(cmt)) {
             cache.setDescription(XmlUtils.validate(cmt));
         }
-        final Date hidden = GPXUtils.gpxNodeChildDate(wptNode, "time", null, null);
+        final Date hidden = GPXUtils.gpxChildDate(wptNode, "time", null, null);
         if (hidden != null) {
             cache.setHidden(hidden);
         }
@@ -206,7 +205,7 @@ final class GPXFullWptParser {
         }
 
         parsedLogs = parseGeocacheExtensions(wptNode, cache);
-        final String urlName = StringUtils.defaultIfBlank(wptNode.getChildValue("urlname"), GPXUtils.gpxNodeChildText(wptNode.getChild("link"), "text", null));
+        final String urlName = StringUtils.defaultIfBlank(wptNode.getChildValue("urlname"), GPXUtils.gpxChildText(wptNode.getChild("link"), "text", null));
         if (Strings.CI.startsWith(cache.getGeocode(), "WM") && cache.getName().equalsIgnoreCase(cache.getGeocode()) && StringUtils.isNotBlank(urlName)) {
             cache.setName(urlName.trim());
         }
@@ -269,7 +268,7 @@ final class GPXFullWptParser {
         final String description = wptNode.getChildValue("desc");
         final String name = "GC_WayPoint1".equals(StringUtils.trim(description)) ? ""
                 : XmlUtils.validate(StringUtils.defaultIfBlank(description, StringUtils.trimToEmpty(rawName)));
-        final XmlNode base = GPXUtils.extensionsBase(wptNode);
+        //final XmlNode base = GPXUtils.extensionsBase(wptNode);
         final Waypoint waypoint = new Waypoint(name, WaypointType.fromGPXString(sym == null ? "" : sym, subtype), false);
         waypoint.setId(Waypoint.NEW_ID);
         waypoint.setCoords(coords);
@@ -279,7 +278,7 @@ final class GPXFullWptParser {
         }
 
         for (IGPXExtension extension : gpxExtensions) {
-            extension.enrichWaypoint(base, waypoint);
+            extension.enrichWaypoint(wptNode, waypoint);
         }
 
         if (!waypoint.isUserDefined() && coords == null) {
@@ -312,9 +311,8 @@ final class GPXFullWptParser {
      */
     @Nullable
     private String resolveParentGeocode(final XmlNode wptNode, final String rawName, final boolean isTerraChildWaypoint, final String scriptUrl) {
-        final XmlNode extensions = GPXUtils.extensionsBase(wptNode);
-        final XmlNode gsakExt = GPXUtils.gpxNodeChild(extensions, "wptExtension", GSAKGPXExtension.GSAK_NS);
-        final String gsakParent = GPXUtils.gpxNodeChildText(gsakExt, "Parent", GSAKGPXExtension.GSAK_NS);
+        final XmlNode gsakExt = GPXUtils.gpxChild(wptNode, "wptExtension", GSAKGPXExtension.GSAK_NS);
+        final String gsakParent = GPXUtils.gpxChildText(gsakExt, "Parent", GSAKGPXExtension.GSAK_NS);
         if (StringUtils.isNotBlank(gsakParent)) {
             return nameToGeocodeIndex.getOrDefault(gsakParent.trim().toLowerCase(Locale.US), gsakParent.trim());
         }
@@ -344,17 +342,13 @@ final class GPXFullWptParser {
 
     @Nullable
     private List<LogEntry> parseGeocacheExtensions(final XmlNode wptNode, final Geocache cache) {
-        final XmlNode base = GPXUtils.extensionsBase(wptNode);
-        if (base == null) {
-            return null;
-        }
         for (final IGPXExtension extension : gpxExtensions) {
-            extension.enrichGeocache(base, cache);
+            extension.enrichGeocache(wptNode, cache);
         }
 
         final List<LogEntry> logs = new ArrayList<>();
         for (IGPXExtension extension : gpxExtensions) {
-            final List<LogEntry> candidate = extension.extractLogs(base, cache);
+            final List<LogEntry> candidate = extension.extractLogs(wptNode, cache);
             if (candidate != null) {
                 logs.addAll(candidate);
             }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
@@ -271,7 +271,7 @@ final class GPXFullWptParser {
         final String name = "GC_WayPoint1".equals(StringUtils.trim(description)) ? ""
                 : XmlUtils.validate(StringUtils.defaultIfBlank(description, StringUtils.trimToEmpty(rawName)));
         final XmlNode base = GPXUtils.extensionsBase(wptNode);
-        final Waypoint waypoint = new Waypoint(name, WaypointType.fromGPXString(sym == null ? "" : sym, subtype), parseWaypointUserDefined(base));
+        final Waypoint waypoint = new Waypoint(name, WaypointType.fromGPXString(sym == null ? "" : sym, subtype), false);
         waypoint.setId(Waypoint.NEW_ID);
         waypoint.setCoords(coords);
         waypoint.setLookup("---"); // GPX has no lookup code
@@ -361,25 +361,6 @@ final class GPXFullWptParser {
             }
         }
         return logs.isEmpty() ? null : logs;
-    }
-
-
-
-
-    private static boolean parseWaypointUserDefined(final XmlNode base) {
-        boolean userDefined = false;
-        for (final XmlNode child : base.getChildrenInOrder()) {
-            if ("userdefined".equals(child.getLocalName())) {
-                userDefined = Boolean.parseBoolean(StringUtils.trim(child.getValue()));
-            } else if ("wptExtension".equals(child.getLocalName())) {
-                for (final XmlNode field : child.getChildrenInOrder()) {
-                    if ("Child_ByGSAK".equals(field.getLocalName())) {
-                        userDefined |= Boolean.parseBoolean(StringUtils.trim(field.getValue()));
-                    }
-                }
-            }
-        }
-        return userDefined;
     }
 
     private static Geocache createCache() {

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
@@ -3,23 +3,14 @@ package cgeo.geocaching.utils.gpx;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.GCUtils;
-import cgeo.geocaching.connector.tc.TerraCachingLogType;
-import cgeo.geocaching.connector.tc.TerraCachingType;
-import cgeo.geocaching.enumerations.CacheAttribute;
-import cgeo.geocaching.enumerations.CacheSize;
-import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogEntry;
-import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.ICoordinate;
 import cgeo.geocaching.models.NamedGeoCoordinate;
-import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.models.WaypointUserNoteCombiner;
-import cgeo.geocaching.utils.EmojiUtilsLegacyMigration;
-import cgeo.geocaching.utils.html.HtmlUtils;
 import cgeo.geocaching.utils.xml.XmlNode;
 import cgeo.geocaching.utils.xml.XmlUtils;
 
@@ -48,20 +39,14 @@ final class GPXFullWptParser {
     private static final Pattern PATTERN_URL_GEOCODE = Pattern.compile("[?&]wp=([^&#]+)", Pattern.CASE_INSENSITIVE);
     private static final Pattern PATTERN_URL_GUID = Pattern.compile("[?&]guid=([0-9a-f-]+)", Pattern.CASE_INSENSITIVE);
 
-    //Namespaces of extensions
-    private static final Set<String> GROUNDSPEAK_NS = Set.of(
-        "http://www.groundspeak.com/cache/1/1", // PQ 1.1
-        "http://www.groundspeak.com/cache/1/0/1", // PQ 1.0.1
-        "http://www.groundspeak.com/cache/1/0" // PQ 1.0
-    );
 
-    private static final Set<String> GSAK_NS = Set.of(
-        "http://www.gsak.net/xmlv1/1",
-        "http://www.gsak.net/xmlv1/2",
-        "http://www.gsak.net/xmlv1/3",
-        "http://www.gsak.net/xmlv1/4",
-        "http://www.gsak.net/xmlv1/5",
-        "http://www.gsak.net/xmlv1/6"
+    //Extensions
+    private final List<IGPXExtension> gpxExtensions = List.of(
+        new GroundspeakGPXExtension(),
+        new GSAKGPXExtension(),
+        new TerraCachingGPXExtension(),
+        new CgeoGPXExtension(),
+        new OpenCachingGPXExtension()
     );
 
     private static final Set<String> CGEO_NS = Set.of(
@@ -70,10 +55,6 @@ final class GPXFullWptParser {
 
     private static final Set<String> OPENCACHING_NS = Set.of(
         "https://github.com/opencaching/gpx-extension-v1"
-    );
-
-    private static final Set<String> TERRA_NS = Set.of(
-            "http://www.TerraCaching.com/GPX/1/0"
     );
 
     /** parse-session-scoped index: (lower-cased, trimmed) cache name/title -&gt; geocode */
@@ -204,10 +185,10 @@ final class GPXFullWptParser {
             cache.setName(rawName.trim());
         }
         if (StringUtils.isNotBlank(desc)) {
-            cache.setShortDescription(validate(desc));
+            cache.setShortDescription(XmlUtils.validate(desc));
         }
         if (StringUtils.isNotBlank(cmt)) {
-            cache.setDescription(validate(cmt));
+            cache.setDescription(XmlUtils.validate(cmt));
         }
         final String timeText = wptNode.getChildValue("time");
         final Date hidden = XmlUtils.parseDate(timeText);
@@ -288,7 +269,7 @@ final class GPXFullWptParser {
 
         final String description = wptNode.getChildValue("desc");
         final String name = "GC_WayPoint1".equals(StringUtils.trim(description)) ? ""
-                : validate(StringUtils.defaultIfBlank(description, StringUtils.trimToEmpty(rawName)));
+                : XmlUtils.validate(StringUtils.defaultIfBlank(description, StringUtils.trimToEmpty(rawName)));
         final XmlNode base = GPXUtils.extensionsBase(wptNode);
         final Waypoint waypoint = new Waypoint(name, WaypointType.fromGPXString(sym == null ? "" : sym, subtype), parseWaypointUserDefined(base));
         waypoint.setId(Waypoint.NEW_ID);
@@ -298,7 +279,10 @@ final class GPXFullWptParser {
             waypoint.setGeocode(parentGeocodeCandidate);
         }
 
-        parseCgeoExtension(base, waypoint);
+        for (IGPXExtension extension : gpxExtensions) {
+            extension.enrichWaypoint(base, waypoint);
+        }
+
         if (!waypoint.isUserDefined() && coords == null) {
             waypoint.setOriginalCoordsEmpty(true);
         }
@@ -306,7 +290,7 @@ final class GPXFullWptParser {
 
         final String note = wptNode.getChildValue("cmt");
         if (StringUtils.isNotBlank(note)) {
-            new WaypointUserNoteCombiner(waypoint).updateNoteAndUserNote(validate(note));
+            new WaypointUserNoteCombiner(waypoint).updateNoteAndUserNote(XmlUtils.validate(note));
         }
 
         parsedParentGeocode = parentGeocodeCandidate;
@@ -330,8 +314,8 @@ final class GPXFullWptParser {
     @Nullable
     private String resolveParentGeocode(final XmlNode wptNode, final String rawName, final boolean isTerraChildWaypoint, final String scriptUrl) {
         final XmlNode extensions = GPXUtils.extensionsBase(wptNode);
-        final XmlNode gsakExt = GPXUtils.gpxNodeChild(extensions, "wptExtension", GSAK_NS);
-        final String gsakParent = GPXUtils.gpxNodeChildText(gsakExt, "Parent", GSAK_NS);
+        final XmlNode gsakExt = GPXUtils.gpxNodeChild(extensions, "wptExtension", GSAKGPXExtension.GSAK_NS);
+        final String gsakParent = GPXUtils.gpxNodeChildText(gsakExt, "Parent", GSAKGPXExtension.GSAK_NS);
         if (StringUtils.isNotBlank(gsakParent)) {
             return nameToGeocodeIndex.getOrDefault(gsakParent.trim().toLowerCase(Locale.US), gsakParent.trim());
         }
@@ -365,285 +349,22 @@ final class GPXFullWptParser {
         if (base == null) {
             return null;
         }
-        parseGroundspeakExtension(base, cache);
-        parseGsakExtension(base, cache);
-        parseTerraCachingExtension(base, cache);
-        parseCgeoExtension(base, cache);
-        parseOpenCachingExtension(base, cache);
+        for (final IGPXExtension extension : gpxExtensions) {
+            extension.enrichGeocache(base, cache);
+        }
+
         final List<LogEntry> logs = new ArrayList<>();
-        for (final XmlNode child : base.getChildrenInOrder()) {
-            final List<LogEntry> sourceLogs;
-            if ("cache".equals(child.getLocalName())) {
-                sourceLogs = parseGroundspeakLogs(child, ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector);
-            } else if ("terracache".equals(child.getLocalName())) {
-                sourceLogs = parseTerraCachingLogs(child);
-            } else {
-                continue;
-            }
-            if (sourceLogs != null) {
-                logs.addAll(sourceLogs);
+        for (IGPXExtension extension : gpxExtensions) {
+            final List<LogEntry> candidate = extension.extractLogs(base, cache);
+            if (candidate != null) {
+                logs.addAll(candidate);
             }
         }
         return logs.isEmpty() ? null : logs;
     }
 
-    /**
-     * Groundspeak cache extension, used by geocaching.com pocket queries and most third-party tools (GSAK, ...).
-     * Schema/namespace (any of 3 historic versions, unified here by local name only): PQ 1.1
-     * {@code http://www.groundspeak.com/cache/1/1}, PQ 1.0.1 {@code http://www.groundspeak.com/cache/1/0/1},
-     * PQ 1.0 {@code http://www.groundspeak.com/cache/1/0}. Element {@code <cache>}.
-     */
-    private void parseGroundspeakExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode gcCache = GPXUtils.gpxNodeChild(base, "cache", GROUNDSPEAK_NS);
-        if (gcCache == null) {
-            return;
-        }
-        final String id = GPXUtils.gpxNodeAttrValue(gcCache, "id", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(id)) {
-            cache.setCacheId(id);
-        }
-        final String archived = GPXUtils.gpxNodeAttrValue(gcCache, "archived", GROUNDSPEAK_NS);
-        if (archived != null) {
-            cache.setArchived("true".equalsIgnoreCase(archived));
-        }
-        final String available = GPXUtils.gpxNodeAttrValue(gcCache, "available", GROUNDSPEAK_NS);
-        if (available != null) {
-            cache.setDisabled(!"true".equalsIgnoreCase(available));
-        }
 
-        final String name = GPXUtils.gpxNodeChildText(gcCache, "name", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(name)) {
-            cache.setName(validate(name));
-        }
-        final String owner = GPXUtils.gpxNodeChildText(gcCache, "owner", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(owner)) {
-            cache.setOwnerUserId(validate(owner));
-        }
-        final String placedBy = GPXUtils.gpxNodeChildText(gcCache, "placed_by", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(placedBy)) {
-            cache.setOwnerDisplayName(validate(placedBy));
-        }
-        final String gcType = GPXUtils.gpxNodeChildText(gcCache, "type", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(gcType)) {
-            String body = validate(gcType);
-            if (body.startsWith("Geocache|")) {
-                body = StringUtils.substringAfter(body, "Geocache|").trim();
-            }
-            cache.setType(CacheType.getByPattern(body));
-        }
-        final String container = GPXUtils.gpxNodeChildText(gcCache, "container", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(container)) {
-            cache.setSize(CacheSize.getById(validate(container)));
-        }
-        final Float difficulty = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "difficulty", GROUNDSPEAK_NS));
-        if (difficulty != null) {
-            cache.setDifficulty(difficulty);
-        }
-        final Float terrain = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "terrain", GROUNDSPEAK_NS));
-        if (terrain != null) {
-            cache.setTerrain(terrain);
-        }
-        final String country = GPXUtils.gpxNodeChildText(gcCache, "country", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(country)) {
-            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(country) : cache.getLocation() + ", " + country.trim());
-        }
-        final String state = GPXUtils.gpxNodeChildText(gcCache, "state", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
-            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
-        }
-        final String hints = GPXUtils.gpxNodeChildText(gcCache, "encoded_hints", GROUNDSPEAK_NS);
-        if (hints != null) {
-            cache.setHint(validate(hints));
-        }
-        final String shortDesc = GPXUtils.gpxNodeChildText(gcCache, "short_description", GROUNDSPEAK_NS);
-        if (shortDesc != null) {
-            cache.setShortDescription(validate(shortDesc));
-        }
-        final String longDesc = GPXUtils.gpxNodeChildText(gcCache, "long_description", GROUNDSPEAK_NS);
-        if (longDesc != null) {
-            cache.setDescription(validate(longDesc));
-        }
 
-        parseGroundspeakAttributes(gcCache, cache);
-        parseGroundspeakTravelbugs(gcCache, cache);
-    }
-
-    /**
-     * Groundspeak logs ({@code <groundspeak:logs><groundspeak:log>...}). Same schema/namespace as
-     * {@link #parseGroundspeakExtension}.
-     */
-    @Nullable
-    private List<LogEntry> parseGroundspeakLogs(final XmlNode gcCache, final boolean gcConnector) {
-        final XmlNode logsNode = GPXUtils.gpxNodeChild(gcCache, "logs", GROUNDSPEAK_NS);
-        if (logsNode == null) {
-            return null;
-        }
-        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
-        if (logNodes == null) {
-            return null;
-        }
-        final List<LogEntry> result = new ArrayList<>();
-        for (final XmlNode logNode : logNodes) {
-            final LogEntry.Builder builder = new LogEntry.Builder();
-            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", GROUNDSPEAK_NS);
-            if (idText != null) {
-                try {
-                    builder.setId(Integer.parseInt(idText.trim()));
-                    if (gcConnector) {
-                        builder.setServiceLogId(GCUtils.logIdToLogCode(builder.getId()));
-                    }
-                } catch (final NumberFormatException ignored) {
-                    // ignore malformed id
-                }
-            }
-            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", GROUNDSPEAK_NS));
-            if (date != null) {
-                builder.setDate(date.getTime());
-            }
-            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", GROUNDSPEAK_NS);
-            if (typeText != null) {
-                builder.setLogType(LogType.getByType(validate(typeText)));
-            }
-            final String finder = GPXUtils.gpxNodeChildText(logNode, "finder", GROUNDSPEAK_NS);
-            if (finder != null) {
-                builder.setAuthor(validate(finder));
-            }
-            final String text = GPXUtils.gpxNodeChildText(logNode, "text", GROUNDSPEAK_NS);
-            if (text != null) {
-                builder.setLog(validate(text));
-            }
-            final LogEntry log = builder.build();
-            if (log.logType != LogType.UNKNOWN) {
-                result.add(log);
-            }
-        }
-        return result.isEmpty() ? null : result;
-    }
-
-    private void parseGroundspeakAttributes(final XmlNode gcCache, final Geocache cache) {
-        final XmlNode attributes = GPXUtils.gpxNodeChild(gcCache, "attributes", GROUNDSPEAK_NS);
-        if (attributes == null) {
-            return;
-        }
-        final List<XmlNode> attributeNodes = GPXUtils.gpxNodeChildren(attributes, "attribute");
-        if (attributeNodes == null) {
-            return;
-        }
-        final List<String> result = new ArrayList<>();
-        for (final XmlNode attributeNode : attributeNodes) {
-            final String idText = GPXUtils.gpxNodeAttrValue(attributeNode, "id", GROUNDSPEAK_NS);
-            final String incText = GPXUtils.gpxNodeAttrValue(attributeNode, "inc", GROUNDSPEAK_NS);
-            if (idText == null || incText == null) {
-                continue;
-            }
-            try {
-                final int attributeId = Integer.parseInt(idText.trim());
-                final boolean active = Integer.parseInt(incText.trim()) != 0;
-                final CacheAttribute attribute = CacheAttribute.getById(attributeId);
-                if (attribute != null) {
-                    result.add(attribute.getValue(active));
-                }
-            } catch (final NumberFormatException ignored) {
-                // ignore malformed attribute entries
-            }
-        }
-        cache.setAttributes(result);
-    }
-
-    private void parseGroundspeakTravelbugs(final XmlNode gcCache, final Geocache cache) {
-        final XmlNode travelbugs = GPXUtils.gpxNodeChild(gcCache, "travelbugs", GROUNDSPEAK_NS);
-        if (travelbugs == null) {
-            return;
-        }
-        final List<XmlNode> tbNodes = GPXUtils.gpxNodeChildren(travelbugs, "travelbug");
-        if (tbNodes == null) {
-            return;
-        }
-        for (final XmlNode tbNode : tbNodes) {
-            final Trackable trackable = new Trackable();
-            final String ref = GPXUtils.gpxNodeAttrValue(tbNode, "ref", GROUNDSPEAK_NS);
-            if (ref != null) {
-                trackable.setGeocode(ref);
-            }
-            final String tbName = GPXUtils.gpxNodeChildText(tbNode, "name", GROUNDSPEAK_NS);
-            if (tbName != null) {
-                trackable.setName(validate(tbName));
-            }
-            if (StringUtils.isNotBlank(trackable.getGeocode()) && StringUtils.isNotBlank(trackable.getName())) {
-                cache.addInventoryItem(trackable);
-            }
-        }
-    }
-
-    /**
-     * GSAK ("Geocaching Swiss Army Knife") wptExtension. Schema/namespace (6 historic versions, unified here by
-     * local name only): {@code http://www.gsak.net/xmlv1/1} through {@code /6}. Element {@code <wptExtension>}.
-     */
-    private void parseGsakExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode gsak = GPXUtils.gpxNodeChild(base, "wptExtension", GSAK_NS);
-        if (gsak == null) {
-            return;
-        }
-        final String watch = GPXUtils.gpxNodeChildText(gsak, "Watch", GSAK_NS);
-        if (watch != null) {
-            cache.setOnWatchlist(Boolean.parseBoolean(watch.trim()));
-        }
-        final String favPoints = GPXUtils.gpxNodeChildText(gsak, "FavPoints", GSAK_NS);
-        if (favPoints != null) {
-            try {
-                cache.setFavoritePoints(Integer.parseInt(favPoints.trim()));
-            } catch (final NumberFormatException ignored) {
-                // ignore malformed favorite points
-            }
-        }
-        final String gcNote = GPXUtils.gpxNodeChildText(gsak, "GcNote", GSAK_NS);
-        if (StringUtils.isNotBlank(gcNote)) {
-            cache.setPersonalNote(StringUtils.trim(gcNote), true);
-        }
-        final String isPremium = GPXUtils.gpxNodeChildText(gsak, "IsPremium", GSAK_NS);
-        if (isPremium != null) {
-            cache.setPremiumMembersOnly(Boolean.parseBoolean(isPremium.trim()));
-        }
-        final String code = GPXUtils.gpxNodeChildText(gsak, "Code", GSAK_NS);
-        if (StringUtils.isNotBlank(code)) {
-            cache.setGeocode(StringUtils.trim(code));
-        }
-        final String dnf = GPXUtils.gpxNodeChildText(gsak, "DNF", GSAK_NS);
-        if (dnf != null && !cache.isFound()) {
-            cache.setDNF(Boolean.parseBoolean(dnf.trim()));
-        }
-        final String dnfDate = GPXUtils.gpxNodeChildText(gsak, "DNFDate", GSAK_NS);
-        if (dnfDate != null && cache.getVisitedDate() == 0) {
-            final Date parsed = XmlUtils.parseDate(dnfDate);
-            if (parsed != null) {
-                cache.setVisitedDate(parsed.getTime());
-            }
-        }
-        final String userFound = GPXUtils.gpxNodeChildText(gsak, "UserFound", GSAK_NS);
-        if (userFound != null && cache.getVisitedDate() == 0) {
-            final Date parsed = XmlUtils.parseDate(userFound);
-            if (parsed != null) {
-                cache.setVisitedDate(parsed.getTime());
-            }
-        }
-
-        final StringBuilder userDataNote = new StringBuilder();
-        appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "UserData", GSAK_NS));
-        for (int i = 2; i <= 4; i++) {
-            appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "User" + i, GSAK_NS));
-        }
-        if (StringUtils.isBlank(cache.getPersonalNote()) && userDataNote.length() > 0) {
-            cache.setPersonalNote(userDataNote.toString().trim(), true);
-        }
-        final Geopoint originalCoords = XmlUtils.parseGeopoint(GPXUtils.gpxNodeChildText(gsak, "LatBeforeCorrect", GSAK_NS), GPXUtils.gpxNodeChildText(gsak, "LonBeforeCorrect", GSAK_NS), false);
-        if (originalCoords != null) {
-            final Waypoint original = new Waypoint(WaypointType.ORIGINAL.gpx, WaypointType.ORIGINAL, false);
-            original.setGeocode(cache.getGeocode());
-            original.setCoords(originalCoords);
-            cache.setWaypoints(Collections.singletonList(original));
-            cache.setUserModifiedCoords(true);
-        }
-    }
 
     private static boolean parseWaypointUserDefined(final XmlNode base) {
         boolean userDefined = false;
@@ -661,147 +382,6 @@ final class GPXFullWptParser {
         return userDefined;
     }
 
-    private static void appendUserData(final StringBuilder buffer, final String userData) {
-        if (StringUtils.isNotBlank(userData)) {
-            buffer.append(' ').append(userData);
-        }
-    }
-
-    /** TerraCaching extension. */
-    private void parseTerraCachingExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode terraCache = GPXUtils.gpxNodeChild(base, "terracache", TERRA_NS);
-        if (terraCache == null) {
-            return;
-        }
-        final String name = GPXUtils.gpxNodeChildText(terraCache, "name", TERRA_NS);
-        if (StringUtils.isNotBlank(name)) {
-            cache.setName(StringUtils.trim(name));
-        }
-        final String owner = GPXUtils.gpxNodeChildText(terraCache, "owner", TERRA_NS);
-        if (StringUtils.isNotBlank(owner)) {
-            cache.setOwnerDisplayName(validate(owner));
-        }
-        final String style = GPXUtils.gpxNodeChildText(terraCache, "style", TERRA_NS);
-        if (StringUtils.isNotBlank(style)) {
-            cache.setType(TerraCachingType.getCacheType(style));
-        }
-        final String size = GPXUtils.gpxNodeChildText(terraCache, "size", TERRA_NS);
-        if (StringUtils.isNotBlank(size)) {
-            cache.setSize(CacheSize.getById(size));
-        }
-        final String country = GPXUtils.gpxNodeChildText(terraCache, "country", TERRA_NS);
-        if (StringUtils.isNotBlank(country)) {
-            cache.setLocation(StringUtils.trim(country));
-        }
-        final String state = GPXUtils.gpxNodeChildText(terraCache, "state", TERRA_NS);
-        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
-            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
-        }
-        final String description = GPXUtils.gpxNodeChildText(terraCache, "description", TERRA_NS);
-        if (description != null) {
-            cache.setDescription(trimHtml(description));
-        }
-        final String hint = GPXUtils.gpxNodeChildText(terraCache, "hint", TERRA_NS);
-        if (hint != null) {
-            cache.setHint(HtmlUtils.extractText(hint));
-        }
-    }
-
-    /** TerraCaching logs ({@code <terracache><logs><log>...}). */
-    @Nullable
-    private List<LogEntry> parseTerraCachingLogs(final XmlNode terraCache) {
-        final XmlNode logsNode = GPXUtils.gpxNodeChild(terraCache, "logs", TERRA_NS);
-        if (logsNode == null) {
-            return null;
-        }
-        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
-        if (logNodes == null) {
-            return null;
-        }
-        final List<LogEntry> result = new ArrayList<>();
-        for (final XmlNode logNode : logNodes) {
-            final LogEntry.Builder builder = new LogEntry.Builder();
-            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", TERRA_NS);
-            if (idText != null) {
-                try {
-                    builder.setId(Integer.parseInt(idText.trim()));
-                } catch (final NumberFormatException ignored) {
-                    // ignore malformed id
-                }
-            }
-            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", TERRA_NS));
-            if (date != null) {
-                builder.setDate(date.getTime());
-            }
-            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", TERRA_NS);
-            if (typeText != null) {
-                builder.setLogType(TerraCachingLogType.getLogType(validate(typeText)));
-            }
-            final String finder = GPXUtils.gpxNodeChildText(logNode, "user", TERRA_NS);
-            if (finder != null) {
-                builder.setAuthor(validate(finder));
-            }
-            final String text = GPXUtils.gpxNodeChildText(logNode, "entry", TERRA_NS);
-            if (text != null) {
-                builder.setLog(trimHtml(validate(text)));
-            }
-            final LogEntry log = builder.build();
-            if (log.logType != LogType.UNKNOWN) {
-                result.add(log);
-            }
-        }
-        return result.isEmpty() ? null : result;
-    }
-
-    /** c:geo's own extension */
-    private void parseCgeoExtension(final XmlNode base, final Geocache cache) {
-        final String assignedEmojiText = GPXUtils.gpxNodeChildText(GPXUtils.gpxNodeChild(base, "cacheExtension", CGEO_NS), "assignedEmoji", CGEO_NS);
-        if (StringUtils.isNotBlank(assignedEmojiText)) {
-            cache.setAssignedEmoji(EmojiUtilsLegacyMigration.parseGpxAssignedEmoji(assignedEmojiText));
-        }
-    }
-
-    /** c:geo waypoint fields are siblings of cacheExtension, not children of it. */
-    private void parseCgeoExtension(final XmlNode base, final Waypoint waypoint) {
-        for (final XmlNode child : base.getChildrenInOrder()) {
-            if ("visited".equals(child.getLocalName())) {
-                waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
-            } else if ("originalCoordsEmpty".equals(child.getLocalName())) {
-                waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
-            }
-        }
-    }
-
-    /**
-     * Opencaching extension. Schema/namespace: {@code https://github.com/opencaching/gpx-extension-v1}. Element
-     * {@code <cache>}.
-     */
-    private void parseOpenCachingExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode ocCache = GPXUtils.gpxNodeChild(base, "cache", OPENCACHING_NS);
-        if (ocCache == null) {
-            return;
-        }
-        final String requiresPassword = GPXUtils.gpxNodeChildText(ocCache, "requires_password", OPENCACHING_NS);
-        if (requiresPassword != null) {
-            cache.setLogPasswordRequired(Boolean.parseBoolean(requiresPassword.trim()));
-        }
-        final String otherCode = GPXUtils.gpxNodeChildText(ocCache, "other_code", OPENCACHING_NS);
-        if (StringUtils.isNotBlank(otherCode)) {
-            cache.setDescription(Geocache.getAlternativeListingText(otherCode.trim()) + cache.getDescription());
-        }
-        final String size = GPXUtils.gpxNodeChildText(ocCache, "size", OPENCACHING_NS);
-        if (StringUtils.isNotBlank(size)) {
-            final CacheSize cacheSize = CacheSize.getById(size);
-            if (cacheSize != CacheSize.UNKNOWN) {
-                cache.setSize(cacheSize);
-            }
-        }
-    }
-
-    private static String trimHtml(final String html) {
-        return StringUtils.trim(Strings.CS.removeEnd(Strings.CS.removeStart(html, "<br>"), "<br>"));
-    }
-
     private static Geocache createCache() {
         final Geocache newCache = new Geocache();
         // explicitly set all properties which could otherwise lead to lazy database access on first read
@@ -812,13 +392,6 @@ final class GPXFullWptParser {
         newCache.setAttributes(Collections.emptyList());
         newCache.setWaypoints(Collections.emptyList());
         return newCache;
-    }
-
-    private static String validate(final String input) {
-        if ("nil".equalsIgnoreCase(input)) {
-            return "";
-        }
-        return input.trim();
     }
 
     @Nullable

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
@@ -154,7 +154,7 @@ final class GPXFullWptParser {
     /** Parses an entry without geocache or waypoint classification. */
     private static ICoordinate parseFallbackCoordinate(final String rawName, final XmlNode wptNode) {
         final Geopoint coords = XmlUtils.parseGeopoint(GPXUtils.gpxNodeAttrValue(wptNode, "lat", null), GPXUtils.gpxNodeAttrValue(wptNode, "lon", null), true);
-        final Float elevation = XmlUtils.parseFloat(wptNode.getChildValue("ele"));
+        final Float elevation = GPXUtils.gpxNodeChildFloat(wptNode, "ele", null, null);
         if (StringUtils.isBlank(rawName) && elevation == null) {
             return coords;
         }
@@ -190,8 +190,7 @@ final class GPXFullWptParser {
         if (StringUtils.isNotBlank(cmt)) {
             cache.setDescription(XmlUtils.validate(cmt));
         }
-        final String timeText = wptNode.getChildValue("time");
-        final Date hidden = XmlUtils.parseDate(timeText);
+        final Date hidden = GPXUtils.gpxNodeChildDate(wptNode, "time", null, null);
         if (hidden != null) {
             cache.setHidden(hidden);
         }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXFullWptParser.java
@@ -1,0 +1,839 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCUtils;
+import cgeo.geocaching.connector.tc.TerraCachingLogType;
+import cgeo.geocaching.connector.tc.TerraCachingType;
+import cgeo.geocaching.enumerations.CacheAttribute;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.ICoordinate;
+import cgeo.geocaching.models.NamedGeoCoordinate;
+import cgeo.geocaching.models.Trackable;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.models.WaypointUserNoteCombiner;
+import cgeo.geocaching.utils.EmojiUtilsLegacyMigration;
+import cgeo.geocaching.utils.html.HtmlUtils;
+import cgeo.geocaching.utils.xml.XmlNode;
+import cgeo.geocaching.utils.xml.XmlUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+
+/** Parses complete geocaches, waypoints and fallback coordinates for {@link GPXParser}. */
+final class GPXFullWptParser {
+
+    // Keep GUID-like Adventure Lab codes intact; provider recognition is delegated to ConnectorFactory.
+    private static final Pattern PATTERN_GEOCODE = Pattern.compile("(?<![\\p{L}\\p{N}_-])[A-Z0-9][A-Z0-9_-]*(?![\\p{L}\\p{N}_-])", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_URL_GEOCODE = Pattern.compile("[?&]wp=([^&#]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_URL_GUID = Pattern.compile("[?&]guid=([0-9a-f-]+)", Pattern.CASE_INSENSITIVE);
+
+    //Namespaces of extensions
+    private static final Set<String> GROUNDSPEAK_NS = Set.of(
+        "http://www.groundspeak.com/cache/1/1", // PQ 1.1
+        "http://www.groundspeak.com/cache/1/0/1", // PQ 1.0.1
+        "http://www.groundspeak.com/cache/1/0" // PQ 1.0
+    );
+
+    private static final Set<String> GSAK_NS = Set.of(
+        "http://www.gsak.net/xmlv1/1",
+        "http://www.gsak.net/xmlv1/2",
+        "http://www.gsak.net/xmlv1/3",
+        "http://www.gsak.net/xmlv1/4",
+        "http://www.gsak.net/xmlv1/5",
+        "http://www.gsak.net/xmlv1/6"
+    );
+
+    private static final Set<String> CGEO_NS = Set.of(
+        "http://www.cgeo.org/wptext/1/0"
+    );
+
+    private static final Set<String> OPENCACHING_NS = Set.of(
+        "https://github.com/opencaching/gpx-extension-v1"
+    );
+
+    private static final Set<String> TERRA_NS = Set.of(
+            "http://www.TerraCaching.com/GPX/1/0"
+    );
+
+    /** parse-session-scoped index: (lower-cased, trimmed) cache name/title -&gt; geocode */
+    private final Map<String, String> nameToGeocodeIndex = new HashMap<>();
+
+    /**
+     * Sticky, single-file-scoped flag:
+     * we can only detect TerraCaching child waypoints by remembering the state of the parent". TerraCaching
+     * marks the cache entry that precedes its own child-stage waypoints with {@code <desc>GC_WayPoint1</desc>};
+     * every following {@code wptType} entry with a "terracache" {@code sym} in the SAME document is then a
+     * child waypoint of that cache, not a new cache itself, until end of file (there is no reset marker).
+     */
+    private boolean terraChildWaypoint;
+
+    // Additional data for the most recently parsed entity, not stored in the entity itself.
+    private List<LogEntry> parsedLogs;
+    private String parsedParentGeocode;
+
+    /** Clears all parsing state, including the cross-file name index. */
+    void reset() {
+        nameToGeocodeIndex.clear();
+        resetDocument();
+    }
+
+    /** Clears document-specific state while retaining the cross-file name index. */
+    void resetDocument() {
+        terraChildWaypoint = false;
+        parsedLogs = null;
+        parsedParentGeocode = null;
+    }
+
+    /** Logs from the most recently parsed geocache, or null when none were parsed. */
+    @Nullable
+    List<LogEntry> getParsedLogs() {
+        return parsedLogs;
+    }
+
+    /** Unnormalized parent candidate for the most recently parsed waypoint, or null when unresolved. */
+    @Nullable
+    String getParsedParentGeocode() {
+        return parsedParentGeocode;
+    }
+
+    /**
+     * Parses a scanned wpt/rtept/trkpt subtree into a geocache, waypoint, named coordinate or plain coordinate.
+     */
+    @NonNull
+    ICoordinate parse(@NonNull final XmlNode wptNode, @Nullable final String scriptUrl) {
+        parsedLogs = null;
+        parsedParentGeocode = null;
+        final Geopoint coords = GPXUtils.gpxNodeReadLatLon(wptNode);
+
+        final String rawName = normalizeName(wptNode.getChildValue("name"), scriptUrl);
+        final String desc = wptNode.getChildValue("desc");
+        final String cmt = wptNode.getChildValue("cmt");
+        final String symRaw = wptNode.getChildValue("sym");
+        final String sym = symRaw == null ? null : symRaw.toLowerCase(Locale.US);
+        final String typeField = wptNode.getChildValue("type");
+        String type = null;
+        String subtype = null;
+        if (StringUtils.isNotBlank(typeField)) {
+            final String[] parts = StringUtils.split(typeField, '|');
+            if (parts.length > 0) {
+                type = parts[0].toLowerCase(Locale.US).trim();
+            }
+            if (parts.length > 1) {
+                subtype = parts[1].toLowerCase(Locale.US).trim();
+            }
+        }
+
+        // sticky state carried over from a PRECEDING sibling wpt (see terraChildWaypoint field doc)
+        final boolean wasTerraChildWaypoint = this.terraChildWaypoint;
+        final boolean isTerraChildWaypointMarker = "GC_WayPoint1".equals(StringUtils.trim(desc));
+
+        final XmlNode base = GPXUtils.extensionsBase(wptNode);
+        final boolean isGeocache = Strings.CI.contains(type, "geocache")
+                || Strings.CI.contains(sym, "geocache")
+                || Strings.CI.contains(sym, "waymark")
+                || (!wasTerraChildWaypoint && (Strings.CI.contains(sym, "terracache")
+                    || base.hasChild("cache") || base.hasChild("terracache")));
+        final boolean isWaypoint = !isGeocache && (Strings.CI.contains(type, "waypoint") || wasTerraChildWaypoint);
+
+        if (isTerraChildWaypointMarker) {
+            this.terraChildWaypoint = true;
+        }
+
+        if (isGeocache) {
+            return parseGeocache(wptNode, coords, rawName, desc, cmt);
+        } else if (isWaypoint) {
+            return parseWaypoint(wptNode, coords, rawName, sym, subtype, wasTerraChildWaypoint, scriptUrl);
+        } else {
+            // fallback: named or plain coordinate
+            return parseFallbackCoordinate(rawName, wptNode);
+        }
+    }
+
+    /** Parses an entry without geocache or waypoint classification. */
+    private static ICoordinate parseFallbackCoordinate(final String rawName, final XmlNode wptNode) {
+        final Geopoint coords = XmlUtils.parseGeopoint(GPXUtils.gpxNodeAttrValue(wptNode, "lat", null), GPXUtils.gpxNodeAttrValue(wptNode, "lon", null), true);
+        final Float elevation = XmlUtils.parseFloat(wptNode.getChildValue("ele"));
+        if (StringUtils.isBlank(rawName) && elevation == null) {
+            return coords;
+        }
+        final NamedGeoCoordinate named = new NamedGeoCoordinate();
+        named.setCoords(coords);
+        if (elevation != null) {
+            named.setElevation(elevation);
+        }
+        if (StringUtils.isNotBlank(rawName)) {
+            named.setName(rawName.trim());
+        }
+        return named;
+    }
+
+    /**
+     * A {@code wptType} classified as a geocache.
+     *
+     * @param coords may be {@code null} when the GPX has no valid coordinate pair
+     */
+    private Geocache parseGeocache(final XmlNode wptNode, @Nullable final Geopoint coords, final String rawName,
+                                 final String desc, final String cmt) {
+
+        final Geocache cache = createCache();
+        cache.setCoords(coords);
+        final String geocode = resolveGeocode(wptNode, rawName, desc, cmt);
+        cache.setGeocode(geocode == null ? "" : geocode);
+        if (StringUtils.isNotBlank(rawName)) {
+            cache.setName(rawName.trim());
+        }
+        if (StringUtils.isNotBlank(desc)) {
+            cache.setShortDescription(validate(desc));
+        }
+        if (StringUtils.isNotBlank(cmt)) {
+            cache.setDescription(validate(cmt));
+        }
+        final String timeText = wptNode.getChildValue("time");
+        final Date hidden = XmlUtils.parseDate(timeText);
+        if (hidden != null) {
+            cache.setHidden(hidden);
+        }
+        final String symbol = wptNode.getChildValue("sym");
+        if (Strings.CI.contains(symbol, "geocache") && Strings.CI.contains(symbol, "found")) {
+            cache.setFound(true);
+            cache.setDNF(false);
+        }
+        final String url = GPXUtils.readWaypointUrl(wptNode);
+        final String guid = matchUrl(PATTERN_URL_GUID, url);
+        if (guid != null) {
+            cache.setGuid(guid);
+        }
+
+        parsedLogs = parseGeocacheExtensions(wptNode, cache);
+        final String urlName = StringUtils.defaultIfBlank(wptNode.getChildValue("urlname"), GPXUtils.gpxNodeChildText(wptNode.getChild("link"), "text", null));
+        if (Strings.CI.startsWith(cache.getGeocode(), "WM") && cache.getName().equalsIgnoreCase(cache.getGeocode()) && StringUtils.isNotBlank(urlName)) {
+            cache.setName(urlName.trim());
+        }
+        if ("GC_WayPoint1".equals(cache.getShortDescription())) {
+            cache.setShortDescription("");
+        }
+        if (ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector) {
+            cache.setCacheId(Long.toString(GCUtils.gcCodeToGcId(cache.getGeocode())));
+        }
+
+        if (StringUtils.isNotBlank(cache.getGeocode()) && StringUtils.isNotBlank(cache.getName())) {
+            nameToGeocodeIndex.put(cache.getName().trim().toLowerCase(Locale.US), cache.getGeocode());
+        }
+
+        return cache;
+    }
+
+    /**
+     * Resolves a geocode purely from GPX-local information: first a geocode-looking pattern in the
+     * name, then in {@code desc}, then in {@code cmt}, then (as last resort) the trimmed name verbatim.
+     */
+    @Nullable
+    private static String resolveGeocode(final XmlNode wptNode, final String rawName, final String desc, final String cmt) {
+        String geocode = findGeoCode(rawName);
+        if (geocode == null) {
+            geocode = matchUrl(PATTERN_URL_GEOCODE, GPXUtils.readWaypointUrl(wptNode));
+        }
+        if (geocode == null) {
+            geocode = findGeoCode(desc);
+        }
+        if (geocode == null) {
+            geocode = findGeoCode(cmt);
+        }
+        if (geocode == null && StringUtils.isNotBlank(rawName)) {
+            geocode = rawName.trim();
+        }
+        return geocode;
+    }
+
+    private static String normalizeName(final String name, final String scriptUrl) {
+        final String trimmed = StringUtils.trim(name);
+        return Strings.CI.contains(scriptUrl, "extremcaching") && Strings.CI.startsWith(trimmed, "GCEC") ? trimmed.substring(2) : trimmed;
+    }
+
+    @Nullable
+    private static String matchUrl(final Pattern pattern, @Nullable final String url) {
+        if (url == null) {
+            return null;
+        }
+        final Matcher matcher = pattern.matcher(url);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    /** handles a {@code wptType} classified as a waypoint. */
+    private Waypoint parseWaypoint(final XmlNode wptNode, @Nullable final Geopoint coords, final String rawName,
+                                   final String sym, final String subtype, final boolean isTerraChildWaypoint, final String scriptUrl) {
+
+        final String parentGeocodeCandidate = resolveParentGeocode(wptNode, rawName, isTerraChildWaypoint, scriptUrl);
+
+        final String description = wptNode.getChildValue("desc");
+        final String name = "GC_WayPoint1".equals(StringUtils.trim(description)) ? ""
+                : validate(StringUtils.defaultIfBlank(description, StringUtils.trimToEmpty(rawName)));
+        final XmlNode base = GPXUtils.extensionsBase(wptNode);
+        final Waypoint waypoint = new Waypoint(name, WaypointType.fromGPXString(sym == null ? "" : sym, subtype), parseWaypointUserDefined(base));
+        waypoint.setId(Waypoint.NEW_ID);
+        waypoint.setCoords(coords);
+        waypoint.setLookup("---"); // GPX has no lookup code
+        if (parentGeocodeCandidate != null) {
+            waypoint.setGeocode(parentGeocodeCandidate);
+        }
+
+        parseCgeoExtension(base, waypoint);
+        if (!waypoint.isUserDefined() && coords == null) {
+            waypoint.setOriginalCoordsEmpty(true);
+        }
+        waypoint.setPrefix(resolveWaypointPrefix(rawName, parentGeocodeCandidate, waypoint.isUserDefined()));
+
+        final String note = wptNode.getChildValue("cmt");
+        if (StringUtils.isNotBlank(note)) {
+            new WaypointUserNoteCombiner(waypoint).updateNoteAndUserNote(validate(note));
+        }
+
+        parsedParentGeocode = parentGeocodeCandidate;
+        return waypoint;
+    }
+
+    private static String resolveWaypointPrefix(final String rawName, @Nullable final String parentGeocode, final boolean userDefined) {
+        String prefix = StringUtils.trimToEmpty(rawName);
+        if (userDefined) {
+            if (StringUtils.length(parentGeocode) > 2 && Strings.CI.endsWith(prefix, parentGeocode.substring(2))) {
+                prefix = prefix.substring(0, prefix.length() - parentGeocode.length() + 2);
+            }
+            prefix = Strings.CI.removeStart(prefix, Waypoint.PREFIX_OWN + "-");
+        }
+        return ConnectorFactory.getConnector(parentGeocode).getWaypointPrefix(prefix);
+    }
+
+    /**
+     * Best-effort resolution of a waypoint's parent geocache geocodefrom information available in the GPX document itself
+     */
+    @Nullable
+    private String resolveParentGeocode(final XmlNode wptNode, final String rawName, final boolean isTerraChildWaypoint, final String scriptUrl) {
+        final XmlNode extensions = GPXUtils.extensionsBase(wptNode);
+        final XmlNode gsakExt = GPXUtils.gpxNodeChild(extensions, "wptExtension", GSAK_NS);
+        final String gsakParent = GPXUtils.gpxNodeChildText(gsakExt, "Parent", GSAK_NS);
+        if (StringUtils.isNotBlank(gsakParent)) {
+            return nameToGeocodeIndex.getOrDefault(gsakParent.trim().toLowerCase(Locale.US), gsakParent.trim());
+        }
+
+        final String trimmedName = StringUtils.trim(rawName);
+        if (StringUtils.isBlank(trimmedName)) {
+            return null;
+        }
+
+        if (isTerraChildWaypoint) {
+            return trimmedName.length() > 1 ? trimmedName.substring(0, trimmedName.length() - 1) : null;
+        }
+
+        if (trimmedName.length() > 2) {
+            if (Strings.CI.contains(scriptUrl, "extremcaching")) {
+                return trimmedName.substring(2);
+            }
+            return "GC" + trimmedName.substring(2).toUpperCase(Locale.US);
+        }
+
+        return nameToGeocodeIndex.get(trimmedName.toLowerCase(Locale.US));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // extension parsing, one method per source
+    // ---------------------------------------------------------------------------------------------------
+
+    @Nullable
+    private List<LogEntry> parseGeocacheExtensions(final XmlNode wptNode, final Geocache cache) {
+        final XmlNode base = GPXUtils.extensionsBase(wptNode);
+        if (base == null) {
+            return null;
+        }
+        parseGroundspeakExtension(base, cache);
+        parseGsakExtension(base, cache);
+        parseTerraCachingExtension(base, cache);
+        parseCgeoExtension(base, cache);
+        parseOpenCachingExtension(base, cache);
+        final List<LogEntry> logs = new ArrayList<>();
+        for (final XmlNode child : base.getChildrenInOrder()) {
+            final List<LogEntry> sourceLogs;
+            if ("cache".equals(child.getLocalName())) {
+                sourceLogs = parseGroundspeakLogs(child, ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector);
+            } else if ("terracache".equals(child.getLocalName())) {
+                sourceLogs = parseTerraCachingLogs(child);
+            } else {
+                continue;
+            }
+            if (sourceLogs != null) {
+                logs.addAll(sourceLogs);
+            }
+        }
+        return logs.isEmpty() ? null : logs;
+    }
+
+    /**
+     * Groundspeak cache extension, used by geocaching.com pocket queries and most third-party tools (GSAK, ...).
+     * Schema/namespace (any of 3 historic versions, unified here by local name only): PQ 1.1
+     * {@code http://www.groundspeak.com/cache/1/1}, PQ 1.0.1 {@code http://www.groundspeak.com/cache/1/0/1},
+     * PQ 1.0 {@code http://www.groundspeak.com/cache/1/0}. Element {@code <cache>}.
+     */
+    private void parseGroundspeakExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode gcCache = GPXUtils.gpxNodeChild(base, "cache", GROUNDSPEAK_NS);
+        if (gcCache == null) {
+            return;
+        }
+        final String id = GPXUtils.gpxNodeAttrValue(gcCache, "id", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(id)) {
+            cache.setCacheId(id);
+        }
+        final String archived = GPXUtils.gpxNodeAttrValue(gcCache, "archived", GROUNDSPEAK_NS);
+        if (archived != null) {
+            cache.setArchived("true".equalsIgnoreCase(archived));
+        }
+        final String available = GPXUtils.gpxNodeAttrValue(gcCache, "available", GROUNDSPEAK_NS);
+        if (available != null) {
+            cache.setDisabled(!"true".equalsIgnoreCase(available));
+        }
+
+        final String name = GPXUtils.gpxNodeChildText(gcCache, "name", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(name)) {
+            cache.setName(validate(name));
+        }
+        final String owner = GPXUtils.gpxNodeChildText(gcCache, "owner", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(owner)) {
+            cache.setOwnerUserId(validate(owner));
+        }
+        final String placedBy = GPXUtils.gpxNodeChildText(gcCache, "placed_by", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(placedBy)) {
+            cache.setOwnerDisplayName(validate(placedBy));
+        }
+        final String gcType = GPXUtils.gpxNodeChildText(gcCache, "type", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(gcType)) {
+            String body = validate(gcType);
+            if (body.startsWith("Geocache|")) {
+                body = StringUtils.substringAfter(body, "Geocache|").trim();
+            }
+            cache.setType(CacheType.getByPattern(body));
+        }
+        final String container = GPXUtils.gpxNodeChildText(gcCache, "container", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(container)) {
+            cache.setSize(CacheSize.getById(validate(container)));
+        }
+        final Float difficulty = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "difficulty", GROUNDSPEAK_NS));
+        if (difficulty != null) {
+            cache.setDifficulty(difficulty);
+        }
+        final Float terrain = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "terrain", GROUNDSPEAK_NS));
+        if (terrain != null) {
+            cache.setTerrain(terrain);
+        }
+        final String country = GPXUtils.gpxNodeChildText(gcCache, "country", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(country)) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(country) : cache.getLocation() + ", " + country.trim());
+        }
+        final String state = GPXUtils.gpxNodeChildText(gcCache, "state", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
+        }
+        final String hints = GPXUtils.gpxNodeChildText(gcCache, "encoded_hints", GROUNDSPEAK_NS);
+        if (hints != null) {
+            cache.setHint(validate(hints));
+        }
+        final String shortDesc = GPXUtils.gpxNodeChildText(gcCache, "short_description", GROUNDSPEAK_NS);
+        if (shortDesc != null) {
+            cache.setShortDescription(validate(shortDesc));
+        }
+        final String longDesc = GPXUtils.gpxNodeChildText(gcCache, "long_description", GROUNDSPEAK_NS);
+        if (longDesc != null) {
+            cache.setDescription(validate(longDesc));
+        }
+
+        parseGroundspeakAttributes(gcCache, cache);
+        parseGroundspeakTravelbugs(gcCache, cache);
+    }
+
+    /**
+     * Groundspeak logs ({@code <groundspeak:logs><groundspeak:log>...}). Same schema/namespace as
+     * {@link #parseGroundspeakExtension}.
+     */
+    @Nullable
+    private List<LogEntry> parseGroundspeakLogs(final XmlNode gcCache, final boolean gcConnector) {
+        final XmlNode logsNode = GPXUtils.gpxNodeChild(gcCache, "logs", GROUNDSPEAK_NS);
+        if (logsNode == null) {
+            return null;
+        }
+        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
+        if (logNodes == null) {
+            return null;
+        }
+        final List<LogEntry> result = new ArrayList<>();
+        for (final XmlNode logNode : logNodes) {
+            final LogEntry.Builder builder = new LogEntry.Builder();
+            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", GROUNDSPEAK_NS);
+            if (idText != null) {
+                try {
+                    builder.setId(Integer.parseInt(idText.trim()));
+                    if (gcConnector) {
+                        builder.setServiceLogId(GCUtils.logIdToLogCode(builder.getId()));
+                    }
+                } catch (final NumberFormatException ignored) {
+                    // ignore malformed id
+                }
+            }
+            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", GROUNDSPEAK_NS));
+            if (date != null) {
+                builder.setDate(date.getTime());
+            }
+            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", GROUNDSPEAK_NS);
+            if (typeText != null) {
+                builder.setLogType(LogType.getByType(validate(typeText)));
+            }
+            final String finder = GPXUtils.gpxNodeChildText(logNode, "finder", GROUNDSPEAK_NS);
+            if (finder != null) {
+                builder.setAuthor(validate(finder));
+            }
+            final String text = GPXUtils.gpxNodeChildText(logNode, "text", GROUNDSPEAK_NS);
+            if (text != null) {
+                builder.setLog(validate(text));
+            }
+            final LogEntry log = builder.build();
+            if (log.logType != LogType.UNKNOWN) {
+                result.add(log);
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    private void parseGroundspeakAttributes(final XmlNode gcCache, final Geocache cache) {
+        final XmlNode attributes = GPXUtils.gpxNodeChild(gcCache, "attributes", GROUNDSPEAK_NS);
+        if (attributes == null) {
+            return;
+        }
+        final List<XmlNode> attributeNodes = GPXUtils.gpxNodeChildren(attributes, "attribute");
+        if (attributeNodes == null) {
+            return;
+        }
+        final List<String> result = new ArrayList<>();
+        for (final XmlNode attributeNode : attributeNodes) {
+            final String idText = GPXUtils.gpxNodeAttrValue(attributeNode, "id", GROUNDSPEAK_NS);
+            final String incText = GPXUtils.gpxNodeAttrValue(attributeNode, "inc", GROUNDSPEAK_NS);
+            if (idText == null || incText == null) {
+                continue;
+            }
+            try {
+                final int attributeId = Integer.parseInt(idText.trim());
+                final boolean active = Integer.parseInt(incText.trim()) != 0;
+                final CacheAttribute attribute = CacheAttribute.getById(attributeId);
+                if (attribute != null) {
+                    result.add(attribute.getValue(active));
+                }
+            } catch (final NumberFormatException ignored) {
+                // ignore malformed attribute entries
+            }
+        }
+        cache.setAttributes(result);
+    }
+
+    private void parseGroundspeakTravelbugs(final XmlNode gcCache, final Geocache cache) {
+        final XmlNode travelbugs = GPXUtils.gpxNodeChild(gcCache, "travelbugs", GROUNDSPEAK_NS);
+        if (travelbugs == null) {
+            return;
+        }
+        final List<XmlNode> tbNodes = GPXUtils.gpxNodeChildren(travelbugs, "travelbug");
+        if (tbNodes == null) {
+            return;
+        }
+        for (final XmlNode tbNode : tbNodes) {
+            final Trackable trackable = new Trackable();
+            final String ref = GPXUtils.gpxNodeAttrValue(tbNode, "ref", GROUNDSPEAK_NS);
+            if (ref != null) {
+                trackable.setGeocode(ref);
+            }
+            final String tbName = GPXUtils.gpxNodeChildText(tbNode, "name", GROUNDSPEAK_NS);
+            if (tbName != null) {
+                trackable.setName(validate(tbName));
+            }
+            if (StringUtils.isNotBlank(trackable.getGeocode()) && StringUtils.isNotBlank(trackable.getName())) {
+                cache.addInventoryItem(trackable);
+            }
+        }
+    }
+
+    /**
+     * GSAK ("Geocaching Swiss Army Knife") wptExtension. Schema/namespace (6 historic versions, unified here by
+     * local name only): {@code http://www.gsak.net/xmlv1/1} through {@code /6}. Element {@code <wptExtension>}.
+     */
+    private void parseGsakExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode gsak = GPXUtils.gpxNodeChild(base, "wptExtension", GSAK_NS);
+        if (gsak == null) {
+            return;
+        }
+        final String watch = GPXUtils.gpxNodeChildText(gsak, "Watch", GSAK_NS);
+        if (watch != null) {
+            cache.setOnWatchlist(Boolean.parseBoolean(watch.trim()));
+        }
+        final String favPoints = GPXUtils.gpxNodeChildText(gsak, "FavPoints", GSAK_NS);
+        if (favPoints != null) {
+            try {
+                cache.setFavoritePoints(Integer.parseInt(favPoints.trim()));
+            } catch (final NumberFormatException ignored) {
+                // ignore malformed favorite points
+            }
+        }
+        final String gcNote = GPXUtils.gpxNodeChildText(gsak, "GcNote", GSAK_NS);
+        if (StringUtils.isNotBlank(gcNote)) {
+            cache.setPersonalNote(StringUtils.trim(gcNote), true);
+        }
+        final String isPremium = GPXUtils.gpxNodeChildText(gsak, "IsPremium", GSAK_NS);
+        if (isPremium != null) {
+            cache.setPremiumMembersOnly(Boolean.parseBoolean(isPremium.trim()));
+        }
+        final String code = GPXUtils.gpxNodeChildText(gsak, "Code", GSAK_NS);
+        if (StringUtils.isNotBlank(code)) {
+            cache.setGeocode(StringUtils.trim(code));
+        }
+        final String dnf = GPXUtils.gpxNodeChildText(gsak, "DNF", GSAK_NS);
+        if (dnf != null && !cache.isFound()) {
+            cache.setDNF(Boolean.parseBoolean(dnf.trim()));
+        }
+        final String dnfDate = GPXUtils.gpxNodeChildText(gsak, "DNFDate", GSAK_NS);
+        if (dnfDate != null && cache.getVisitedDate() == 0) {
+            final Date parsed = XmlUtils.parseDate(dnfDate);
+            if (parsed != null) {
+                cache.setVisitedDate(parsed.getTime());
+            }
+        }
+        final String userFound = GPXUtils.gpxNodeChildText(gsak, "UserFound", GSAK_NS);
+        if (userFound != null && cache.getVisitedDate() == 0) {
+            final Date parsed = XmlUtils.parseDate(userFound);
+            if (parsed != null) {
+                cache.setVisitedDate(parsed.getTime());
+            }
+        }
+
+        final StringBuilder userDataNote = new StringBuilder();
+        appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "UserData", GSAK_NS));
+        for (int i = 2; i <= 4; i++) {
+            appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "User" + i, GSAK_NS));
+        }
+        if (StringUtils.isBlank(cache.getPersonalNote()) && userDataNote.length() > 0) {
+            cache.setPersonalNote(userDataNote.toString().trim(), true);
+        }
+        final Geopoint originalCoords = XmlUtils.parseGeopoint(GPXUtils.gpxNodeChildText(gsak, "LatBeforeCorrect", GSAK_NS), GPXUtils.gpxNodeChildText(gsak, "LonBeforeCorrect", GSAK_NS), false);
+        if (originalCoords != null) {
+            final Waypoint original = new Waypoint(WaypointType.ORIGINAL.gpx, WaypointType.ORIGINAL, false);
+            original.setGeocode(cache.getGeocode());
+            original.setCoords(originalCoords);
+            cache.setWaypoints(Collections.singletonList(original));
+            cache.setUserModifiedCoords(true);
+        }
+    }
+
+    private static boolean parseWaypointUserDefined(final XmlNode base) {
+        boolean userDefined = false;
+        for (final XmlNode child : base.getChildrenInOrder()) {
+            if ("userdefined".equals(child.getLocalName())) {
+                userDefined = Boolean.parseBoolean(StringUtils.trim(child.getValue()));
+            } else if ("wptExtension".equals(child.getLocalName())) {
+                for (final XmlNode field : child.getChildrenInOrder()) {
+                    if ("Child_ByGSAK".equals(field.getLocalName())) {
+                        userDefined |= Boolean.parseBoolean(StringUtils.trim(field.getValue()));
+                    }
+                }
+            }
+        }
+        return userDefined;
+    }
+
+    private static void appendUserData(final StringBuilder buffer, final String userData) {
+        if (StringUtils.isNotBlank(userData)) {
+            buffer.append(' ').append(userData);
+        }
+    }
+
+    /** TerraCaching extension. */
+    private void parseTerraCachingExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode terraCache = GPXUtils.gpxNodeChild(base, "terracache", TERRA_NS);
+        if (terraCache == null) {
+            return;
+        }
+        final String name = GPXUtils.gpxNodeChildText(terraCache, "name", TERRA_NS);
+        if (StringUtils.isNotBlank(name)) {
+            cache.setName(StringUtils.trim(name));
+        }
+        final String owner = GPXUtils.gpxNodeChildText(terraCache, "owner", TERRA_NS);
+        if (StringUtils.isNotBlank(owner)) {
+            cache.setOwnerDisplayName(validate(owner));
+        }
+        final String style = GPXUtils.gpxNodeChildText(terraCache, "style", TERRA_NS);
+        if (StringUtils.isNotBlank(style)) {
+            cache.setType(TerraCachingType.getCacheType(style));
+        }
+        final String size = GPXUtils.gpxNodeChildText(terraCache, "size", TERRA_NS);
+        if (StringUtils.isNotBlank(size)) {
+            cache.setSize(CacheSize.getById(size));
+        }
+        final String country = GPXUtils.gpxNodeChildText(terraCache, "country", TERRA_NS);
+        if (StringUtils.isNotBlank(country)) {
+            cache.setLocation(StringUtils.trim(country));
+        }
+        final String state = GPXUtils.gpxNodeChildText(terraCache, "state", TERRA_NS);
+        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
+        }
+        final String description = GPXUtils.gpxNodeChildText(terraCache, "description", TERRA_NS);
+        if (description != null) {
+            cache.setDescription(trimHtml(description));
+        }
+        final String hint = GPXUtils.gpxNodeChildText(terraCache, "hint", TERRA_NS);
+        if (hint != null) {
+            cache.setHint(HtmlUtils.extractText(hint));
+        }
+    }
+
+    /** TerraCaching logs ({@code <terracache><logs><log>...}). */
+    @Nullable
+    private List<LogEntry> parseTerraCachingLogs(final XmlNode terraCache) {
+        final XmlNode logsNode = GPXUtils.gpxNodeChild(terraCache, "logs", TERRA_NS);
+        if (logsNode == null) {
+            return null;
+        }
+        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
+        if (logNodes == null) {
+            return null;
+        }
+        final List<LogEntry> result = new ArrayList<>();
+        for (final XmlNode logNode : logNodes) {
+            final LogEntry.Builder builder = new LogEntry.Builder();
+            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", TERRA_NS);
+            if (idText != null) {
+                try {
+                    builder.setId(Integer.parseInt(idText.trim()));
+                } catch (final NumberFormatException ignored) {
+                    // ignore malformed id
+                }
+            }
+            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", TERRA_NS));
+            if (date != null) {
+                builder.setDate(date.getTime());
+            }
+            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", TERRA_NS);
+            if (typeText != null) {
+                builder.setLogType(TerraCachingLogType.getLogType(validate(typeText)));
+            }
+            final String finder = GPXUtils.gpxNodeChildText(logNode, "user", TERRA_NS);
+            if (finder != null) {
+                builder.setAuthor(validate(finder));
+            }
+            final String text = GPXUtils.gpxNodeChildText(logNode, "entry", TERRA_NS);
+            if (text != null) {
+                builder.setLog(trimHtml(validate(text)));
+            }
+            final LogEntry log = builder.build();
+            if (log.logType != LogType.UNKNOWN) {
+                result.add(log);
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    /** c:geo's own extension */
+    private void parseCgeoExtension(final XmlNode base, final Geocache cache) {
+        final String assignedEmojiText = GPXUtils.gpxNodeChildText(GPXUtils.gpxNodeChild(base, "cacheExtension", CGEO_NS), "assignedEmoji", CGEO_NS);
+        if (StringUtils.isNotBlank(assignedEmojiText)) {
+            cache.setAssignedEmoji(EmojiUtilsLegacyMigration.parseGpxAssignedEmoji(assignedEmojiText));
+        }
+    }
+
+    /** c:geo waypoint fields are siblings of cacheExtension, not children of it. */
+    private void parseCgeoExtension(final XmlNode base, final Waypoint waypoint) {
+        for (final XmlNode child : base.getChildrenInOrder()) {
+            if ("visited".equals(child.getLocalName())) {
+                waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
+            } else if ("originalCoordsEmpty".equals(child.getLocalName())) {
+                waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
+            }
+        }
+    }
+
+    /**
+     * Opencaching extension. Schema/namespace: {@code https://github.com/opencaching/gpx-extension-v1}. Element
+     * {@code <cache>}.
+     */
+    private void parseOpenCachingExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode ocCache = GPXUtils.gpxNodeChild(base, "cache", OPENCACHING_NS);
+        if (ocCache == null) {
+            return;
+        }
+        final String requiresPassword = GPXUtils.gpxNodeChildText(ocCache, "requires_password", OPENCACHING_NS);
+        if (requiresPassword != null) {
+            cache.setLogPasswordRequired(Boolean.parseBoolean(requiresPassword.trim()));
+        }
+        final String otherCode = GPXUtils.gpxNodeChildText(ocCache, "other_code", OPENCACHING_NS);
+        if (StringUtils.isNotBlank(otherCode)) {
+            cache.setDescription(Geocache.getAlternativeListingText(otherCode.trim()) + cache.getDescription());
+        }
+        final String size = GPXUtils.gpxNodeChildText(ocCache, "size", OPENCACHING_NS);
+        if (StringUtils.isNotBlank(size)) {
+            final CacheSize cacheSize = CacheSize.getById(size);
+            if (cacheSize != CacheSize.UNKNOWN) {
+                cache.setSize(cacheSize);
+            }
+        }
+    }
+
+    private static String trimHtml(final String html) {
+        return StringUtils.trim(Strings.CS.removeEnd(Strings.CS.removeStart(html, "<br>"), "<br>"));
+    }
+
+    private static Geocache createCache() {
+        final Geocache newCache = new Geocache();
+        // explicitly set all properties which could otherwise lead to lazy database access on first read
+        newCache.setLocation("");
+        newCache.setDescription("");
+        newCache.setShortDescription("");
+        newCache.setHint("");
+        newCache.setAttributes(Collections.emptyList());
+        newCache.setWaypoints(Collections.emptyList());
+        return newCache;
+    }
+
+    private static String validate(final String input) {
+        if ("nil".equalsIgnoreCase(input)) {
+            return "";
+        }
+        return input.trim();
+    }
+
+    @Nullable
+    private static String findGeoCode(final String input) {
+        if (input == null) {
+            return null;
+        }
+        final Matcher matcher = PATTERN_GEOCODE.matcher(input);
+        while (matcher.find()) {
+            final String geocode = matcher.group().toUpperCase(Locale.US);
+            if (ConnectorFactory.getConnector(geocode) != ConnectorFactory.UNKNOWN_CONNECTOR) {
+                return geocode;
+            }
+        }
+        return null;
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
@@ -1,48 +1,19 @@
 package cgeo.geocaching.utils.gpx;
 
-import cgeo.geocaching.connector.ConnectorFactory;
-import cgeo.geocaching.connector.gc.GCConnector;
-import cgeo.geocaching.connector.gc.GCUtils;
-import cgeo.geocaching.connector.tc.TerraCachingLogType;
-import cgeo.geocaching.connector.tc.TerraCachingType;
-import cgeo.geocaching.enumerations.CacheAttribute;
-import cgeo.geocaching.enumerations.CacheSize;
-import cgeo.geocaching.enumerations.CacheType;
-import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
-import cgeo.geocaching.log.LogEntry;
-import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.ICoordinate;
 import cgeo.geocaching.models.NamedGeoCoordinate;
-import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.models.Waypoint;
-import cgeo.geocaching.models.WaypointUserNoteCombiner;
-import cgeo.geocaching.utils.EmojiUtilsLegacyMigration;
-import cgeo.geocaching.utils.html.HtmlUtils;
 import cgeo.geocaching.utils.xml.XmlNode;
 import cgeo.geocaching.utils.xml.XmlUtils;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Strings;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -66,52 +37,11 @@ import org.xmlpull.v1.XmlPullParserException;
  */
 public class GPXParser {
 
-    // Keep GUID-like Adventure Lab codes intact; provider recognition is delegated to ConnectorFactory.
-    private static final Pattern PATTERN_GEOCODE = Pattern.compile("(?<![\\p{L}\\p{N}_-])[A-Z0-9][A-Z0-9_-]*(?![\\p{L}\\p{N}_-])", Pattern.CASE_INSENSITIVE);
-    private static final Pattern PATTERN_URL_GEOCODE = Pattern.compile("[?&]wp=([^&#]+)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern PATTERN_URL_GUID = Pattern.compile("[?&]guid=([0-9a-f-]+)", Pattern.CASE_INSENSITIVE);
-
-    //Namespaces of extensions
-    private static final Set<String> GROUNDSPEAK_NS = Set.of(
-        "http://www.groundspeak.com/cache/1/1", // PQ 1.1
-        "http://www.groundspeak.com/cache/1/0/1", // PQ 1.0.1
-        "http://www.groundspeak.com/cache/1/0" // PQ 1.0
-    );
-
-    private static final Set<String> GSAK_NS = Set.of(
-        "http://www.gsak.net/xmlv1/1",
-        "http://www.gsak.net/xmlv1/2",
-        "http://www.gsak.net/xmlv1/3",
-        "http://www.gsak.net/xmlv1/4",
-        "http://www.gsak.net/xmlv1/5",
-        "http://www.gsak.net/xmlv1/6"
-    );
-
-    private static final Set<String> CGEO_NS = Set.of(
-        "http://www.cgeo.org/wptext/1/0"
-    );
-
-    private static final Set<String> OPENCACHING_NS = Set.of(
-        "https://github.com/opencaching/gpx-extension-v1"
-    );
-
-    private static final Set<String> TERRA_NS = Set.of(
-            "http://www.TerraCaching.com/GPX/1/0"
-    );
+    private GPXFullWptParser fullWptParser;
 
     private ParseMode mode = ParseMode.FULL;
 
-    /** parse-session-scoped index: (lower-cased, trimmed) cache name/title -&gt; geocode */
-    private final Map<String, String> nameToGeocodeIndex = new HashMap<>();
-
-    /**
-     * Sticky, single-file-scoped flag:
-     * we can only detect TerraCaching child waypoints by remembering the state of the parent". TerraCaching
-     * marks the cache entry that precedes its own child-stage waypoints with {@code <desc>GC_WayPoint1</desc>};
-     * every following {@code wptType} entry with a "terracache" {@code sym} in the SAME document is then a
-     * child waypoint of that cache, not a new cache itself, until end of file (there is no reset marker).
-     */
-    private boolean terraChildWaypoint;
+    // Retain document metadata even before the first FULL point is encountered.
     private String scriptUrl;
 
     private IGPXParseHooks hooks;
@@ -139,16 +69,17 @@ public class GPXParser {
 
     /** Clears this instance's session-scoped state (esp the cross-file name→geocode index). */
     public GPXParser reset() {
-        nameToGeocodeIndex.clear();
-        terraChildWaypoint = false;
+        if (fullWptParser != null) {
+            fullWptParser.reset();
+        }
         scriptUrl = null;
         return this;
     }
 
     /** Parses the given stream as GPX, notifying {@code hooks} about business elements found. */
-    public void parse(@NonNull final InputStream stream, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
+    public boolean parse(@NonNull final InputStream stream, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
         final XmlPullParser parser = XmlUtils.createParser(stream, true);
-        parse(parser, hooks);
+        return parse(parser, hooks);
     }
 
     /**
@@ -159,13 +90,15 @@ public class GPXParser {
      */
     public boolean parse(@NonNull final XmlPullParser parser, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
         this.hooks = hooks;
-        this.terraChildWaypoint = false;
+        if (fullWptParser != null) {
+            fullWptParser.resetDocument();
+        }
         this.scriptUrl = null;
 
         try {
             int event = parser.getEventType();
             while (event != XmlPullParser.END_DOCUMENT) {
-                if (event == XmlPullParser.START_TAG && "gpx".equals(localName(parser.getName()))) {
+                if (event == XmlPullParser.START_TAG && "gpx".equals(GPXUtils.localName(parser.getName()))) {
                     handleGpx(parser);
                     return true;
                 }
@@ -178,14 +111,14 @@ public class GPXParser {
     }
 
     private void handleGpx(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        final String creator = attr(parser, "creator");
+        final String creator = GPXUtils.attr(parser, "creator");
         scriptUrl = creator;
         adjustParsemode(hooks.onInit(creator));
 
         int event = parser.next();
-        while (!(event == XmlPullParser.END_TAG && "gpx".equals(localName(parser.getName())))) {
+        while (!(event == XmlPullParser.END_TAG && "gpx".equals(GPXUtils.localName(parser.getName())))) {
             if (event == XmlPullParser.START_TAG) {
-                final String name = localName(parser.getName());
+                final String name = GPXUtils.localName(parser.getName());
                 if ("wpt".equals(name)) {
                     dispatchWptType(parser);
                 } else if ("rte".equals(name)) {
@@ -193,15 +126,15 @@ public class GPXParser {
                 } else if ("trk".equals(name)) {
                     handleTrack(parser);
                 } else if ("url".equals(name) || "creator".equals(name)) {
-                    scriptUrl = readText(parser);
+                    scriptUrl = XmlUtils.parseText(parser);
                 } else if ("metadata".equals(name)) {
                     final XmlNode metadata = XmlNode.scanNode(parser);
-                    final String url = readLinkUrl(metadata.getChild("link"));
+                    final String url = GPXUtils.readLinkUrl(metadata.getChild("link"));
                     if (StringUtils.isNotBlank(url)) {
                         scriptUrl = url;
                     }
                 } else {
-                    skipSubtree(parser);
+                    XmlUtils.skipSubtree(parser);
                 }
             }
             event = parser.next();
@@ -218,16 +151,16 @@ public class GPXParser {
         int pointCount = 0;
 
         int event = parser.next();
-        while (!(event == XmlPullParser.END_TAG && "rte".equals(localName(parser.getName())))) {
+        while (!(event == XmlPullParser.END_TAG && "rte".equals(GPXUtils.localName(parser.getName())))) {
             if (event == XmlPullParser.START_TAG) {
-                final String name = localName(parser.getName());
+                final String name = GPXUtils.localName(parser.getName());
                 if ("name".equals(name)) {
-                    routeName = readText(parser);
+                    routeName = XmlUtils.parseText(parser);
                 } else if ("rtept".equals(name)) {
                     dispatchWptType(parser);
                     pointCount++;
                 } else {
-                    skipSubtree(parser);
+                    XmlUtils.skipSubtree(parser);
                 }
             }
             event = parser.next();
@@ -246,16 +179,16 @@ public class GPXParser {
         int totalPointCount = 0;
 
         int event = parser.next();
-        while (!(event == XmlPullParser.END_TAG && "trk".equals(localName(parser.getName())))) {
+        while (!(event == XmlPullParser.END_TAG && "trk".equals(GPXUtils.localName(parser.getName())))) {
             if (event == XmlPullParser.START_TAG) {
-                final String name = localName(parser.getName());
+                final String name = GPXUtils.localName(parser.getName());
                 if ("name".equals(name)) {
-                    trackName = readText(parser);
+                    trackName = XmlUtils.parseText(parser);
                 } else if ("trkseg".equals(name)) {
                     totalPointCount += handleTrackSegment(parser);
                     segmentCount++;
                 } else {
-                    skipSubtree(parser);
+                    XmlUtils.skipSubtree(parser);
                 }
             }
             event = parser.next();
@@ -270,16 +203,16 @@ public class GPXParser {
         int pointCount = 0;
 
         int event = parser.next();
-        while (!(event == XmlPullParser.END_TAG && "trkseg".equals(localName(parser.getName())))) {
+        while (!(event == XmlPullParser.END_TAG && "trkseg".equals(GPXUtils.localName(parser.getName())))) {
             if (event == XmlPullParser.START_TAG) {
-                final String name = localName(parser.getName());
+                final String name = GPXUtils.localName(parser.getName());
                 if ("name".equals(name)) {
-                    segmentName = readText(parser);
+                    segmentName = XmlUtils.parseText(parser);
                 } else if ("trkpt".equals(name)) {
                     dispatchWptType(parser);
                     pointCount++;
                 } else {
-                    skipSubtree(parser);
+                    XmlUtils.skipSubtree(parser);
                 }
             }
             event = parser.next();
@@ -289,16 +222,29 @@ public class GPXParser {
     }
 
     /**
-     * Handles a single {@code rtept}/{@code trkpt} according to the given (already-resolved) {@link ParseMode}.
+     * Handles a single {@code wpt}/{@code rtept}/{@code trkpt} according to the given (already-resolved) {@link ParseMode}.
      * Fires the appropriate hook(s) for the point, if any.
      */
     private void dispatchWptType(final XmlPullParser parser) throws IOException, XmlPullParserException {
         if (this.mode == ParseMode.SKIP) {
-            skipSubtree(parser);
+            XmlUtils.skipSubtree(parser);
         } else if (this.mode == ParseMode.COORDINATES_ONLY) {
             dispatchWptTypeCoordinateOnly(parser);
         } else {
-            dispatchWptTypeFull(parser);
+            if (fullWptParser == null) {
+                fullWptParser = new GPXFullWptParser();
+            }
+            final XmlNode wptNode = XmlNode.scanNode(parser);
+            final ICoordinate entity = fullWptParser.parse(wptNode, scriptUrl);
+            if (entity instanceof Geocache) {
+                adjustParsemode(hooks.onGeocache((Geocache) entity, fullWptParser.getParsedLogs()));
+            } else if (entity instanceof Waypoint) {
+                adjustParsemode(hooks.onWaypoint((Waypoint) entity, fullWptParser.getParsedParentGeocode()));
+            } else if (entity instanceof NamedGeoCoordinate) {
+                adjustParsemode(hooks.onNamedCoordinate((NamedGeoCoordinate) entity));
+            } else {
+                adjustParsemode(hooks.onCoordinate(entity));
+            }
         }
     }
 
@@ -306,20 +252,20 @@ public class GPXParser {
      * lightweight, non-buffering read of a wpt/rtept/trkpt when only coordinates are wanted (ParseMode.COORDINATES_ONLY)
      */
     private void dispatchWptTypeCoordinateOnly(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        final Geopoint coords = toGeopoint(attr(parser, "lat"), attr(parser, "lon"), true);
+        final Geopoint coords = XmlUtils.parseGeopoint(GPXUtils.attr(parser, "lat"), GPXUtils.attr(parser, "lon"), true);
 
         String name = null;
         Float elevation = null;
         int event = parser.next();
         while (event != XmlPullParser.END_TAG) {
             if (event == XmlPullParser.START_TAG) {
-                final String childName = localName(parser.getName());
+                final String childName = GPXUtils.localName(parser.getName());
                 if ("name".equals(childName)) {
-                    name = readText(parser);
+                    name = XmlUtils.parseText(parser);
                 } else if ("ele".equals(childName)) {
-                    elevation = parseFloatSafe(readText(parser));
+                    elevation = XmlUtils.parseFloat(XmlUtils.parseText(parser));
                 } else {
-                    skipSubtree(parser);
+                    XmlUtils.skipSubtree(parser);
                 }
             }
             event = parser.next();
@@ -340,859 +286,6 @@ public class GPXParser {
         }
     }
 
-    /**
-     * FULL scan of a wpt/rtept/trkpt subtree, classifying it as geocache / waypoint / named coordinate / plain coordinate and firing the appropriate hook.
-     */
-    private void dispatchWptTypeFull(final XmlPullParser parser) throws XmlPullParserException, IOException {
-        final XmlNode wptNode = XmlNode.scanNode(parser);
-        final Geopoint coords = xmlNodeReadLatLon(wptNode);
-
-        final String rawName = normalizeName(wptNode.getChildValue("name"));
-        final String desc = wptNode.getChildValue("desc");
-        final String cmt = wptNode.getChildValue("cmt");
-        final String symRaw = wptNode.getChildValue("sym");
-        final String sym = symRaw == null ? null : symRaw.toLowerCase(Locale.US);
-        final String typeField = wptNode.getChildValue("type");
-        String type = null;
-        String subtype = null;
-        if (StringUtils.isNotBlank(typeField)) {
-            final String[] parts = StringUtils.split(typeField, '|');
-            if (parts.length > 0) {
-                type = parts[0].toLowerCase(Locale.US).trim();
-            }
-            if (parts.length > 1) {
-                subtype = parts[1].toLowerCase(Locale.US).trim();
-            }
-        }
-
-        // sticky state carried over from a PRECEDING sibling wpt (see terraChildWaypoint field doc)
-        final boolean wasTerraChildWaypoint = this.terraChildWaypoint;
-        final boolean isTerraChildWaypointMarker = "GC_WayPoint1".equals(StringUtils.trim(desc));
-
-        final XmlNode base = extensionsBase(wptNode);
-        final boolean isGeocache = Strings.CI.contains(type, "geocache")
-                || Strings.CI.contains(sym, "geocache")
-                || Strings.CI.contains(sym, "waymark")
-                || (!wasTerraChildWaypoint && (Strings.CI.contains(sym, "terracache")
-                    || base.hasChild("cache") || base.hasChild("terracache")));
-        final boolean isWaypoint = !isGeocache && (Strings.CI.contains(type, "waypoint") || wasTerraChildWaypoint);
-
-        if (isTerraChildWaypointMarker) {
-            this.terraChildWaypoint = true;
-        }
-
-        if (isGeocache) {
-            dispatchGeocache(wptNode, coords, rawName, desc, cmt);
-        } else if (isWaypoint) {
-            dispatchWaypoint(wptNode, coords, rawName, sym, subtype, wasTerraChildWaypoint);
-        } else {
-            // fallback: named or plain coordinate
-            dispatchFallbackCoordinate(rawName, wptNode);
-        }
-    }
-
-    /** Fires {@link IGPXParseHooks#onCoordinate}/{@link IGPXParseHooks#onNamedCoordinate} as appropriate. */
-    private void dispatchFallbackCoordinate(final String rawName, final XmlNode wptNode) {
-        final Geopoint coords = toGeopoint(xmlNodeAttrValue(wptNode, "lat", null), xmlNodeAttrValue(wptNode, "lon", null), true);
-        final Float elevation = parseFloatSafe(wptNode.getChildValue("ele"));
-        if (StringUtils.isBlank(rawName) && elevation == null) {
-            adjustParsemode(hooks.onCoordinate(coords));
-            return;
-        }
-        final NamedGeoCoordinate named = new NamedGeoCoordinate();
-        named.setCoords(coords);
-        if (elevation != null) {
-            named.setElevation(elevation);
-        }
-        if (StringUtils.isNotBlank(rawName)) {
-            named.setName(rawName.trim());
-        }
-        adjustParsemode(hooks.onNamedCoordinate(named));
-    }
-
-    /**
-     * A {@code wptType} classified as a geocache.
-     *
-     * @param coords may be {@code null} when the GPX has no valid coordinate pair
-     */
-    private void dispatchGeocache(final XmlNode wptNode, @Nullable final Geopoint coords, final String rawName,
-                                   final String desc, final String cmt) {
-
-        final Geocache cache = createCache();
-        cache.setCoords(coords);
-        final String geocode = resolveGeocode(wptNode, rawName, desc, cmt);
-        cache.setGeocode(geocode == null ? "" : geocode);
-        if (StringUtils.isNotBlank(rawName)) {
-            cache.setName(rawName.trim());
-        }
-        if (StringUtils.isNotBlank(desc)) {
-            cache.setShortDescription(validate(desc));
-        }
-        if (StringUtils.isNotBlank(cmt)) {
-            cache.setDescription(validate(cmt));
-        }
-        final String timeText = wptNode.getChildValue("time");
-        final Date hidden = parseDate(timeText);
-        if (hidden != null) {
-            cache.setHidden(hidden);
-        }
-        final String symbol = wptNode.getChildValue("sym");
-        if (Strings.CI.contains(symbol, "geocache") && Strings.CI.contains(symbol, "found")) {
-            cache.setFound(true);
-            cache.setDNF(false);
-        }
-        final String url = readWaypointUrl(wptNode);
-        final String guid = matchUrl(PATTERN_URL_GUID, url);
-        if (guid != null) {
-            cache.setGuid(guid);
-        }
-
-        final List<LogEntry> logs = parseGeocacheExtensions(wptNode, cache);
-        final String urlName = StringUtils.defaultIfBlank(wptNode.getChildValue("urlname"), xmlNodeChildText(wptNode.getChild("link"), "text", null));
-        if (Strings.CI.startsWith(cache.getGeocode(), "WM") && cache.getName().equalsIgnoreCase(cache.getGeocode()) && StringUtils.isNotBlank(urlName)) {
-            cache.setName(urlName.trim());
-        }
-        if ("GC_WayPoint1".equals(cache.getShortDescription())) {
-            cache.setShortDescription("");
-        }
-        if (ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector) {
-            cache.setCacheId(Long.toString(GCUtils.gcCodeToGcId(cache.getGeocode())));
-        }
-
-        if (StringUtils.isNotBlank(cache.getGeocode()) && StringUtils.isNotBlank(cache.getName())) {
-            nameToGeocodeIndex.put(cache.getName().trim().toLowerCase(Locale.US), cache.getGeocode());
-        }
-
-        adjustParsemode(hooks.onGeocache(cache, logs));
-    }
-
-    /**
-     * Resolves a geocode purely from GPX-local information: first a geocode-looking pattern in the
-     * name, then in {@code desc}, then in {@code cmt}, then (as last resort) the trimmed name verbatim.
-     */
-    @Nullable
-    private static String resolveGeocode(final XmlNode wptNode, final String rawName, final String desc, final String cmt) {
-        String geocode = findGeoCode(rawName);
-        if (geocode == null) {
-            geocode = matchUrl(PATTERN_URL_GEOCODE, readWaypointUrl(wptNode));
-        }
-        if (geocode == null) {
-            geocode = findGeoCode(desc);
-        }
-        if (geocode == null) {
-            geocode = findGeoCode(cmt);
-        }
-        if (geocode == null && StringUtils.isNotBlank(rawName)) {
-            geocode = rawName.trim();
-        }
-        return geocode;
-    }
-
-    private String normalizeName(final String name) {
-        final String trimmed = StringUtils.trim(name);
-        return Strings.CI.contains(scriptUrl, "extremcaching") && Strings.CI.startsWith(trimmed, "GCEC") ? trimmed.substring(2) : trimmed;
-    }
-
-    @Nullable
-    private static String readLinkUrl(@Nullable final XmlNode link) {
-        return StringUtils.defaultIfBlank(xmlNodeAttrValue(link, "href", null), xmlNodeChildText(link, "href", null));
-    }
-
-    @Nullable
-    private static String readWaypointUrl(final XmlNode node) {
-        return StringUtils.defaultIfBlank(node.getChildValue("url"), readLinkUrl(node.getChild("link")));
-    }
-
-    @Nullable
-    private static String matchUrl(final Pattern pattern, @Nullable final String url) {
-        if (url == null) {
-            return null;
-        }
-        final Matcher matcher = pattern.matcher(url);
-        return matcher.find() ? matcher.group(1) : null;
-    }
-
-    /** handles a {@code wptType} classified as a waypoint. */
-    private void dispatchWaypoint(final XmlNode wptNode, @Nullable final Geopoint coords, final String rawName,
-                                   final String sym, final String subtype, final boolean isTerraChildWaypoint) {
-
-        final String parentGeocodeCandidate = resolveParentGeocode(wptNode, rawName, isTerraChildWaypoint);
-
-        final String description = wptNode.getChildValue("desc");
-        final String name = "GC_WayPoint1".equals(StringUtils.trim(description)) ? ""
-                : validate(StringUtils.defaultIfBlank(description, StringUtils.trimToEmpty(rawName)));
-        final XmlNode base = extensionsBase(wptNode);
-        final Waypoint waypoint = new Waypoint(name, WaypointType.fromGPXString(sym == null ? "" : sym, subtype), parseWaypointUserDefined(base));
-        waypoint.setId(Waypoint.NEW_ID);
-        waypoint.setCoords(coords);
-        waypoint.setLookup("---"); // GPX has no lookup code
-        if (parentGeocodeCandidate != null) {
-            waypoint.setGeocode(parentGeocodeCandidate);
-        }
-
-        parseCgeoExtension(base, waypoint);
-        if (!waypoint.isUserDefined() && coords == null) {
-            waypoint.setOriginalCoordsEmpty(true);
-        }
-        waypoint.setPrefix(resolveWaypointPrefix(rawName, parentGeocodeCandidate, waypoint.isUserDefined()));
-
-        final String note = wptNode.getChildValue("cmt");
-        if (StringUtils.isNotBlank(note)) {
-            new WaypointUserNoteCombiner(waypoint).updateNoteAndUserNote(validate(note));
-        }
-
-        adjustParsemode(hooks.onWaypoint(waypoint, parentGeocodeCandidate));
-    }
-
-    private static String resolveWaypointPrefix(final String rawName, @Nullable final String parentGeocode, final boolean userDefined) {
-        String prefix = StringUtils.trimToEmpty(rawName);
-        if (userDefined) {
-            if (StringUtils.length(parentGeocode) > 2 && Strings.CI.endsWith(prefix, parentGeocode.substring(2))) {
-                prefix = prefix.substring(0, prefix.length() - parentGeocode.length() + 2);
-            }
-            prefix = Strings.CI.removeStart(prefix, Waypoint.PREFIX_OWN + "-");
-        }
-        return ConnectorFactory.getConnector(parentGeocode).getWaypointPrefix(prefix);
-    }
-
-    /**
-     * Best-effort resolution of a waypoint's parent geocache geocodefrom information available in the GPX document itself
-     */
-    @Nullable
-    private String resolveParentGeocode(final XmlNode wptNode, final String rawName, final boolean isTerraChildWaypoint) {
-        final XmlNode extensions = extensionsBase(wptNode);
-        final XmlNode gsakExt = xmlNodeChild(extensions, "wptExtension", GSAK_NS);
-        final String gsakParent = xmlNodeChildText(gsakExt, "Parent", GSAK_NS);
-        if (StringUtils.isNotBlank(gsakParent)) {
-            return nameToGeocodeIndex.getOrDefault(gsakParent.trim().toLowerCase(Locale.US), gsakParent.trim());
-        }
-
-        final String trimmedName = StringUtils.trim(rawName);
-        if (StringUtils.isBlank(trimmedName)) {
-            return null;
-        }
-
-        if (isTerraChildWaypoint) {
-            return trimmedName.length() > 1 ? trimmedName.substring(0, trimmedName.length() - 1) : null;
-        }
-
-        if (trimmedName.length() > 2) {
-            if (Strings.CI.contains(scriptUrl, "extremcaching")) {
-                return trimmedName.substring(2);
-            }
-            return "GC" + trimmedName.substring(2).toUpperCase(Locale.US);
-        }
-
-        return nameToGeocodeIndex.get(trimmedName.toLowerCase(Locale.US));
-    }
-
-    // ---------------------------------------------------------------------------------------------------
-    // extension parsing, one method per source
-    // ---------------------------------------------------------------------------------------------------
-
-    @Nullable
-    private List<LogEntry> parseGeocacheExtensions(final XmlNode wptNode, final Geocache cache) {
-        final XmlNode base = extensionsBase(wptNode);
-        if (base == null) {
-            return null;
-        }
-        parseGroundspeakExtension(base, cache);
-        parseGsakExtension(base, cache);
-        parseTerraCachingExtension(base, cache);
-        parseCgeoExtension(base, cache);
-        parseOpenCachingExtension(base, cache);
-        final List<LogEntry> logs = new ArrayList<>();
-        for (final XmlNode child : base.getChildrenInOrder()) {
-            final List<LogEntry> sourceLogs;
-            if ("cache".equals(child.getLocalName())) {
-                sourceLogs = parseGroundspeakLogs(child, ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector);
-            } else if ("terracache".equals(child.getLocalName())) {
-                sourceLogs = parseTerraCachingLogs(child);
-            } else {
-                continue;
-            }
-            if (sourceLogs != null) {
-                logs.addAll(sourceLogs);
-            }
-        }
-        return logs.isEmpty() ? null : logs;
-    }
-
-    /**
-     * Groundspeak cache extension, used by geocaching.com pocket queries and most third-party tools (GSAK, ...).
-     * Schema/namespace (any of 3 historic versions, unified here by local name only): PQ 1.1
-     * {@code http://www.groundspeak.com/cache/1/1}, PQ 1.0.1 {@code http://www.groundspeak.com/cache/1/0/1},
-     * PQ 1.0 {@code http://www.groundspeak.com/cache/1/0}. Element {@code <cache>}.
-     */
-    private void parseGroundspeakExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode gcCache = xmlNodeChild(base, "cache", GROUNDSPEAK_NS);
-        if (gcCache == null) {
-            return;
-        }
-        final String id = xmlNodeAttrValue(gcCache, "id", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(id)) {
-            cache.setCacheId(id);
-        }
-        final String archived = xmlNodeAttrValue(gcCache, "archived", GROUNDSPEAK_NS);
-        if (archived != null) {
-            cache.setArchived("true".equalsIgnoreCase(archived));
-        }
-        final String available = xmlNodeAttrValue(gcCache, "available", GROUNDSPEAK_NS);
-        if (available != null) {
-            cache.setDisabled(!"true".equalsIgnoreCase(available));
-        }
-
-        final String name = xmlNodeChildText(gcCache, "name", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(name)) {
-            cache.setName(validate(name));
-        }
-        final String owner = xmlNodeChildText(gcCache, "owner", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(owner)) {
-            cache.setOwnerUserId(validate(owner));
-        }
-        final String placedBy = xmlNodeChildText(gcCache, "placed_by", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(placedBy)) {
-            cache.setOwnerDisplayName(validate(placedBy));
-        }
-        final String gcType = xmlNodeChildText(gcCache, "type", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(gcType)) {
-            String body = validate(gcType);
-            if (body.startsWith("Geocache|")) {
-                body = StringUtils.substringAfter(body, "Geocache|").trim();
-            }
-            cache.setType(CacheType.getByPattern(body));
-        }
-        final String container = xmlNodeChildText(gcCache, "container", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(container)) {
-            cache.setSize(CacheSize.getById(validate(container)));
-        }
-        final Float difficulty = parseFloatSafe(xmlNodeChildText(gcCache, "difficulty", GROUNDSPEAK_NS));
-        if (difficulty != null) {
-            cache.setDifficulty(difficulty);
-        }
-        final Float terrain = parseFloatSafe(xmlNodeChildText(gcCache, "terrain", GROUNDSPEAK_NS));
-        if (terrain != null) {
-            cache.setTerrain(terrain);
-        }
-        final String country = xmlNodeChildText(gcCache, "country", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(country)) {
-            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(country) : cache.getLocation() + ", " + country.trim());
-        }
-        final String state = xmlNodeChildText(gcCache, "state", GROUNDSPEAK_NS);
-        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
-            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
-        }
-        final String hints = xmlNodeChildText(gcCache, "encoded_hints", GROUNDSPEAK_NS);
-        if (hints != null) {
-            cache.setHint(validate(hints));
-        }
-        final String shortDesc = xmlNodeChildText(gcCache, "short_description", GROUNDSPEAK_NS);
-        if (shortDesc != null) {
-            cache.setShortDescription(validate(shortDesc));
-        }
-        final String longDesc = xmlNodeChildText(gcCache, "long_description", GROUNDSPEAK_NS);
-        if (longDesc != null) {
-            cache.setDescription(validate(longDesc));
-        }
-
-        parseGroundspeakAttributes(gcCache, cache);
-        parseGroundspeakTravelbugs(gcCache, cache);
-    }
-
-    /**
-     * Groundspeak logs ({@code <groundspeak:logs><groundspeak:log>...}). Same schema/namespace as
-     * {@link #parseGroundspeakExtension}.
-     */
-    @Nullable
-    private List<LogEntry> parseGroundspeakLogs(final XmlNode gcCache, final boolean gcConnector) {
-        final XmlNode logsNode = xmlNodeChild(gcCache, "logs", GROUNDSPEAK_NS);
-        if (logsNode == null) {
-            return null;
-        }
-        final List<XmlNode> logNodes = xmlNodeChildren(logsNode, "log");
-        if (logNodes == null) {
-            return null;
-        }
-        final List<LogEntry> result = new ArrayList<>();
-        for (final XmlNode logNode : logNodes) {
-            final LogEntry.Builder builder = new LogEntry.Builder();
-            final String idText = xmlNodeAttrValue(logNode, "id", GROUNDSPEAK_NS);
-            if (idText != null) {
-                try {
-                    builder.setId(Integer.parseInt(idText.trim()));
-                    if (gcConnector) {
-                        builder.setServiceLogId(GCUtils.logIdToLogCode(builder.getId()));
-                    }
-                } catch (final NumberFormatException ignored) {
-                    // ignore malformed id
-                }
-            }
-            final Date date = parseDate(xmlNodeChildText(logNode, "date", GROUNDSPEAK_NS));
-            if (date != null) {
-                builder.setDate(date.getTime());
-            }
-            final String typeText = xmlNodeChildText(logNode, "type", GROUNDSPEAK_NS);
-            if (typeText != null) {
-                builder.setLogType(LogType.getByType(validate(typeText)));
-            }
-            final String finder = xmlNodeChildText(logNode, "finder", GROUNDSPEAK_NS);
-            if (finder != null) {
-                builder.setAuthor(validate(finder));
-            }
-            final String text = xmlNodeChildText(logNode, "text", GROUNDSPEAK_NS);
-            if (text != null) {
-                builder.setLog(validate(text));
-            }
-            final LogEntry log = builder.build();
-            if (log.logType != LogType.UNKNOWN) {
-                result.add(log);
-            }
-        }
-        return result.isEmpty() ? null : result;
-    }
-
-    private void parseGroundspeakAttributes(final XmlNode gcCache, final Geocache cache) {
-        final XmlNode attributes = xmlNodeChild(gcCache, "attributes", GROUNDSPEAK_NS);
-        if (attributes == null) {
-            return;
-        }
-        final List<XmlNode> attributeNodes = xmlNodeChildren(attributes, "attribute");
-        if (attributeNodes == null) {
-            return;
-        }
-        final List<String> result = new ArrayList<>();
-        for (final XmlNode attributeNode : attributeNodes) {
-            final String idText = xmlNodeAttrValue(attributeNode, "id", GROUNDSPEAK_NS);
-            final String incText = xmlNodeAttrValue(attributeNode, "inc", GROUNDSPEAK_NS);
-            if (idText == null || incText == null) {
-                continue;
-            }
-            try {
-                final int attributeId = Integer.parseInt(idText.trim());
-                final boolean active = Integer.parseInt(incText.trim()) != 0;
-                final CacheAttribute attribute = CacheAttribute.getById(attributeId);
-                if (attribute != null) {
-                    result.add(attribute.getValue(active));
-                }
-            } catch (final NumberFormatException ignored) {
-                // ignore malformed attribute entries
-            }
-        }
-        cache.setAttributes(result);
-    }
-
-    private void parseGroundspeakTravelbugs(final XmlNode gcCache, final Geocache cache) {
-        final XmlNode travelbugs = xmlNodeChild(gcCache, "travelbugs", GROUNDSPEAK_NS);
-        if (travelbugs == null) {
-            return;
-        }
-        final List<XmlNode> tbNodes = xmlNodeChildren(travelbugs, "travelbug");
-        if (tbNodes == null) {
-            return;
-        }
-        for (final XmlNode tbNode : tbNodes) {
-            final Trackable trackable = new Trackable();
-            final String ref = xmlNodeAttrValue(tbNode, "ref", GROUNDSPEAK_NS);
-            if (ref != null) {
-                trackable.setGeocode(ref);
-            }
-            final String tbName = xmlNodeChildText(tbNode, "name", GROUNDSPEAK_NS);
-            if (tbName != null) {
-                trackable.setName(validate(tbName));
-            }
-            if (StringUtils.isNotBlank(trackable.getGeocode()) && StringUtils.isNotBlank(trackable.getName())) {
-                cache.addInventoryItem(trackable);
-            }
-        }
-    }
-
-    /**
-     * GSAK ("Geocaching Swiss Army Knife") wptExtension. Schema/namespace (6 historic versions, unified here by
-     * local name only): {@code http://www.gsak.net/xmlv1/1} through {@code /6}. Element {@code <wptExtension>}.
-     */
-    private void parseGsakExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode gsak = xmlNodeChild(base, "wptExtension", GSAK_NS);
-        if (gsak == null) {
-            return;
-        }
-        final String watch = xmlNodeChildText(gsak, "Watch", GSAK_NS);
-        if (watch != null) {
-            cache.setOnWatchlist(Boolean.parseBoolean(watch.trim()));
-        }
-        final String favPoints = xmlNodeChildText(gsak, "FavPoints", GSAK_NS);
-        if (favPoints != null) {
-            try {
-                cache.setFavoritePoints(Integer.parseInt(favPoints.trim()));
-            } catch (final NumberFormatException ignored) {
-                // ignore malformed favorite points
-            }
-        }
-        final String gcNote = xmlNodeChildText(gsak, "GcNote", GSAK_NS);
-        if (StringUtils.isNotBlank(gcNote)) {
-            cache.setPersonalNote(StringUtils.trim(gcNote), true);
-        }
-        final String isPremium = xmlNodeChildText(gsak, "IsPremium", GSAK_NS);
-        if (isPremium != null) {
-            cache.setPremiumMembersOnly(Boolean.parseBoolean(isPremium.trim()));
-        }
-        final String code = xmlNodeChildText(gsak, "Code", GSAK_NS);
-        if (StringUtils.isNotBlank(code)) {
-            cache.setGeocode(StringUtils.trim(code));
-        }
-        final String dnf = xmlNodeChildText(gsak, "DNF", GSAK_NS);
-        if (dnf != null && !cache.isFound()) {
-            cache.setDNF(Boolean.parseBoolean(dnf.trim()));
-        }
-        final String dnfDate = xmlNodeChildText(gsak, "DNFDate", GSAK_NS);
-        if (dnfDate != null && cache.getVisitedDate() == 0) {
-            final Date parsed = parseDate(dnfDate);
-            if (parsed != null) {
-                cache.setVisitedDate(parsed.getTime());
-            }
-        }
-        final String userFound = xmlNodeChildText(gsak, "UserFound", GSAK_NS);
-        if (userFound != null && cache.getVisitedDate() == 0) {
-            final Date parsed = parseDate(userFound);
-            if (parsed != null) {
-                cache.setVisitedDate(parsed.getTime());
-            }
-        }
-
-        final StringBuilder userDataNote = new StringBuilder();
-        appendUserData(userDataNote, xmlNodeChildText(gsak, "UserData", GSAK_NS));
-        for (int i = 2; i <= 4; i++) {
-            appendUserData(userDataNote, xmlNodeChildText(gsak, "User" + i, GSAK_NS));
-        }
-        if (StringUtils.isBlank(cache.getPersonalNote()) && userDataNote.length() > 0) {
-            cache.setPersonalNote(userDataNote.toString().trim(), true);
-        }
-        final Geopoint originalCoords = toGeopoint(xmlNodeChildText(gsak, "LatBeforeCorrect", GSAK_NS), xmlNodeChildText(gsak, "LonBeforeCorrect", GSAK_NS), false);
-        if (originalCoords != null) {
-            final Waypoint original = new Waypoint(WaypointType.ORIGINAL.gpx, WaypointType.ORIGINAL, false);
-            original.setGeocode(cache.getGeocode());
-            original.setCoords(originalCoords);
-            cache.setWaypoints(Collections.singletonList(original));
-            cache.setUserModifiedCoords(true);
-        }
-    }
-
-    private static boolean parseWaypointUserDefined(final XmlNode base) {
-        boolean userDefined = false;
-        for (final XmlNode child : base.getChildrenInOrder()) {
-            if ("userdefined".equals(child.getLocalName())) {
-                userDefined = Boolean.parseBoolean(StringUtils.trim(child.getValue()));
-            } else if ("wptExtension".equals(child.getLocalName())) {
-                for (final XmlNode field : child.getChildrenInOrder()) {
-                    if ("Child_ByGSAK".equals(field.getLocalName())) {
-                        userDefined |= Boolean.parseBoolean(StringUtils.trim(field.getValue()));
-                    }
-                }
-            }
-        }
-        return userDefined;
-    }
-
-    private static void appendUserData(final StringBuilder buffer, final String userData) {
-        if (StringUtils.isNotBlank(userData)) {
-            buffer.append(' ').append(userData);
-        }
-    }
-
-    /** TerraCaching extension. */
-    private void parseTerraCachingExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode terraCache = xmlNodeChild(base, "terracache", TERRA_NS);
-        if (terraCache == null) {
-            return;
-        }
-        final String name = xmlNodeChildText(terraCache, "name", TERRA_NS);
-        if (StringUtils.isNotBlank(name)) {
-            cache.setName(StringUtils.trim(name));
-        }
-        final String owner = xmlNodeChildText(terraCache, "owner", TERRA_NS);
-        if (StringUtils.isNotBlank(owner)) {
-            cache.setOwnerDisplayName(validate(owner));
-        }
-        final String style = xmlNodeChildText(terraCache, "style", TERRA_NS);
-        if (StringUtils.isNotBlank(style)) {
-            cache.setType(TerraCachingType.getCacheType(style));
-        }
-        final String size = xmlNodeChildText(terraCache, "size", TERRA_NS);
-        if (StringUtils.isNotBlank(size)) {
-            cache.setSize(CacheSize.getById(size));
-        }
-        final String country = xmlNodeChildText(terraCache, "country", TERRA_NS);
-        if (StringUtils.isNotBlank(country)) {
-            cache.setLocation(StringUtils.trim(country));
-        }
-        final String state = xmlNodeChildText(terraCache, "state", TERRA_NS);
-        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
-            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
-        }
-        final String description = xmlNodeChildText(terraCache, "description", TERRA_NS);
-        if (description != null) {
-            cache.setDescription(trimHtml(description));
-        }
-        final String hint = xmlNodeChildText(terraCache, "hint", TERRA_NS);
-        if (hint != null) {
-            cache.setHint(HtmlUtils.extractText(hint));
-        }
-    }
-
-    /** TerraCaching logs ({@code <terracache><logs><log>...}). */
-    @Nullable
-    private List<LogEntry> parseTerraCachingLogs(final XmlNode terraCache) {
-        final XmlNode logsNode = xmlNodeChild(terraCache, "logs", TERRA_NS);
-        if (logsNode == null) {
-            return null;
-        }
-        final List<XmlNode> logNodes = xmlNodeChildren(logsNode, "log");
-        if (logNodes == null) {
-            return null;
-        }
-        final List<LogEntry> result = new ArrayList<>();
-        for (final XmlNode logNode : logNodes) {
-            final LogEntry.Builder builder = new LogEntry.Builder();
-            final String idText = xmlNodeAttrValue(logNode, "id", TERRA_NS);
-            if (idText != null) {
-                try {
-                    builder.setId(Integer.parseInt(idText.trim()));
-                } catch (final NumberFormatException ignored) {
-                    // ignore malformed id
-                }
-            }
-            final Date date = parseDate(xmlNodeChildText(logNode, "date", TERRA_NS));
-            if (date != null) {
-                builder.setDate(date.getTime());
-            }
-            final String typeText = xmlNodeChildText(logNode, "type", TERRA_NS);
-            if (typeText != null) {
-                builder.setLogType(TerraCachingLogType.getLogType(validate(typeText)));
-            }
-            final String finder = xmlNodeChildText(logNode, "user", TERRA_NS);
-            if (finder != null) {
-                builder.setAuthor(validate(finder));
-            }
-            final String text = xmlNodeChildText(logNode, "entry", TERRA_NS);
-            if (text != null) {
-                builder.setLog(trimHtml(validate(text)));
-            }
-            final LogEntry log = builder.build();
-            if (log.logType != LogType.UNKNOWN) {
-                result.add(log);
-            }
-        }
-        return result.isEmpty() ? null : result;
-    }
-
-    /** c:geo's own extension */
-    private void parseCgeoExtension(final XmlNode base, final Geocache cache) {
-        final String assignedEmojiText = xmlNodeChildText(xmlNodeChild(base, "cacheExtension", CGEO_NS), "assignedEmoji", CGEO_NS);
-        if (StringUtils.isNotBlank(assignedEmojiText)) {
-            cache.setAssignedEmoji(EmojiUtilsLegacyMigration.parseGpxAssignedEmoji(assignedEmojiText));
-        }
-    }
-
-    /** c:geo waypoint fields are siblings of cacheExtension, not children of it. */
-    private void parseCgeoExtension(final XmlNode base, final Waypoint waypoint) {
-        for (final XmlNode child : base.getChildrenInOrder()) {
-            if ("visited".equals(child.getLocalName())) {
-                waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
-            } else if ("originalCoordsEmpty".equals(child.getLocalName())) {
-                waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
-            }
-        }
-    }
-
-    /**
-     * Opencaching extension. Schema/namespace: {@code https://github.com/opencaching/gpx-extension-v1}. Element
-     * {@code <cache>}.
-     */
-    private void parseOpenCachingExtension(final XmlNode base, final Geocache cache) {
-        final XmlNode ocCache = xmlNodeChild(base, "cache", OPENCACHING_NS);
-        if (ocCache == null) {
-            return;
-        }
-        final String requiresPassword = xmlNodeChildText(ocCache, "requires_password", OPENCACHING_NS);
-        if (requiresPassword != null) {
-            cache.setLogPasswordRequired(Boolean.parseBoolean(requiresPassword.trim()));
-        }
-        final String otherCode = xmlNodeChildText(ocCache, "other_code", OPENCACHING_NS);
-        if (StringUtils.isNotBlank(otherCode)) {
-            cache.setDescription(Geocache.getAlternativeListingText(otherCode.trim()) + cache.getDescription());
-        }
-        final String size = xmlNodeChildText(ocCache, "size", OPENCACHING_NS);
-        if (StringUtils.isNotBlank(size)) {
-            final CacheSize cacheSize = CacheSize.getById(size);
-            if (cacheSize != CacheSize.UNKNOWN) {
-                cache.setSize(cacheSize);
-            }
-        }
-    }
-
-    private static String trimHtml(final String html) {
-        return StringUtils.trim(Strings.CS.removeEnd(Strings.CS.removeStart(html, "<br>"), "<br>"));
-    }
-
-    private static Geocache createCache() {
-        final Geocache newCache = new Geocache();
-        // explicitly set all properties which could otherwise lead to lazy database access on first read
-        newCache.setLocation("");
-        newCache.setDescription("");
-        newCache.setShortDescription("");
-        newCache.setHint("");
-        newCache.setAttributes(Collections.emptyList());
-        newCache.setWaypoints(Collections.emptyList());
-        return newCache;
-    }
-
-    private static String validate(final String input) {
-        if ("nil".equalsIgnoreCase(input)) {
-            return "";
-        }
-        return input.trim();
-    }
-
-    @Nullable
-    private static String findGeoCode(final String input) {
-        if (input == null) {
-            return null;
-        }
-        final Matcher matcher = PATTERN_GEOCODE.matcher(input);
-        while (matcher.find()) {
-            final String geocode = matcher.group().toUpperCase(Locale.US);
-            if (ConnectorFactory.getConnector(geocode) != ConnectorFactory.UNKNOWN_CONNECTOR) {
-                return geocode;
-            }
-        }
-        return null;
-    }
-
-    // ---------------------------------------------------------------------------------------------------
-    // date parsing: tolerant of the handful of date formats found in real-world GPX files
-    // ---------------------------------------------------------------------------------------------------
-
-    private static final Pattern PATTERN_MILLISECONDS = Pattern.compile("\\.\\d+");
-
-    @Nullable
-    private static Date parseDate(final String input) {
-        if (StringUtils.isBlank(input)) {
-            return null;
-        }
-        String body = input.trim();
-        body = PATTERN_MILLISECONDS.matcher(body).replaceFirst("");
-        final String[] patterns = {
-            "yyyy-MM-dd'T'HH:mm:ssXXX",
-            "yyyy-MM-dd'T'HH:mm:ssXX",
-            "yyyy-MM-dd'T'HH:mm:ss",
-            "yyyy-MM-dd",
-        };
-        for (final String pattern : patterns) {
-            final SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.US);
-            format.setLenient(false);
-            format.setTimeZone(TimeZone.getDefault());
-            final ParsePosition position = new ParsePosition(0);
-            final Date parsed = format.parse(body, position);
-            if (parsed != null && position.getIndex() == body.length()) {
-                return parsed;
-            }
-        }
-        return null;
-    }
-
-    @Nullable
-    private static Float parseFloatSafe(final String input) {
-        if (StringUtils.isBlank(input)) {
-            return null;
-        }
-        try {
-            return Float.parseFloat(input.trim());
-        } catch (final NumberFormatException e) {
-            return null;
-        }
-    }
-
-    // ---------------------------------------------------------------------------------------------------
-    // XmlNode helpers: namespace-tolerant lookup by local name (D-namespace tolerance, point 34)
-    // ---------------------------------------------------------------------------------------------------
-
-    /**
-     * For GPX 1.1 files, extension fields live inside a {@code <extensions>} child; for GPX 1.0 files, they are
-     * direct children of the {@code wpt}/{@code rtept}/{@code trkpt} element itself. .
-     */
-    @Nullable
-    private static XmlNode extensionsBase(final XmlNode wptNode) {
-        final XmlNode extensions = xmlNodeChild(wptNode, "extensions", null);
-        return extensions != null ? extensions : wptNode;
-    }
-
-    @Nullable
-    private static XmlNode xmlNodeChild(final XmlNode node, final String name, final Set<String> namespaces) {
-        return XmlNode.getChild(node, name, namespaces);
-    }
-
-    @Nullable
-    private static String xmlNodeChildText(final XmlNode node, final String name, final Set<String> namespaces) {
-        final XmlNode c = xmlNodeChild(node, name, namespaces);
-        // A present, empty element must be able to clear an earlier fallback value.
-        return c == null ? null : StringUtils.defaultString(c.getValue());
-    }
-
-    /** Like {@link #xmlNodeChild}, but returns ALL matching children (namespace-tolerant, by local name), not just the first. */
-    @Nullable
-    private static List<XmlNode> xmlNodeChildren(final XmlNode node, final String name) {
-        return node == null ? null : node.getChildrenAsList(name);
-    }
-
-    @Nullable
-    private static String xmlNodeAttrValue(final XmlNode node, final String attributeName, final Set<String> namespaces) {
-        return xmlNodeChildText(node, XmlNode.ATTRIBUTE_PRAEFIX + attributeName, namespaces);
-    }
-
-    @Nullable
-    private static Geopoint xmlNodeReadLatLon(final XmlNode node) {
-        final String lat = xmlNodeAttrValue(node, "lat", null);
-        final String lon = xmlNodeAttrValue(node, "lon", null);
-        return toGeopoint(lat, lon, false);
-    }
-
-    @Nullable
-    private static Geopoint toGeopoint(final String lat, final String lon, final boolean zeroFill) {
-        final Double latitude = parseCoordinate(lat, 90);
-        final Double longitude = parseCoordinate(lon, 180);
-        if (!zeroFill && (latitude == null || longitude == null || (latitude == 0 && longitude == 0))) {
-            return null;
-        }
-        return new Geopoint(latitude == null ? 0 : latitude, longitude == null ? 0 : longitude);
-    }
-
-    @Nullable
-    private static Double parseCoordinate(final String value, final int limit) {
-        if (StringUtils.isBlank(value)) {
-            return null;
-        }
-        try {
-            final double coordinate = Double.parseDouble(value.trim());
-            return Double.isFinite(coordinate) && Math.abs(coordinate) <= limit ? coordinate : null;
-        } catch (final NumberFormatException e) {
-            return null;
-        }
-    }
-
-    @Nullable
-    private static String attr(final XmlPullParser parser, final String name) {
-        for (int i = 0; i < parser.getAttributeCount(); i++) {
-            if (name.equals(localName(parser.getAttributeName(i)))) {
-                return parser.getAttributeValue(i);
-            }
-        }
-        return null;
-    }
-
-    @Nullable
-    private static String localName(final String raw) {
-        return XmlUtils.getLocalName(raw);
-    }
-
     private ParseMode adjustParsemode(final ParseMode candidate) {
         if (candidate != null) {
             this.mode = candidate;
@@ -1201,38 +294,5 @@ public class GPXParser {
             throw new AbortException();
         }
         return this.mode;
-    }
-
-    /** Reads the text content of the element the parser is currently positioned at (a {@code START_TAG}). */
-    private static String readText(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        String text = null;
-        int event = parser.next();
-        while (event != XmlPullParser.END_TAG) {
-            if (event == XmlPullParser.TEXT) {
-                text = parser.getText();
-            } else if (event == XmlPullParser.START_TAG) {
-                skipSubtree(parser);
-            }
-            event = parser.next();
-        }
-        return text;
-    }
-
-    /**
-     * Skips the subtree of the element the parser is currently positioned at (a {@code START_TAG}), leaving the
-     * parser positioned at the corresponding {@code END_TAG}.
-     */
-    private static void skipSubtree(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        int depth = 1;
-        while (depth > 0) {
-            final int event = parser.next();
-            if (event == XmlPullParser.START_TAG) {
-                depth++;
-            } else if (event == XmlPullParser.END_TAG) {
-                depth--;
-            } else if (event == XmlPullParser.END_DOCUMENT) {
-                throw new XmlPullParserException("Unexpected end of document while skipping subtree");
-            }
-        }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
@@ -251,7 +251,7 @@ public class GPXParser {
                 if ("name".equals(childName)) {
                     name = XmlUtils.parseText(parser);
                 } else if ("ele".equals(childName)) {
-                    elevation = XmlUtils.parseFloat(XmlUtils.parseText(parser));
+                    elevation = XmlUtils.toFloat(XmlUtils.parseText(parser), null);
                 } else {
                     XmlUtils.skipSubtree(parser);
                 }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
@@ -46,18 +46,6 @@ public class GPXParser {
 
     private IGPXParseHooks hooks;
 
-    /** Controls how wptTypes are parsed. */
-    public enum ParseMode {
-        /** Parse/collect complete information. */
-        FULL,
-        /** Parse only basic data per wptType (name + coordinate) */
-        COORDINATES_ONLY,
-        /** Do not collect wptType data.*/
-        SKIP,
-        /** Flag to use to abort parsing completely */
-        ABORT
-    }
-
     private static class AbortException extends RuntimeException {
 
     }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
@@ -1,0 +1,1143 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.connector.internal.InternalConnector;
+import cgeo.geocaching.connector.tc.TerraCachingLogType;
+import cgeo.geocaching.connector.tc.TerraCachingType;
+import cgeo.geocaching.enumerations.CacheAttribute;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.NamedGeoCoordinate;
+import cgeo.geocaching.models.Trackable;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.utils.EmojiUtilsLegacyMigration;
+import cgeo.geocaching.utils.html.HtmlUtils;
+import cgeo.geocaching.utils.xml.XmlNode;
+import cgeo.geocaching.utils.xml.XmlUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+/**
+ * Unified, namespace-tolerant "business element" pull-parser for GPX files relevant to Geocaching. Reacts on
+ * Geocaches, Waypoints, (Named) Coordinates, Routes and Tracks instead of raw XML elements, via
+ * {@link IGPXParseHooks}.
+ * <br>
+ * <ul>
+ *     <li>Handles GPX 1.0 and GPX 1.1 (and mixtures thereof) in one unified code path (no version-specific subclasses).</li>
+ *     <li>Does not rely on namespaces being correctly declared; elements/attributes are identified by local
+ *     name only (namespace prefixes, if any, are simply stripped).</li>
+ *     <li>Self-contained: will only use information from GPX file(s) in created objects.</li>
+ *     <li>Multi-file-capability: multiple calls to "parse" may be used to scan related GPX files (eg from a ZIP file)</li>
+ *     <li>Handling of enhancements such as GSAP, Groundspeak and c:geo's own tags (via dedicated methods).</li>
+ * </ul>
+ * <br>
+ * {@link #parse} can be called repeatedly, in any order, on the same instance to handle multi-GPX-file-situations (eg from ZIP file).
+ * Session-scoped state (esp the cross-file name→geocode index) is <em>not</em> cleared automatically between calls,
+ * so resolution works cross-file. Call {@link #reset()} to explicitly start a new, unrelated session on a reused instance.
+ */
+public class GPXParser {
+
+    private static final Pattern PATTERN_GEOCODE = Pattern.compile("[0-9A-Z]{5,}");
+
+    //Namespaces of extensions
+    private static final Set<String> GROUNDSPEAK_NS = Set.of(
+        "http://www.groundspeak.com/cache/1/1", // PQ 1.1
+        "http://www.groundspeak.com/cache/1/0/1", // PQ 1.0.1
+        "http://www.groundspeak.com/cache/1/0" // PQ 1.0
+    );
+
+    private static final Set<String> GSAK_NS = Set.of(
+        "http://www.gsak.net/xmlv1/1",
+        "http://www.gsak.net/xmlv1/2",
+        "http://www.gsak.net/xmlv1/3",
+        "http://www.gsak.net/xmlv1/4",
+        "http://www.gsak.net/xmlv1/5",
+        "http://www.gsak.net/xmlv1/6"
+    );
+
+    private static final Set<String> CGEO_NS = Set.of(
+        "http://www.cgeo.org/wptext/1/0"
+    );
+
+    private static final Set<String> OPENCACHING_NS = Set.of(
+        "https://github.com/opencaching/gpx-extension-v1"
+    );
+
+    private static final Set<String> TERRA_NS = Set.of(
+            "http://www.TerraCaching.com/GPX/1/0"
+    );
+
+    private WptParseMode geocacheWptParseMode = WptParseMode.FULL;
+    private WptParseMode waypointWptParseMode = WptParseMode.FULL;
+    private WptParseMode defaultRouteWptParseMode = WptParseMode.FULL;
+    private WptParseMode defaultTrackWptParseMode = WptParseMode.FULL;
+
+    /** parse-session-scoped index: (lower-cased, trimmed) cache name/title -&gt; geocode */
+    private final Map<String, String> nameToGeocodeIndex = new HashMap<>();
+
+    /**
+     * Sticky, single-file-scoped flag:
+     * we can only detect TerraCaching child waypoints by remembering the state of the parent". TerraCaching
+     * marks the cache entry that precedes its own child-stage waypoints with {@code <desc>GC_WayPoint1</desc>};
+     * every following {@code wptType} entry with a "terracache" {@code sym} in the SAME document is then a
+     * child waypoint of that cache, not a new cache itself, until end of file (there is no reset marker).
+     */
+    private boolean terraChildWaypoint;
+
+    private IGPXParseHooks hooks;
+
+    /** Controls how wptTypes are parsed. */
+    public enum WptParseMode {
+        /** Parse/collect the complete information. */
+        FULL,
+        /** only basic data is parsed per wptType (name + coordinate) */
+        COORDINATES_ONLY,
+        /** Do not collect wptType data.*/
+        SKIP
+    }
+
+    public GPXParser setGeocacheParseMode(final WptParseMode mode) {
+        this.geocacheWptParseMode = mode == null ? WptParseMode.FULL : mode;
+        return this;
+    }
+
+    public GPXParser setWaypointParseMode(final WptParseMode mode) {
+        this.waypointWptParseMode = mode == null ? WptParseMode.FULL : mode;
+        return this;
+    }
+
+    public GPXParser setDefaultRouteParseMode(final WptParseMode mode) {
+        this.defaultRouteWptParseMode = mode == null ? WptParseMode.FULL : mode;
+        return this;
+    }
+
+    public GPXParser setDefaultTrackParseMode(final WptParseMode mode) {
+        this.defaultTrackWptParseMode = mode == null ? WptParseMode.FULL : mode;
+        return this;
+    }
+
+    /** Clears this instance's session-scoped state (esp the cross-file name→geocode index). */
+    public GPXParser reset() {
+        nameToGeocodeIndex.clear();
+        terraChildWaypoint = false;
+        return this;
+    }
+
+    /** Parses the given stream as GPX, notifying {@code hooks} about business elements found. */
+    public void parse(@NonNull final InputStream stream, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
+        parse(XmlUtils.createParser(stream, false), hooks);
+    }
+
+    /**
+     * Parses the given, already-positioned-or-fresh pull parser as GPX, notifying {@code hooks} about business
+     * elements found. The parser is driven forward (single, forward-only pass). May be called
+     * repeatedly on the same instance to parse several related GPX documents as one logical unit
+     */
+    public void parse(@NonNull final XmlPullParser parser, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
+        this.hooks = hooks;
+        this.terraChildWaypoint = false;
+
+        int event = parser.getEventType();
+        while (event != XmlPullParser.END_DOCUMENT) {
+            if (event == XmlPullParser.START_TAG && "gpx".equals(localName(parser.getName()))) {
+                handleGpx(parser);
+                return;
+            }
+            event = parser.next();
+        }
+    }
+
+    private void handleGpx(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        final String creator = attr(parser, "creator");
+        hooks.onInit(creator);
+
+        int event = parser.next();
+        while (!(event == XmlPullParser.END_TAG && "gpx".equals(localName(parser.getName())))) {
+            if (event == XmlPullParser.START_TAG) {
+                final String name = localName(parser.getName());
+                if ("wpt".equals(name)) {
+                    handleTopLevelWpt(parser);
+                } else if ("rte".equals(name)) {
+                    handleRoute(parser);
+                } else if ("trk".equals(name)) {
+                    handleTrack(parser);
+                } else {
+                    skipSubtree(parser);
+                }
+            }
+            event = parser.next();
+        }
+    }
+
+    private void handleTopLevelWpt(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        // note: can't cheaply pre-filter by lat/lon here (unlike route/track points) - a geocache-classified
+        // entry without valid coordinates may still be reportable, see the ZZ (c:geo "cache without known
+        // coordinates") exception: https://github.com/cgeo/cgeo/issues/9305
+        dispatchWptType(parser);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // routes
+    // ---------------------------------------------------------------------------------------------------
+
+    private void handleRoute(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        final WptParseMode mode = orDefault(hooks.onRouteStart(), defaultRouteWptParseMode);
+        String routeName = null;
+        int pointCount = 0;
+
+        int event = parser.next();
+        while (!(event == XmlPullParser.END_TAG && "rte".equals(localName(parser.getName())))) {
+            if (event == XmlPullParser.START_TAG) {
+                final String name = localName(parser.getName());
+                if ("name".equals(name)) {
+                    routeName = readText(parser);
+                } else if ("rtept".equals(name)) {
+                    if (handleRouteOrTrackPoint(parser, mode)) {
+                        pointCount++;
+                    }
+                } else {
+                    skipSubtree(parser);
+                }
+            }
+            event = parser.next();
+        }
+        hooks.onRouteEnd(routeName, pointCount);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // tracks
+    // ---------------------------------------------------------------------------------------------------
+
+    private void handleTrack(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        final WptParseMode trackMode = orDefault(hooks.onTrackStart(), defaultTrackWptParseMode);
+        String trackName = null;
+        int segmentCount = 0;
+        int totalPointCount = 0;
+
+        int event = parser.next();
+        while (!(event == XmlPullParser.END_TAG && "trk".equals(localName(parser.getName())))) {
+            if (event == XmlPullParser.START_TAG) {
+                final String name = localName(parser.getName());
+                if ("name".equals(name)) {
+                    trackName = readText(parser);
+                } else if ("trkseg".equals(name)) {
+                    totalPointCount += handleTrackSegment(parser, trackMode);
+                    segmentCount++;
+                } else {
+                    skipSubtree(parser);
+                }
+            }
+            event = parser.next();
+        }
+        hooks.onTrackEnd(trackName, segmentCount, totalPointCount);
+    }
+
+    /** @return number of valid points found in this segment */
+    private int handleTrackSegment(final XmlPullParser parser, final WptParseMode trackMode) throws IOException, XmlPullParserException {
+        final WptParseMode mode = orDefault(hooks.onTrackSegmentStart(), trackMode);
+        String segmentName = null;
+        int pointCount = 0;
+
+        int event = parser.next();
+        while (!(event == XmlPullParser.END_TAG && "trkseg".equals(localName(parser.getName())))) {
+            if (event == XmlPullParser.START_TAG) {
+                final String name = localName(parser.getName());
+                if ("name".equals(name)) {
+                    segmentName = readText(parser);
+                } else if ("trkpt".equals(name)) {
+                    if (handleRouteOrTrackPoint(parser, mode)) {
+                        pointCount++;
+                    }
+                } else {
+                    skipSubtree(parser);
+                }
+            }
+            event = parser.next();
+        }
+        hooks.onTrackSegmentEnd(segmentName, pointCount);
+        return pointCount;
+    }
+
+    /**
+     * Handles a single {@code rtept}/{@code trkpt} according to the given (already-resolved) {@link WptParseMode}.
+     * Fires the appropriate hook(s) for the point, if any.
+     *
+     * @return {@code true} if the point had valid lat/lon and therefore counts towards the enclosing
+     * route's/segment's point count; {@code false} otherwise
+     */
+    private boolean handleRouteOrTrackPoint(final XmlPullParser parser, final WptParseMode mode) throws IOException, XmlPullParserException {
+        if (mode == WptParseMode.SKIP) {
+            // cheap: only check lat/lon (attributes on the start tag) for counting purposes
+            final boolean valid = xmlNodeReadLatLon(parser) != null;
+            skipSubtree(parser);
+            return valid;
+        }
+        if (mode == WptParseMode.COORDINATES_ONLY) {
+            return dispatchCoordinateOnly(parser);
+        }
+        // FULL: full classification, same as for a top-level wpt; cannot cheaply pre-filter by lat/lon
+        // here either, for the same reason as handleTopLevelWpt (ZZ exception)
+        return dispatchWptType(parser);
+    }
+
+    /**
+     * lightweight, non-buffering read of a wpt/rtept/trkpt when only coordinates are wanted (ParseMode.COORDINATES_ONLY)
+     * @return {@code true} if the point had valid lat/lon, {@code false} if it was ignored entirely
+     */
+    private boolean dispatchCoordinateOnly(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        final Geopoint coords = xmlNodeReadLatLon(parser);
+        if (coords == null) {
+            skipSubtree(parser);
+            return false;
+        }
+
+        String name = null;
+        Float elevation = null;
+        int event = parser.next();
+        while (event != XmlPullParser.END_TAG) {
+            if (event == XmlPullParser.START_TAG) {
+                final String childName = localName(parser.getName());
+                if ("name".equals(childName)) {
+                    name = readText(parser);
+                } else if ("ele".equals(childName)) {
+                    elevation = parseFloatSafe(readText(parser));
+                } else {
+                    skipSubtree(parser);
+                }
+            }
+            event = parser.next();
+        }
+
+        if (StringUtils.isBlank(name) && elevation == null) {
+            hooks.onCoordinate(coords);
+        } else {
+            final NamedGeoCoordinate named = new NamedGeoCoordinate();
+            named.setCoords(coords);
+            if (elevation != null) {
+                named.setElevation(elevation);
+            }
+            if (StringUtils.isNotBlank(name)) {
+                named.setName(name.trim());
+            }
+            hooks.onNamedCoordinate(named);
+        }
+        return true;
+    }
+
+    /**
+     * Full scan of a wpt/rtept/trkpt subtree, classifying it as geocache / waypoint / named coordinate / plain coordinate and firing the appropriate hook.
+     * @return {@code true} if the element had valid lat/lon and was processed; {@code false} otherwise
+     */
+    private boolean dispatchWptType(final XmlPullParser parser) throws XmlPullParserException, IOException {
+        final XmlNode wptNode = XmlNode.scanNode(parser);
+        final Geopoint coords = xmlNodeReadLatLon(wptNode);
+
+        final String rawName = wptNode.getChildValue("name");
+        final String desc = wptNode.getChildValue("desc");
+        final String cmt = wptNode.getChildValue("cmt");
+        final String symRaw = wptNode.getChildValue("sym");
+        final String sym = symRaw == null ? null : symRaw.toLowerCase(Locale.US);
+        final String typeField = wptNode.getChildValue("type");
+        String type = null;
+        String subtype = null;
+        if (StringUtils.isNotBlank(typeField)) {
+            final String[] parts = StringUtils.split(typeField, '|');
+            if (parts.length > 0) {
+                type = parts[0].toLowerCase(Locale.US).trim();
+            }
+            if (parts.length > 1) {
+                subtype = parts[1].toLowerCase(Locale.US).trim();
+            }
+        }
+
+        // sticky state carried over from a PRECEDING sibling wpt (see terraChildWaypoint field doc)
+        final boolean wasTerraChildWaypoint = this.terraChildWaypoint;
+        final boolean isTerraChildWaypointMarker = "GC_WayPoint1".equals(StringUtils.trim(desc));
+
+        final boolean isGeocache = Strings.CI.contains(type, "geocache")
+                || Strings.CI.contains(sym, "geocache")
+                || Strings.CI.contains(sym, "waymark")
+                || (Strings.CI.contains(sym, "terracache") && !wasTerraChildWaypoint);
+        final boolean isWaypoint = !isGeocache && (Strings.CI.contains(type, "waypoint") || wasTerraChildWaypoint);
+
+        if (isTerraChildWaypointMarker) {
+            this.terraChildWaypoint = true;
+        }
+
+        if (coords == null) {
+            // no valid coordinates -> ignore entirely, as if this wptType didn't exist...
+            if (!isGeocache || geocacheWptParseMode != WptParseMode.FULL) {
+                return false;
+            }
+            final String geocode = resolveGeocode(rawName, desc, cmt);
+            // ...EXCEPT: the ZZ-case with no coordinates (see https://github.com/cgeo/cgeo/issues/9305)
+            if (geocode == null || !InternalConnector.getInstance().canHandle(geocode)) {
+                return false;
+            }
+            dispatchGeocache(wptNode, null, rawName, desc, cmt);
+            return true;
+        }
+
+        if (isGeocache) {
+            dispatchGeocache(wptNode, coords, rawName, desc, cmt);
+        } else if (isWaypoint) {
+            dispatchWaypoint(wptNode, coords, rawName, sym, subtype, wasTerraChildWaypoint);
+        } else {
+            // fallback: named or plain coordinate
+            dispatchFallbackCoordinate(coords, rawName, wptNode);
+        }
+        return true;
+    }
+
+    /** Fires {@link IGPXParseHooks#onCoordinate}/{@link IGPXParseHooks#onNamedCoordinate} as appropriate. */
+    private void dispatchFallbackCoordinate(final Geopoint coords, final String rawName, final XmlNode wptNode) {
+        final Float elevation = parseFloatSafe(wptNode.getChildValue("ele"));
+        if (StringUtils.isBlank(rawName) && elevation == null) {
+            hooks.onCoordinate(coords);
+            return;
+        }
+        final NamedGeoCoordinate named = new NamedGeoCoordinate();
+        named.setCoords(coords);
+        if (elevation != null) {
+            named.setElevation(elevation);
+        }
+        if (StringUtils.isNotBlank(rawName)) {
+            named.setName(rawName.trim());
+        }
+        hooks.onNamedCoordinate(named);
+    }
+
+    /**
+     * A {@code wptType} classified as a geocache.
+     *
+     * @param coords may be {@code null} (only possible via the ZZ exception)
+     */
+    private void dispatchGeocache(final XmlNode wptNode, @Nullable final Geopoint coords, final String rawName,
+                                   final String desc, final String cmt) {
+        if (geocacheWptParseMode == WptParseMode.SKIP) {
+            return;
+        }
+        if (geocacheWptParseMode == WptParseMode.COORDINATES_ONLY) {
+            dispatchFallbackCoordinate(coords, rawName, wptNode);
+            return;
+        }
+
+        final Geocache cache = createCache();
+        cache.setCoords(coords);
+        final String geocode = resolveGeocode(rawName, desc, cmt);
+        cache.setGeocode(geocode == null ? "" : geocode);
+        if (StringUtils.isNotBlank(rawName)) {
+            cache.setName(rawName.trim());
+        }
+        if (StringUtils.isNotBlank(desc)) {
+            cache.setShortDescription(validate(desc));
+        }
+        if (StringUtils.isNotBlank(cmt)) {
+            cache.setDescription(validate(cmt));
+        }
+        final String timeText = wptNode.getChildValue("time");
+        final Date hidden = parseDate(timeText);
+        if (hidden != null) {
+            cache.setHidden(hidden);
+        }
+
+        final List<LogEntry> logs = parseGeocacheExtensions(wptNode, cache);
+
+        if (StringUtils.isNotBlank(cache.getGeocode()) && StringUtils.isNotBlank(cache.getName())) {
+            nameToGeocodeIndex.put(cache.getName().trim().toLowerCase(Locale.US), cache.getGeocode());
+        }
+
+        hooks.onGeocache(cache, logs);
+    }
+
+    /**
+     * Resolves a geocode purely from GPX-local information: first a geocode-looking pattern in the
+     * name, then in {@code desc}, then in {@code cmt}, then (as last resort) the trimmed name verbatim.
+     */
+    @Nullable
+    private static String resolveGeocode(final String rawName, final String desc, final String cmt) {
+        String geocode = findGeoCode(rawName);
+        if (geocode == null) {
+            geocode = findGeoCode(desc);
+        }
+        if (geocode == null) {
+            geocode = findGeoCode(cmt);
+        }
+        if (geocode == null && StringUtils.isNotBlank(rawName)) {
+            geocode = rawName.trim();
+        }
+        return geocode;
+    }
+
+    /** handles a {@code wptType} classified as a waypoint. */
+    private void dispatchWaypoint(final XmlNode wptNode, final Geopoint coords, final String rawName,
+                                   final String sym, final String subtype, final boolean isTerraChildWaypoint) {
+        if (waypointWptParseMode == WptParseMode.SKIP) {
+            return;
+        }
+        if (waypointWptParseMode == WptParseMode.COORDINATES_ONLY) {
+            dispatchFallbackCoordinate(coords, rawName, wptNode);
+            return;
+        }
+
+        final String parentGeocodeCandidate = resolveParentGeocode(wptNode, rawName, isTerraChildWaypoint);
+
+        final Waypoint waypoint = new Waypoint(StringUtils.trim(rawName), WaypointType.fromGPXString(sym == null ? "" : sym, subtype), false);
+        waypoint.setId(Waypoint.NEW_ID);
+        waypoint.setCoords(coords);
+        if (parentGeocodeCandidate != null) {
+            waypoint.setGeocode(parentGeocodeCandidate);
+        }
+
+        final String note = wptNode.getChildValue("cmt");
+        if (StringUtils.isNotBlank(note)) {
+            waypoint.setNote(validate(note));
+        }
+
+        hooks.onWaypoint(waypoint, parentGeocodeCandidate);
+    }
+
+    /**
+     * Best-effort resolution of a waypoint's parent geocache geocodefrom information available in the GPX document itself
+     */
+    @Nullable
+    private String resolveParentGeocode(final XmlNode wptNode, final String rawName, final boolean isTerraChildWaypoint) {
+        final XmlNode extensions = extensionsBase(wptNode);
+        final XmlNode gsakExt = extensions == null ? null : extensions.getChild("wptExtension");
+        final String gsakParent = gsakExt == null ? null : gsakExt.getChildValue("Parent");
+        if (StringUtils.isNotBlank(gsakParent)) {
+            return gsakParent.trim();
+        }
+
+        final String trimmedName = StringUtils.trim(rawName);
+        if (StringUtils.isBlank(trimmedName)) {
+            return null;
+        }
+
+        if (isTerraChildWaypoint) {
+            return trimmedName.length() > 1 ? trimmedName.substring(0, trimmedName.length() - 1) : null;
+        }
+
+        if (trimmedName.length() > 2) {
+            return "GC" + trimmedName.substring(2).toUpperCase(Locale.US);
+        }
+
+        return nameToGeocodeIndex.get(trimmedName.toLowerCase(Locale.US));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // extension parsing, one method per source
+    // ---------------------------------------------------------------------------------------------------
+
+    @Nullable
+    private List<LogEntry> parseGeocacheExtensions(final XmlNode wptNode, final Geocache cache) {
+        final XmlNode base = extensionsBase(wptNode);
+        if (base == null) {
+            return null;
+        }
+        final List<LogEntry> groundspeakLogs = parseGroundspeakExtension(base, cache);
+        parseGsakExtension(base, cache);
+        final List<LogEntry> terraLogs = parseTerraCachingExtension(base, cache);
+        parseCgeoExtension(base, cache);
+        parseOpenCachingExtension(base, cache);
+        return groundspeakLogs != null ? groundspeakLogs : terraLogs;
+    }
+
+    /**
+     * Groundspeak cache extension, used by geocaching.com pocket queries and most third-party tools (GSAK, ...).
+     * Schema/namespace (any of 3 historic versions, unified here by local name only): PQ 1.1
+     * {@code http://www.groundspeak.com/cache/1/1}, PQ 1.0.1 {@code http://www.groundspeak.com/cache/1/0/1},
+     * PQ 1.0 {@code http://www.groundspeak.com/cache/1/0}. Element {@code <cache>}.
+     */
+    @Nullable
+    private List<LogEntry> parseGroundspeakExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode gcCache = xmlNodeChild(base, "cache", GROUNDSPEAK_NS);
+        if (gcCache == null) {
+            return null;
+        }
+        final String id = xmlNodeAttrValue(gcCache, "id", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(id)) {
+            cache.setCacheId(id);
+        }
+        final String archived = xmlNodeAttrValue(gcCache, "archived", GROUNDSPEAK_NS);
+        if (archived != null) {
+            cache.setArchived("true".equalsIgnoreCase(archived));
+        }
+        final String available = xmlNodeAttrValue(gcCache, "available", GROUNDSPEAK_NS);
+        if (available != null) {
+            cache.setDisabled(!"true".equalsIgnoreCase(available));
+        }
+
+        final String name = xmlNodeChildText(gcCache, "name", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(name)) {
+            cache.setName(validate(name));
+        }
+        final String owner = xmlNodeChildText(gcCache, "owner", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(owner)) {
+            cache.setOwnerUserId(validate(owner));
+        }
+        final String placedBy = xmlNodeChildText(gcCache, "placed_by", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(placedBy)) {
+            cache.setOwnerDisplayName(validate(placedBy));
+        }
+        final String gcType = xmlNodeChildText(gcCache, "type", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(gcType)) {
+            String body = validate(gcType);
+            if (body.startsWith("Geocache|")) {
+                body = StringUtils.substringAfter(body, "Geocache|").trim();
+            }
+            cache.setType(CacheType.getByPattern(body));
+        }
+        final String container = xmlNodeChildText(gcCache, "container", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(container)) {
+            cache.setSize(CacheSize.getById(validate(container)));
+        }
+        final Float difficulty = parseFloatSafe(xmlNodeChildText(gcCache, "difficulty", GROUNDSPEAK_NS));
+        if (difficulty != null) {
+            cache.setDifficulty(difficulty);
+        }
+        final Float terrain = parseFloatSafe(xmlNodeChildText(gcCache, "terrain", GROUNDSPEAK_NS));
+        if (terrain != null) {
+            cache.setTerrain(terrain);
+        }
+        final String country = xmlNodeChildText(gcCache, "country", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(country)) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(country) : cache.getLocation() + ", " + country.trim());
+        }
+        final String state = xmlNodeChildText(gcCache, "state", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
+        }
+        final String hints = xmlNodeChildText(gcCache, "encoded_hints", GROUNDSPEAK_NS);
+        if (hints != null) {
+            cache.setHint(validate(hints));
+        }
+        final String shortDesc = xmlNodeChildText(gcCache, "short_description", GROUNDSPEAK_NS);
+        if (shortDesc != null) {
+            cache.setShortDescription(validate(shortDesc));
+        }
+        final String longDesc = xmlNodeChildText(gcCache, "long_description", GROUNDSPEAK_NS);
+        if (longDesc != null) {
+            cache.setDescription(validate(longDesc));
+        }
+
+        parseGroundspeakAttributes(gcCache, cache);
+        parseGroundspeakTravelbugs(gcCache, cache);
+        return parseGroundspeakLogs(gcCache);
+    }
+
+    /**
+     * Groundspeak logs ({@code <groundspeak:logs><groundspeak:log>...}). Same schema/namespace as
+     * {@link #parseGroundspeakExtension}.
+     */
+    @Nullable
+    private List<LogEntry> parseGroundspeakLogs(final XmlNode gcCache) {
+        final XmlNode logsNode = xmlNodeChild(gcCache, "logs", GROUNDSPEAK_NS);
+        if (logsNode == null) {
+            return null;
+        }
+        final List<XmlNode> logNodes = xmlNodeChildren(logsNode, "log");
+        if (logNodes == null) {
+            return null;
+        }
+        final List<LogEntry> result = new ArrayList<>();
+        for (final XmlNode logNode : logNodes) {
+            final LogEntry.Builder builder = new LogEntry.Builder();
+            final String idText = xmlNodeAttrValue(logNode, "id", GROUNDSPEAK_NS);
+            if (idText != null) {
+                try {
+                    builder.setId(Integer.parseInt(idText.trim()));
+                } catch (final NumberFormatException ignored) {
+                    // ignore malformed id
+                }
+            }
+            final Date date = parseDate(xmlNodeChildText(logNode, "date", GROUNDSPEAK_NS));
+            if (date != null) {
+                builder.setDate(date.getTime());
+            }
+            final String typeText = xmlNodeChildText(logNode, "type", GROUNDSPEAK_NS);
+            if (typeText != null) {
+                builder.setLogType(LogType.getByType(validate(typeText)));
+            }
+            final String finder = xmlNodeChildText(logNode, "finder", GROUNDSPEAK_NS);
+            if (finder != null) {
+                builder.setAuthor(validate(finder));
+            }
+            final String text = xmlNodeChildText(logNode, "text", GROUNDSPEAK_NS);
+            if (text != null) {
+                builder.setLog(validate(text));
+            }
+            result.add(builder.build());
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    private void parseGroundspeakAttributes(final XmlNode gcCache, final Geocache cache) {
+        final XmlNode attributes = xmlNodeChild(gcCache, "attributes", GROUNDSPEAK_NS);
+        if (attributes == null) {
+            return;
+        }
+        final List<XmlNode> attributeNodes = xmlNodeChildren(attributes, "attribute");
+        if (attributeNodes == null) {
+            return;
+        }
+        final List<String> result = new ArrayList<>();
+        for (final XmlNode attributeNode : attributeNodes) {
+            final String idText = xmlNodeAttrValue(attributeNode, "id", GROUNDSPEAK_NS);
+            final String incText = xmlNodeAttrValue(attributeNode, "inc", GROUNDSPEAK_NS);
+            if (idText == null || incText == null) {
+                continue;
+            }
+            try {
+                final int attributeId = Integer.parseInt(idText.trim());
+                final boolean active = Integer.parseInt(incText.trim()) != 0;
+                final CacheAttribute attribute = CacheAttribute.getById(attributeId);
+                if (attribute != null) {
+                    result.add(attribute.getValue(active));
+                }
+            } catch (final NumberFormatException ignored) {
+                // ignore malformed attribute entries
+            }
+        }
+        cache.setAttributes(result);
+    }
+
+    private void parseGroundspeakTravelbugs(final XmlNode gcCache, final Geocache cache) {
+        final XmlNode travelbugs = xmlNodeChild(gcCache, "travelbugs", GROUNDSPEAK_NS);
+        if (travelbugs == null) {
+            return;
+        }
+        final List<XmlNode> tbNodes = xmlNodeChildren(travelbugs, "travelbug");
+        if (tbNodes == null) {
+            return;
+        }
+        for (final XmlNode tbNode : tbNodes) {
+            final Trackable trackable = new Trackable();
+            final String ref = xmlNodeAttrValue(tbNode, "ref", GROUNDSPEAK_NS);
+            if (ref != null) {
+                trackable.setGeocode(ref);
+            }
+            final String tbName = xmlNodeChildText(tbNode, "name", GROUNDSPEAK_NS);
+            if (tbName != null) {
+                trackable.setName(validate(tbName));
+            }
+            if (StringUtils.isNotBlank(trackable.getGeocode()) && StringUtils.isNotBlank(trackable.getName())) {
+                cache.addInventoryItem(trackable);
+            }
+        }
+    }
+
+    /**
+     * GSAK ("Geocaching Swiss Army Knife") wptExtension. Schema/namespace (6 historic versions, unified here by
+     * local name only): {@code http://www.gsak.net/xmlv1/1} through {@code /6}. Element {@code <wptExtension>}.
+     */
+    private void parseGsakExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode gsak = xmlNodeChild(base, "wptExtension", GSAK_NS);
+        if (gsak == null) {
+            return;
+        }
+        final String watch = xmlNodeChildText(gsak, "Watch", GSAK_NS);
+        if (watch != null) {
+            cache.setOnWatchlist(Boolean.parseBoolean(watch.trim()));
+        }
+        final String favPoints = xmlNodeChildText(gsak, "FavPoints", GSAK_NS);
+        if (favPoints != null) {
+            try {
+                cache.setFavoritePoints(Integer.parseInt(favPoints.trim()));
+            } catch (final NumberFormatException ignored) {
+                // ignore malformed favorite points
+            }
+        }
+        final String gcNote = xmlNodeChildText(gsak, "GcNote", GSAK_NS);
+        if (StringUtils.isNotBlank(gcNote)) {
+            cache.setPersonalNote(StringUtils.trim(gcNote), true);
+        }
+        final String isPremium = xmlNodeChildText(gsak, "IsPremium", GSAK_NS);
+        if (isPremium != null) {
+            cache.setPremiumMembersOnly(Boolean.parseBoolean(isPremium.trim()));
+        }
+        final String code = xmlNodeChildText(gsak, "Code", GSAK_NS);
+        if (StringUtils.isNotBlank(code)) {
+            cache.setGeocode(StringUtils.trim(code));
+        }
+        final String dnf = xmlNodeChildText(gsak, "DNF", GSAK_NS);
+        if (dnf != null && !cache.isFound()) {
+            cache.setDNF(Boolean.parseBoolean(dnf.trim()));
+        }
+        final String dnfDate = xmlNodeChildText(gsak, "DNFDate", GSAK_NS);
+        if (dnfDate != null && cache.getVisitedDate() == 0) {
+            final Date parsed = parseDate(dnfDate);
+            if (parsed != null) {
+                cache.setVisitedDate(parsed.getTime());
+            }
+        }
+        final String userFound = xmlNodeChildText(gsak, "UserFound", GSAK_NS);
+        if (userFound != null && cache.getVisitedDate() == 0) {
+            final Date parsed = parseDate(userFound);
+            if (parsed != null) {
+                cache.setVisitedDate(parsed.getTime());
+            }
+        }
+
+        final StringBuilder userDataNote = new StringBuilder();
+        appendUserData(userDataNote, xmlNodeChildText(gsak, "UserData", GSAK_NS));
+        for (int i = 2; i <= 4; i++) {
+            appendUserData(userDataNote, xmlNodeChildText(gsak, "User" + i, GSAK_NS));
+        }
+        if (StringUtils.isBlank(cache.getPersonalNote()) && userDataNote.length() > 0) {
+            cache.setPersonalNote(userDataNote.toString().trim(), true);
+        }
+    }
+
+    private static void appendUserData(final StringBuilder buffer, final String userData) {
+        if (StringUtils.isNotBlank(userData)) {
+            buffer.append(' ').append(userData);
+        }
+    }
+
+    /** TerraCaching extension. */
+    @Nullable
+    private List<LogEntry> parseTerraCachingExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode terraCache = xmlNodeChild(base, "terracache", TERRA_NS);
+        if (terraCache == null) {
+            return null;
+        }
+        final String name = xmlNodeChildText(terraCache, "name", TERRA_NS);
+        if (StringUtils.isNotBlank(name)) {
+            cache.setName(StringUtils.trim(name));
+        }
+        final String owner = xmlNodeChildText(terraCache, "owner", TERRA_NS);
+        if (StringUtils.isNotBlank(owner)) {
+            cache.setOwnerDisplayName(validate(owner));
+        }
+        final String style = xmlNodeChildText(terraCache, "style", TERRA_NS);
+        if (StringUtils.isNotBlank(style)) {
+            cache.setType(TerraCachingType.getCacheType(style));
+        }
+        final String size = xmlNodeChildText(terraCache, "size", TERRA_NS);
+        if (StringUtils.isNotBlank(size)) {
+            cache.setSize(CacheSize.getById(size));
+        }
+        final String country = xmlNodeChildText(terraCache, "country", TERRA_NS);
+        if (StringUtils.isNotBlank(country)) {
+            cache.setLocation(StringUtils.trim(country));
+        }
+        final String state = xmlNodeChildText(terraCache, "state", TERRA_NS);
+        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? validate(state) : state.trim() + ", " + cache.getLocation());
+        }
+        final String description = xmlNodeChildText(terraCache, "description", TERRA_NS);
+        if (description != null) {
+            cache.setDescription(trimHtml(description));
+        }
+        final String hint = xmlNodeChildText(terraCache, "hint", TERRA_NS);
+        if (hint != null) {
+            cache.setHint(HtmlUtils.extractText(hint));
+        }
+        return parseTerraCachingLogs(terraCache);
+    }
+
+    /** TerraCaching logs ({@code <terracache><logs><log>...}). */
+    @Nullable
+    private List<LogEntry> parseTerraCachingLogs(final XmlNode terraCache) {
+        final XmlNode logsNode = xmlNodeChild(terraCache, "logs", TERRA_NS);
+        if (logsNode == null) {
+            return null;
+        }
+        final List<XmlNode> logNodes = xmlNodeChildren(logsNode, "log");
+        if (logNodes == null) {
+            return null;
+        }
+        final List<LogEntry> result = new ArrayList<>();
+        for (final XmlNode logNode : logNodes) {
+            final LogEntry.Builder builder = new LogEntry.Builder();
+            final String idText = xmlNodeAttrValue(logNode, "id", TERRA_NS);
+            if (idText != null) {
+                try {
+                    builder.setId(Integer.parseInt(idText.trim()));
+                } catch (final NumberFormatException ignored) {
+                    // ignore malformed id
+                }
+            }
+            final Date date = parseDate(xmlNodeChildText(logNode, "date", TERRA_NS));
+            if (date != null) {
+                builder.setDate(date.getTime());
+            }
+            final String typeText = xmlNodeChildText(logNode, "type", TERRA_NS);
+            if (typeText != null) {
+                builder.setLogType(TerraCachingLogType.getLogType(validate(typeText)));
+            }
+            final String finder = xmlNodeChildText(logNode, "user", TERRA_NS);
+            if (finder != null) {
+                builder.setAuthor(validate(finder));
+            }
+            final String text = xmlNodeChildText(logNode, "entry", TERRA_NS);
+            if (text != null) {
+                builder.setLog(trimHtml(validate(text)));
+            }
+            result.add(builder.build());
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    /** c:geo's own extension */
+    private void parseCgeoExtension(final XmlNode base, final Geocache cache) {
+        final String assignedEmojiText = xmlNodeChildText(xmlNodeChild(base, "cacheExtension", CGEO_NS), "assignedEmoji", CGEO_NS);
+        if (StringUtils.isNotBlank(assignedEmojiText)) {
+            cache.setAssignedEmoji(EmojiUtilsLegacyMigration.parseGpxAssignedEmoji(assignedEmojiText));
+        }
+    }
+
+    /**
+     * Opencaching extension. Schema/namespace: {@code https://github.com/opencaching/gpx-extension-v1}. Element
+     * {@code <cache>}.
+     */
+    private void parseOpenCachingExtension(final XmlNode base, final Geocache cache) {
+        final XmlNode ocCache = xmlNodeChild(base, "cache", OPENCACHING_NS);
+        if (ocCache == null) {
+            return;
+        }
+        final String size = xmlNodeChildText(ocCache, "size", OPENCACHING_NS);
+        if (StringUtils.isNotBlank(size)) {
+            final CacheSize cacheSize = CacheSize.getById(size);
+            if (cacheSize != CacheSize.UNKNOWN) {
+                cache.setSize(cacheSize);
+            }
+        }
+    }
+
+    private static String trimHtml(final String html) {
+        return StringUtils.trim(Strings.CS.removeEnd(Strings.CS.removeStart(html, "<br>"), "<br>"));
+    }
+
+    private static Geocache createCache() {
+        final Geocache newCache = new Geocache();
+        // explicitly set all properties which could otherwise lead to lazy database access on first read
+        newCache.setLocation("");
+        newCache.setDescription("");
+        newCache.setShortDescription("");
+        newCache.setHint("");
+        newCache.setAttributes(Collections.emptyList());
+        newCache.setWaypoints(Collections.emptyList());
+        return newCache;
+    }
+
+    private static String validate(final String input) {
+        if ("nil".equalsIgnoreCase(input)) {
+            return "";
+        }
+        return input.trim();
+    }
+
+    @Nullable
+    private static String findGeoCode(final String input) {
+        if (input == null) {
+            return null;
+        }
+        final String trimmed = input.trim();
+        final java.util.regex.Matcher matcher = PATTERN_GEOCODE.matcher(trimmed);
+        if (matcher.find()) {
+            final String geocode = matcher.group();
+            if (geocode.length() == trimmed.length() || Character.isWhitespace(trimmed.charAt(geocode.length()))) {
+                return geocode;
+            }
+        }
+        return null;
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // date parsing: tolerant of the handful of date formats found in real-world GPX files
+    // ---------------------------------------------------------------------------------------------------
+
+    private static final Pattern PATTERN_MILLISECONDS = Pattern.compile("\\.\\d{3,7}");
+
+    @Nullable
+    private static Date parseDate(final String input) {
+        if (StringUtils.isBlank(input)) {
+            return null;
+        }
+        String body = input.trim();
+        body = PATTERN_MILLISECONDS.matcher(body).replaceFirst("");
+        final String[] patterns = {
+            "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd",
+        };
+        for (final String pattern : patterns) {
+            try {
+                final SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.US);
+                return format.parse(body);
+            } catch (final ParseException ignored) {
+                // try next pattern
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static Float parseFloatSafe(final String input) {
+        if (StringUtils.isBlank(input)) {
+            return null;
+        }
+        try {
+            return Float.parseFloat(input.trim());
+        } catch (final NumberFormatException e) {
+            return null;
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // XmlNode helpers: namespace-tolerant lookup by local name (D-namespace tolerance, point 34)
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * For GPX 1.1 files, extension fields live inside a {@code <extensions>} child; for GPX 1.0 files, they are
+     * direct children of the {@code wpt}/{@code rtept}/{@code trkpt} element itself. .
+     */
+    @Nullable
+    private static XmlNode extensionsBase(final XmlNode wptNode) {
+        final XmlNode extensions = xmlNodeChild(wptNode, "extensions", null);
+        return extensions != null ? extensions : wptNode;
+    }
+
+    @Nullable
+    private static XmlNode xmlNodeChild(final XmlNode node, final String name, final Set<String> namespaces) {
+        return XmlNode.getChild(node, name, namespaces);
+    }
+
+    @Nullable
+    private static String xmlNodeChildText(final XmlNode node, final String name, final Set<String> namespaces) {
+        final XmlNode c = xmlNodeChild(node, name, namespaces);
+        return c == null ? null : c.getValue();
+    }
+
+    /** Like {@link #xmlNodeChild}, but returns ALL matching children (namespace-tolerant, by local name), not just the first. */
+    @Nullable
+    private static List<XmlNode> xmlNodeChildren(final XmlNode node, final String name) {
+        return node == null ? null : node.getChildrenAsList(name);
+    }
+
+    @Nullable
+    private static String xmlNodeAttrValue(final XmlNode node, final String attributeName, final Set<String> namespaces) {
+        return xmlNodeChildText(node, XmlNode.ATTRIBUTE_PRAEFIX + attributeName, namespaces);
+    }
+
+    @Nullable
+    private static Geopoint xmlNodeReadLatLon(final XmlNode node) {
+        final String lat = xmlNodeAttrValue(node, "lat", null);
+        final String lon = xmlNodeAttrValue(node, "lon", null);
+        return toGeopoint(lat, lon);
+    }
+
+    @Nullable
+    private static Geopoint xmlNodeReadLatLon(final XmlPullParser parser) {
+        return toGeopoint(attr(parser, "lat"), attr(parser, "lon"));
+    }
+
+    @Nullable
+    private static Geopoint toGeopoint(final String lat, final String lon) {
+        if (StringUtils.isBlank(lat) || StringUtils.isBlank(lon)) {
+            return null;
+        }
+        try {
+            final double latD = Double.parseDouble(lat);
+            final double lonD = Double.parseDouble(lon);
+            if (latD == 0 && lonD == 0) {
+                return null;
+            }
+            return new Geopoint(latD, lonD);
+        } catch (final NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static String attr(final XmlPullParser parser, final String name) {
+        for (int i = 0; i < parser.getAttributeCount(); i++) {
+            if (name.equals(localName(parser.getAttributeName(i)))) {
+                return parser.getAttributeValue(i);
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static String localName(final String raw) {
+        return XmlUtils.getLocalName(raw);
+    }
+
+    private static WptParseMode orDefault(final WptParseMode candidate, final WptParseMode fallback) {
+        return candidate == null ? fallback : candidate;
+    }
+
+    /** Reads the text content of the element the parser is currently positioned at (a {@code START_TAG}). */
+    private static String readText(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        String text = null;
+        int event = parser.next();
+        while (event != XmlPullParser.END_TAG) {
+            if (event == XmlPullParser.TEXT) {
+                text = parser.getText();
+            } else if (event == XmlPullParser.START_TAG) {
+                skipSubtree(parser);
+            }
+            event = parser.next();
+        }
+        return text;
+    }
+
+    /**
+     * Skips the subtree of the element the parser is currently positioned at (a {@code START_TAG}), leaving the
+     * parser positioned at the corresponding {@code END_TAG}.
+     */
+    private static void skipSubtree(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        int depth = 1;
+        while (depth > 0) {
+            final int event = parser.next();
+            if (event == XmlPullParser.START_TAG) {
+                depth++;
+            } else if (event == XmlPullParser.END_TAG) {
+                depth--;
+            } else if (event == XmlPullParser.END_DOCUMENT) {
+                throw new XmlPullParserException("Unexpected end of document while skipping subtree");
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXParser.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.utils.gpx;
 
-import cgeo.geocaching.connector.internal.InternalConnector;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCUtils;
 import cgeo.geocaching.connector.tc.TerraCachingLogType;
 import cgeo.geocaching.connector.tc.TerraCachingType;
 import cgeo.geocaching.enumerations.CacheAttribute;
@@ -14,6 +16,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.NamedGeoCoordinate;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.models.WaypointUserNoteCombiner;
 import cgeo.geocaching.utils.EmojiUtilsLegacyMigration;
 import cgeo.geocaching.utils.html.HtmlUtils;
 import cgeo.geocaching.utils.xml.XmlNode;
@@ -24,7 +27,7 @@ import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.ParseException;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,6 +37,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
@@ -61,7 +66,10 @@ import org.xmlpull.v1.XmlPullParserException;
  */
 public class GPXParser {
 
-    private static final Pattern PATTERN_GEOCODE = Pattern.compile("[0-9A-Z]{5,}");
+    // Keep GUID-like Adventure Lab codes intact; provider recognition is delegated to ConnectorFactory.
+    private static final Pattern PATTERN_GEOCODE = Pattern.compile("(?<![\\p{L}\\p{N}_-])[A-Z0-9][A-Z0-9_-]*(?![\\p{L}\\p{N}_-])", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_URL_GEOCODE = Pattern.compile("[?&]wp=([^&#]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_URL_GUID = Pattern.compile("[?&]guid=([0-9a-f-]+)", Pattern.CASE_INSENSITIVE);
 
     //Namespaces of extensions
     private static final Set<String> GROUNDSPEAK_NS = Set.of(
@@ -91,10 +99,7 @@ public class GPXParser {
             "http://www.TerraCaching.com/GPX/1/0"
     );
 
-    private WptParseMode geocacheWptParseMode = WptParseMode.FULL;
-    private WptParseMode waypointWptParseMode = WptParseMode.FULL;
-    private WptParseMode defaultRouteWptParseMode = WptParseMode.FULL;
-    private WptParseMode defaultTrackWptParseMode = WptParseMode.FULL;
+    private ParseMode mode = ParseMode.FULL;
 
     /** parse-session-scoped index: (lower-cased, trimmed) cache name/title -&gt; geocode */
     private final Map<String, String> nameToGeocodeIndex = new HashMap<>();
@@ -107,36 +112,28 @@ public class GPXParser {
      * child waypoint of that cache, not a new cache itself, until end of file (there is no reset marker).
      */
     private boolean terraChildWaypoint;
+    private String scriptUrl;
 
     private IGPXParseHooks hooks;
 
     /** Controls how wptTypes are parsed. */
-    public enum WptParseMode {
-        /** Parse/collect the complete information. */
+    public enum ParseMode {
+        /** Parse/collect complete information. */
         FULL,
-        /** only basic data is parsed per wptType (name + coordinate) */
+        /** Parse only basic data per wptType (name + coordinate) */
         COORDINATES_ONLY,
         /** Do not collect wptType data.*/
-        SKIP
+        SKIP,
+        /** Flag to use to abort parsing completely */
+        ABORT
     }
 
-    public GPXParser setGeocacheParseMode(final WptParseMode mode) {
-        this.geocacheWptParseMode = mode == null ? WptParseMode.FULL : mode;
-        return this;
+    private static class AbortException extends RuntimeException {
+
     }
 
-    public GPXParser setWaypointParseMode(final WptParseMode mode) {
-        this.waypointWptParseMode = mode == null ? WptParseMode.FULL : mode;
-        return this;
-    }
-
-    public GPXParser setDefaultRouteParseMode(final WptParseMode mode) {
-        this.defaultRouteWptParseMode = mode == null ? WptParseMode.FULL : mode;
-        return this;
-    }
-
-    public GPXParser setDefaultTrackParseMode(final WptParseMode mode) {
-        this.defaultTrackWptParseMode = mode == null ? WptParseMode.FULL : mode;
+    public GPXParser setParseMode(final ParseMode mode) {
+        this.mode = mode == null ? ParseMode.FULL : mode;
         return this;
     }
 
@@ -144,47 +141,65 @@ public class GPXParser {
     public GPXParser reset() {
         nameToGeocodeIndex.clear();
         terraChildWaypoint = false;
+        scriptUrl = null;
         return this;
     }
 
     /** Parses the given stream as GPX, notifying {@code hooks} about business elements found. */
     public void parse(@NonNull final InputStream stream, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
-        parse(XmlUtils.createParser(stream, false), hooks);
+        final XmlPullParser parser = XmlUtils.createParser(stream, true);
+        parse(parser, hooks);
     }
 
     /**
      * Parses the given, already-positioned-or-fresh pull parser as GPX, notifying {@code hooks} about business
      * elements found. The parser is driven forward (single, forward-only pass). May be called
      * repeatedly on the same instance to parse several related GPX documents as one logical unit
+     * @return if true, then parsing completed. If false then parsing was aborted by hooks.
      */
-    public void parse(@NonNull final XmlPullParser parser, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
+    public boolean parse(@NonNull final XmlPullParser parser, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
         this.hooks = hooks;
         this.terraChildWaypoint = false;
+        this.scriptUrl = null;
 
-        int event = parser.getEventType();
-        while (event != XmlPullParser.END_DOCUMENT) {
-            if (event == XmlPullParser.START_TAG && "gpx".equals(localName(parser.getName()))) {
-                handleGpx(parser);
-                return;
+        try {
+            int event = parser.getEventType();
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG && "gpx".equals(localName(parser.getName()))) {
+                    handleGpx(parser);
+                    return true;
+                }
+                event = parser.next();
             }
-            event = parser.next();
+            return true;
+        } catch (AbortException ae) {
+            return false;
         }
     }
 
     private void handleGpx(final XmlPullParser parser) throws IOException, XmlPullParserException {
         final String creator = attr(parser, "creator");
-        hooks.onInit(creator);
+        scriptUrl = creator;
+        adjustParsemode(hooks.onInit(creator));
 
         int event = parser.next();
         while (!(event == XmlPullParser.END_TAG && "gpx".equals(localName(parser.getName())))) {
             if (event == XmlPullParser.START_TAG) {
                 final String name = localName(parser.getName());
                 if ("wpt".equals(name)) {
-                    handleTopLevelWpt(parser);
+                    dispatchWptType(parser);
                 } else if ("rte".equals(name)) {
                     handleRoute(parser);
                 } else if ("trk".equals(name)) {
                     handleTrack(parser);
+                } else if ("url".equals(name) || "creator".equals(name)) {
+                    scriptUrl = readText(parser);
+                } else if ("metadata".equals(name)) {
+                    final XmlNode metadata = XmlNode.scanNode(parser);
+                    final String url = readLinkUrl(metadata.getChild("link"));
+                    if (StringUtils.isNotBlank(url)) {
+                        scriptUrl = url;
+                    }
                 } else {
                     skipSubtree(parser);
                 }
@@ -193,19 +208,12 @@ public class GPXParser {
         }
     }
 
-    private void handleTopLevelWpt(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        // note: can't cheaply pre-filter by lat/lon here (unlike route/track points) - a geocache-classified
-        // entry without valid coordinates may still be reportable, see the ZZ (c:geo "cache without known
-        // coordinates") exception: https://github.com/cgeo/cgeo/issues/9305
-        dispatchWptType(parser);
-    }
-
     // ---------------------------------------------------------------------------------------------------
     // routes
     // ---------------------------------------------------------------------------------------------------
 
     private void handleRoute(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        final WptParseMode mode = orDefault(hooks.onRouteStart(), defaultRouteWptParseMode);
+        adjustParsemode(hooks.onRouteStart());
         String routeName = null;
         int pointCount = 0;
 
@@ -216,16 +224,15 @@ public class GPXParser {
                 if ("name".equals(name)) {
                     routeName = readText(parser);
                 } else if ("rtept".equals(name)) {
-                    if (handleRouteOrTrackPoint(parser, mode)) {
-                        pointCount++;
-                    }
+                    dispatchWptType(parser);
+                    pointCount++;
                 } else {
                     skipSubtree(parser);
                 }
             }
             event = parser.next();
         }
-        hooks.onRouteEnd(routeName, pointCount);
+        adjustParsemode(hooks.onRouteEnd(routeName, pointCount));
     }
 
     // ---------------------------------------------------------------------------------------------------
@@ -233,7 +240,7 @@ public class GPXParser {
     // ---------------------------------------------------------------------------------------------------
 
     private void handleTrack(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        final WptParseMode trackMode = orDefault(hooks.onTrackStart(), defaultTrackWptParseMode);
+        adjustParsemode(hooks.onTrackStart());
         String trackName = null;
         int segmentCount = 0;
         int totalPointCount = 0;
@@ -245,7 +252,7 @@ public class GPXParser {
                 if ("name".equals(name)) {
                     trackName = readText(parser);
                 } else if ("trkseg".equals(name)) {
-                    totalPointCount += handleTrackSegment(parser, trackMode);
+                    totalPointCount += handleTrackSegment(parser);
                     segmentCount++;
                 } else {
                     skipSubtree(parser);
@@ -253,12 +260,12 @@ public class GPXParser {
             }
             event = parser.next();
         }
-        hooks.onTrackEnd(trackName, segmentCount, totalPointCount);
+        adjustParsemode(hooks.onTrackEnd(trackName, segmentCount, totalPointCount));
     }
 
-    /** @return number of valid points found in this segment */
-    private int handleTrackSegment(final XmlPullParser parser, final WptParseMode trackMode) throws IOException, XmlPullParserException {
-        final WptParseMode mode = orDefault(hooks.onTrackSegmentStart(), trackMode);
+    /** @return number of point entries found in this segment, including entries without coordinates */
+    private int handleTrackSegment(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        adjustParsemode(hooks.onTrackSegmentStart());
         String segmentName = null;
         int pointCount = 0;
 
@@ -269,51 +276,37 @@ public class GPXParser {
                 if ("name".equals(name)) {
                     segmentName = readText(parser);
                 } else if ("trkpt".equals(name)) {
-                    if (handleRouteOrTrackPoint(parser, mode)) {
-                        pointCount++;
-                    }
+                    dispatchWptType(parser);
+                    pointCount++;
                 } else {
                     skipSubtree(parser);
                 }
             }
             event = parser.next();
         }
-        hooks.onTrackSegmentEnd(segmentName, pointCount);
+        adjustParsemode(hooks.onTrackSegmentEnd(segmentName, pointCount));
         return pointCount;
     }
 
     /**
-     * Handles a single {@code rtept}/{@code trkpt} according to the given (already-resolved) {@link WptParseMode}.
+     * Handles a single {@code rtept}/{@code trkpt} according to the given (already-resolved) {@link ParseMode}.
      * Fires the appropriate hook(s) for the point, if any.
-     *
-     * @return {@code true} if the point had valid lat/lon and therefore counts towards the enclosing
-     * route's/segment's point count; {@code false} otherwise
      */
-    private boolean handleRouteOrTrackPoint(final XmlPullParser parser, final WptParseMode mode) throws IOException, XmlPullParserException {
-        if (mode == WptParseMode.SKIP) {
-            // cheap: only check lat/lon (attributes on the start tag) for counting purposes
-            final boolean valid = xmlNodeReadLatLon(parser) != null;
+    private void dispatchWptType(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        if (this.mode == ParseMode.SKIP) {
             skipSubtree(parser);
-            return valid;
+        } else if (this.mode == ParseMode.COORDINATES_ONLY) {
+            dispatchWptTypeCoordinateOnly(parser);
+        } else {
+            dispatchWptTypeFull(parser);
         }
-        if (mode == WptParseMode.COORDINATES_ONLY) {
-            return dispatchCoordinateOnly(parser);
-        }
-        // FULL: full classification, same as for a top-level wpt; cannot cheaply pre-filter by lat/lon
-        // here either, for the same reason as handleTopLevelWpt (ZZ exception)
-        return dispatchWptType(parser);
     }
 
     /**
      * lightweight, non-buffering read of a wpt/rtept/trkpt when only coordinates are wanted (ParseMode.COORDINATES_ONLY)
-     * @return {@code true} if the point had valid lat/lon, {@code false} if it was ignored entirely
      */
-    private boolean dispatchCoordinateOnly(final XmlPullParser parser) throws IOException, XmlPullParserException {
-        final Geopoint coords = xmlNodeReadLatLon(parser);
-        if (coords == null) {
-            skipSubtree(parser);
-            return false;
-        }
+    private void dispatchWptTypeCoordinateOnly(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        final Geopoint coords = toGeopoint(attr(parser, "lat"), attr(parser, "lon"), true);
 
         String name = null;
         Float elevation = null;
@@ -333,7 +326,7 @@ public class GPXParser {
         }
 
         if (StringUtils.isBlank(name) && elevation == null) {
-            hooks.onCoordinate(coords);
+            adjustParsemode(hooks.onCoordinate(coords));
         } else {
             final NamedGeoCoordinate named = new NamedGeoCoordinate();
             named.setCoords(coords);
@@ -343,20 +336,18 @@ public class GPXParser {
             if (StringUtils.isNotBlank(name)) {
                 named.setName(name.trim());
             }
-            hooks.onNamedCoordinate(named);
+            adjustParsemode(hooks.onNamedCoordinate(named));
         }
-        return true;
     }
 
     /**
-     * Full scan of a wpt/rtept/trkpt subtree, classifying it as geocache / waypoint / named coordinate / plain coordinate and firing the appropriate hook.
-     * @return {@code true} if the element had valid lat/lon and was processed; {@code false} otherwise
+     * FULL scan of a wpt/rtept/trkpt subtree, classifying it as geocache / waypoint / named coordinate / plain coordinate and firing the appropriate hook.
      */
-    private boolean dispatchWptType(final XmlPullParser parser) throws XmlPullParserException, IOException {
+    private void dispatchWptTypeFull(final XmlPullParser parser) throws XmlPullParserException, IOException {
         final XmlNode wptNode = XmlNode.scanNode(parser);
         final Geopoint coords = xmlNodeReadLatLon(wptNode);
 
-        final String rawName = wptNode.getChildValue("name");
+        final String rawName = normalizeName(wptNode.getChildValue("name"));
         final String desc = wptNode.getChildValue("desc");
         final String cmt = wptNode.getChildValue("cmt");
         final String symRaw = wptNode.getChildValue("sym");
@@ -378,28 +369,16 @@ public class GPXParser {
         final boolean wasTerraChildWaypoint = this.terraChildWaypoint;
         final boolean isTerraChildWaypointMarker = "GC_WayPoint1".equals(StringUtils.trim(desc));
 
+        final XmlNode base = extensionsBase(wptNode);
         final boolean isGeocache = Strings.CI.contains(type, "geocache")
                 || Strings.CI.contains(sym, "geocache")
                 || Strings.CI.contains(sym, "waymark")
-                || (Strings.CI.contains(sym, "terracache") && !wasTerraChildWaypoint);
+                || (!wasTerraChildWaypoint && (Strings.CI.contains(sym, "terracache")
+                    || base.hasChild("cache") || base.hasChild("terracache")));
         final boolean isWaypoint = !isGeocache && (Strings.CI.contains(type, "waypoint") || wasTerraChildWaypoint);
 
         if (isTerraChildWaypointMarker) {
             this.terraChildWaypoint = true;
-        }
-
-        if (coords == null) {
-            // no valid coordinates -> ignore entirely, as if this wptType didn't exist...
-            if (!isGeocache || geocacheWptParseMode != WptParseMode.FULL) {
-                return false;
-            }
-            final String geocode = resolveGeocode(rawName, desc, cmt);
-            // ...EXCEPT: the ZZ-case with no coordinates (see https://github.com/cgeo/cgeo/issues/9305)
-            if (geocode == null || !InternalConnector.getInstance().canHandle(geocode)) {
-                return false;
-            }
-            dispatchGeocache(wptNode, null, rawName, desc, cmt);
-            return true;
         }
 
         if (isGeocache) {
@@ -408,16 +387,16 @@ public class GPXParser {
             dispatchWaypoint(wptNode, coords, rawName, sym, subtype, wasTerraChildWaypoint);
         } else {
             // fallback: named or plain coordinate
-            dispatchFallbackCoordinate(coords, rawName, wptNode);
+            dispatchFallbackCoordinate(rawName, wptNode);
         }
-        return true;
     }
 
     /** Fires {@link IGPXParseHooks#onCoordinate}/{@link IGPXParseHooks#onNamedCoordinate} as appropriate. */
-    private void dispatchFallbackCoordinate(final Geopoint coords, final String rawName, final XmlNode wptNode) {
+    private void dispatchFallbackCoordinate(final String rawName, final XmlNode wptNode) {
+        final Geopoint coords = toGeopoint(xmlNodeAttrValue(wptNode, "lat", null), xmlNodeAttrValue(wptNode, "lon", null), true);
         final Float elevation = parseFloatSafe(wptNode.getChildValue("ele"));
         if (StringUtils.isBlank(rawName) && elevation == null) {
-            hooks.onCoordinate(coords);
+            adjustParsemode(hooks.onCoordinate(coords));
             return;
         }
         final NamedGeoCoordinate named = new NamedGeoCoordinate();
@@ -428,27 +407,20 @@ public class GPXParser {
         if (StringUtils.isNotBlank(rawName)) {
             named.setName(rawName.trim());
         }
-        hooks.onNamedCoordinate(named);
+        adjustParsemode(hooks.onNamedCoordinate(named));
     }
 
     /**
      * A {@code wptType} classified as a geocache.
      *
-     * @param coords may be {@code null} (only possible via the ZZ exception)
+     * @param coords may be {@code null} when the GPX has no valid coordinate pair
      */
     private void dispatchGeocache(final XmlNode wptNode, @Nullable final Geopoint coords, final String rawName,
                                    final String desc, final String cmt) {
-        if (geocacheWptParseMode == WptParseMode.SKIP) {
-            return;
-        }
-        if (geocacheWptParseMode == WptParseMode.COORDINATES_ONLY) {
-            dispatchFallbackCoordinate(coords, rawName, wptNode);
-            return;
-        }
 
         final Geocache cache = createCache();
         cache.setCoords(coords);
-        final String geocode = resolveGeocode(rawName, desc, cmt);
+        final String geocode = resolveGeocode(wptNode, rawName, desc, cmt);
         cache.setGeocode(geocode == null ? "" : geocode);
         if (StringUtils.isNotBlank(rawName)) {
             cache.setName(rawName.trim());
@@ -464,14 +436,34 @@ public class GPXParser {
         if (hidden != null) {
             cache.setHidden(hidden);
         }
+        final String symbol = wptNode.getChildValue("sym");
+        if (Strings.CI.contains(symbol, "geocache") && Strings.CI.contains(symbol, "found")) {
+            cache.setFound(true);
+            cache.setDNF(false);
+        }
+        final String url = readWaypointUrl(wptNode);
+        final String guid = matchUrl(PATTERN_URL_GUID, url);
+        if (guid != null) {
+            cache.setGuid(guid);
+        }
 
         final List<LogEntry> logs = parseGeocacheExtensions(wptNode, cache);
+        final String urlName = StringUtils.defaultIfBlank(wptNode.getChildValue("urlname"), xmlNodeChildText(wptNode.getChild("link"), "text", null));
+        if (Strings.CI.startsWith(cache.getGeocode(), "WM") && cache.getName().equalsIgnoreCase(cache.getGeocode()) && StringUtils.isNotBlank(urlName)) {
+            cache.setName(urlName.trim());
+        }
+        if ("GC_WayPoint1".equals(cache.getShortDescription())) {
+            cache.setShortDescription("");
+        }
+        if (ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector) {
+            cache.setCacheId(Long.toString(GCUtils.gcCodeToGcId(cache.getGeocode())));
+        }
 
         if (StringUtils.isNotBlank(cache.getGeocode()) && StringUtils.isNotBlank(cache.getName())) {
             nameToGeocodeIndex.put(cache.getName().trim().toLowerCase(Locale.US), cache.getGeocode());
         }
 
-        hooks.onGeocache(cache, logs);
+        adjustParsemode(hooks.onGeocache(cache, logs));
     }
 
     /**
@@ -479,8 +471,11 @@ public class GPXParser {
      * name, then in {@code desc}, then in {@code cmt}, then (as last resort) the trimmed name verbatim.
      */
     @Nullable
-    private static String resolveGeocode(final String rawName, final String desc, final String cmt) {
+    private static String resolveGeocode(final XmlNode wptNode, final String rawName, final String desc, final String cmt) {
         String geocode = findGeoCode(rawName);
+        if (geocode == null) {
+            geocode = matchUrl(PATTERN_URL_GEOCODE, readWaypointUrl(wptNode));
+        }
         if (geocode == null) {
             geocode = findGeoCode(desc);
         }
@@ -493,32 +488,71 @@ public class GPXParser {
         return geocode;
     }
 
+    private String normalizeName(final String name) {
+        final String trimmed = StringUtils.trim(name);
+        return Strings.CI.contains(scriptUrl, "extremcaching") && Strings.CI.startsWith(trimmed, "GCEC") ? trimmed.substring(2) : trimmed;
+    }
+
+    @Nullable
+    private static String readLinkUrl(@Nullable final XmlNode link) {
+        return StringUtils.defaultIfBlank(xmlNodeAttrValue(link, "href", null), xmlNodeChildText(link, "href", null));
+    }
+
+    @Nullable
+    private static String readWaypointUrl(final XmlNode node) {
+        return StringUtils.defaultIfBlank(node.getChildValue("url"), readLinkUrl(node.getChild("link")));
+    }
+
+    @Nullable
+    private static String matchUrl(final Pattern pattern, @Nullable final String url) {
+        if (url == null) {
+            return null;
+        }
+        final Matcher matcher = pattern.matcher(url);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
     /** handles a {@code wptType} classified as a waypoint. */
-    private void dispatchWaypoint(final XmlNode wptNode, final Geopoint coords, final String rawName,
+    private void dispatchWaypoint(final XmlNode wptNode, @Nullable final Geopoint coords, final String rawName,
                                    final String sym, final String subtype, final boolean isTerraChildWaypoint) {
-        if (waypointWptParseMode == WptParseMode.SKIP) {
-            return;
-        }
-        if (waypointWptParseMode == WptParseMode.COORDINATES_ONLY) {
-            dispatchFallbackCoordinate(coords, rawName, wptNode);
-            return;
-        }
 
         final String parentGeocodeCandidate = resolveParentGeocode(wptNode, rawName, isTerraChildWaypoint);
 
-        final Waypoint waypoint = new Waypoint(StringUtils.trim(rawName), WaypointType.fromGPXString(sym == null ? "" : sym, subtype), false);
+        final String description = wptNode.getChildValue("desc");
+        final String name = "GC_WayPoint1".equals(StringUtils.trim(description)) ? ""
+                : validate(StringUtils.defaultIfBlank(description, StringUtils.trimToEmpty(rawName)));
+        final XmlNode base = extensionsBase(wptNode);
+        final Waypoint waypoint = new Waypoint(name, WaypointType.fromGPXString(sym == null ? "" : sym, subtype), parseWaypointUserDefined(base));
         waypoint.setId(Waypoint.NEW_ID);
         waypoint.setCoords(coords);
+        waypoint.setLookup("---"); // GPX has no lookup code
         if (parentGeocodeCandidate != null) {
             waypoint.setGeocode(parentGeocodeCandidate);
         }
 
+        parseCgeoExtension(base, waypoint);
+        if (!waypoint.isUserDefined() && coords == null) {
+            waypoint.setOriginalCoordsEmpty(true);
+        }
+        waypoint.setPrefix(resolveWaypointPrefix(rawName, parentGeocodeCandidate, waypoint.isUserDefined()));
+
         final String note = wptNode.getChildValue("cmt");
         if (StringUtils.isNotBlank(note)) {
-            waypoint.setNote(validate(note));
+            new WaypointUserNoteCombiner(waypoint).updateNoteAndUserNote(validate(note));
         }
 
-        hooks.onWaypoint(waypoint, parentGeocodeCandidate);
+        adjustParsemode(hooks.onWaypoint(waypoint, parentGeocodeCandidate));
+    }
+
+    private static String resolveWaypointPrefix(final String rawName, @Nullable final String parentGeocode, final boolean userDefined) {
+        String prefix = StringUtils.trimToEmpty(rawName);
+        if (userDefined) {
+            if (StringUtils.length(parentGeocode) > 2 && Strings.CI.endsWith(prefix, parentGeocode.substring(2))) {
+                prefix = prefix.substring(0, prefix.length() - parentGeocode.length() + 2);
+            }
+            prefix = Strings.CI.removeStart(prefix, Waypoint.PREFIX_OWN + "-");
+        }
+        return ConnectorFactory.getConnector(parentGeocode).getWaypointPrefix(prefix);
     }
 
     /**
@@ -527,10 +561,10 @@ public class GPXParser {
     @Nullable
     private String resolveParentGeocode(final XmlNode wptNode, final String rawName, final boolean isTerraChildWaypoint) {
         final XmlNode extensions = extensionsBase(wptNode);
-        final XmlNode gsakExt = extensions == null ? null : extensions.getChild("wptExtension");
-        final String gsakParent = gsakExt == null ? null : gsakExt.getChildValue("Parent");
+        final XmlNode gsakExt = xmlNodeChild(extensions, "wptExtension", GSAK_NS);
+        final String gsakParent = xmlNodeChildText(gsakExt, "Parent", GSAK_NS);
         if (StringUtils.isNotBlank(gsakParent)) {
-            return gsakParent.trim();
+            return nameToGeocodeIndex.getOrDefault(gsakParent.trim().toLowerCase(Locale.US), gsakParent.trim());
         }
 
         final String trimmedName = StringUtils.trim(rawName);
@@ -543,6 +577,9 @@ public class GPXParser {
         }
 
         if (trimmedName.length() > 2) {
+            if (Strings.CI.contains(scriptUrl, "extremcaching")) {
+                return trimmedName.substring(2);
+            }
             return "GC" + trimmedName.substring(2).toUpperCase(Locale.US);
         }
 
@@ -559,12 +596,26 @@ public class GPXParser {
         if (base == null) {
             return null;
         }
-        final List<LogEntry> groundspeakLogs = parseGroundspeakExtension(base, cache);
+        parseGroundspeakExtension(base, cache);
         parseGsakExtension(base, cache);
-        final List<LogEntry> terraLogs = parseTerraCachingExtension(base, cache);
+        parseTerraCachingExtension(base, cache);
         parseCgeoExtension(base, cache);
         parseOpenCachingExtension(base, cache);
-        return groundspeakLogs != null ? groundspeakLogs : terraLogs;
+        final List<LogEntry> logs = new ArrayList<>();
+        for (final XmlNode child : base.getChildrenInOrder()) {
+            final List<LogEntry> sourceLogs;
+            if ("cache".equals(child.getLocalName())) {
+                sourceLogs = parseGroundspeakLogs(child, ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector);
+            } else if ("terracache".equals(child.getLocalName())) {
+                sourceLogs = parseTerraCachingLogs(child);
+            } else {
+                continue;
+            }
+            if (sourceLogs != null) {
+                logs.addAll(sourceLogs);
+            }
+        }
+        return logs.isEmpty() ? null : logs;
     }
 
     /**
@@ -573,11 +624,10 @@ public class GPXParser {
      * {@code http://www.groundspeak.com/cache/1/1}, PQ 1.0.1 {@code http://www.groundspeak.com/cache/1/0/1},
      * PQ 1.0 {@code http://www.groundspeak.com/cache/1/0}. Element {@code <cache>}.
      */
-    @Nullable
-    private List<LogEntry> parseGroundspeakExtension(final XmlNode base, final Geocache cache) {
+    private void parseGroundspeakExtension(final XmlNode base, final Geocache cache) {
         final XmlNode gcCache = xmlNodeChild(base, "cache", GROUNDSPEAK_NS);
         if (gcCache == null) {
-            return null;
+            return;
         }
         final String id = xmlNodeAttrValue(gcCache, "id", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(id)) {
@@ -647,7 +697,6 @@ public class GPXParser {
 
         parseGroundspeakAttributes(gcCache, cache);
         parseGroundspeakTravelbugs(gcCache, cache);
-        return parseGroundspeakLogs(gcCache);
     }
 
     /**
@@ -655,7 +704,7 @@ public class GPXParser {
      * {@link #parseGroundspeakExtension}.
      */
     @Nullable
-    private List<LogEntry> parseGroundspeakLogs(final XmlNode gcCache) {
+    private List<LogEntry> parseGroundspeakLogs(final XmlNode gcCache, final boolean gcConnector) {
         final XmlNode logsNode = xmlNodeChild(gcCache, "logs", GROUNDSPEAK_NS);
         if (logsNode == null) {
             return null;
@@ -671,6 +720,9 @@ public class GPXParser {
             if (idText != null) {
                 try {
                     builder.setId(Integer.parseInt(idText.trim()));
+                    if (gcConnector) {
+                        builder.setServiceLogId(GCUtils.logIdToLogCode(builder.getId()));
+                    }
                 } catch (final NumberFormatException ignored) {
                     // ignore malformed id
                 }
@@ -691,7 +743,10 @@ public class GPXParser {
             if (text != null) {
                 builder.setLog(validate(text));
             }
-            result.add(builder.build());
+            final LogEntry log = builder.build();
+            if (log.logType != LogType.UNKNOWN) {
+                result.add(log);
+            }
         }
         return result.isEmpty() ? null : result;
     }
@@ -811,6 +866,30 @@ public class GPXParser {
         if (StringUtils.isBlank(cache.getPersonalNote()) && userDataNote.length() > 0) {
             cache.setPersonalNote(userDataNote.toString().trim(), true);
         }
+        final Geopoint originalCoords = toGeopoint(xmlNodeChildText(gsak, "LatBeforeCorrect", GSAK_NS), xmlNodeChildText(gsak, "LonBeforeCorrect", GSAK_NS), false);
+        if (originalCoords != null) {
+            final Waypoint original = new Waypoint(WaypointType.ORIGINAL.gpx, WaypointType.ORIGINAL, false);
+            original.setGeocode(cache.getGeocode());
+            original.setCoords(originalCoords);
+            cache.setWaypoints(Collections.singletonList(original));
+            cache.setUserModifiedCoords(true);
+        }
+    }
+
+    private static boolean parseWaypointUserDefined(final XmlNode base) {
+        boolean userDefined = false;
+        for (final XmlNode child : base.getChildrenInOrder()) {
+            if ("userdefined".equals(child.getLocalName())) {
+                userDefined = Boolean.parseBoolean(StringUtils.trim(child.getValue()));
+            } else if ("wptExtension".equals(child.getLocalName())) {
+                for (final XmlNode field : child.getChildrenInOrder()) {
+                    if ("Child_ByGSAK".equals(field.getLocalName())) {
+                        userDefined |= Boolean.parseBoolean(StringUtils.trim(field.getValue()));
+                    }
+                }
+            }
+        }
+        return userDefined;
     }
 
     private static void appendUserData(final StringBuilder buffer, final String userData) {
@@ -820,11 +899,10 @@ public class GPXParser {
     }
 
     /** TerraCaching extension. */
-    @Nullable
-    private List<LogEntry> parseTerraCachingExtension(final XmlNode base, final Geocache cache) {
+    private void parseTerraCachingExtension(final XmlNode base, final Geocache cache) {
         final XmlNode terraCache = xmlNodeChild(base, "terracache", TERRA_NS);
         if (terraCache == null) {
-            return null;
+            return;
         }
         final String name = xmlNodeChildText(terraCache, "name", TERRA_NS);
         if (StringUtils.isNotBlank(name)) {
@@ -858,7 +936,6 @@ public class GPXParser {
         if (hint != null) {
             cache.setHint(HtmlUtils.extractText(hint));
         }
-        return parseTerraCachingLogs(terraCache);
     }
 
     /** TerraCaching logs ({@code <terracache><logs><log>...}). */
@@ -899,7 +976,10 @@ public class GPXParser {
             if (text != null) {
                 builder.setLog(trimHtml(validate(text)));
             }
-            result.add(builder.build());
+            final LogEntry log = builder.build();
+            if (log.logType != LogType.UNKNOWN) {
+                result.add(log);
+            }
         }
         return result.isEmpty() ? null : result;
     }
@@ -912,6 +992,17 @@ public class GPXParser {
         }
     }
 
+    /** c:geo waypoint fields are siblings of cacheExtension, not children of it. */
+    private void parseCgeoExtension(final XmlNode base, final Waypoint waypoint) {
+        for (final XmlNode child : base.getChildrenInOrder()) {
+            if ("visited".equals(child.getLocalName())) {
+                waypoint.setVisited(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
+            } else if ("originalCoordsEmpty".equals(child.getLocalName())) {
+                waypoint.setOriginalCoordsEmpty(Boolean.parseBoolean(StringUtils.trim(child.getValue())));
+            }
+        }
+    }
+
     /**
      * Opencaching extension. Schema/namespace: {@code https://github.com/opencaching/gpx-extension-v1}. Element
      * {@code <cache>}.
@@ -920,6 +1011,14 @@ public class GPXParser {
         final XmlNode ocCache = xmlNodeChild(base, "cache", OPENCACHING_NS);
         if (ocCache == null) {
             return;
+        }
+        final String requiresPassword = xmlNodeChildText(ocCache, "requires_password", OPENCACHING_NS);
+        if (requiresPassword != null) {
+            cache.setLogPasswordRequired(Boolean.parseBoolean(requiresPassword.trim()));
+        }
+        final String otherCode = xmlNodeChildText(ocCache, "other_code", OPENCACHING_NS);
+        if (StringUtils.isNotBlank(otherCode)) {
+            cache.setDescription(Geocache.getAlternativeListingText(otherCode.trim()) + cache.getDescription());
         }
         final String size = xmlNodeChildText(ocCache, "size", OPENCACHING_NS);
         if (StringUtils.isNotBlank(size)) {
@@ -958,11 +1057,10 @@ public class GPXParser {
         if (input == null) {
             return null;
         }
-        final String trimmed = input.trim();
-        final java.util.regex.Matcher matcher = PATTERN_GEOCODE.matcher(trimmed);
-        if (matcher.find()) {
-            final String geocode = matcher.group();
-            if (geocode.length() == trimmed.length() || Character.isWhitespace(trimmed.charAt(geocode.length()))) {
+        final Matcher matcher = PATTERN_GEOCODE.matcher(input);
+        while (matcher.find()) {
+            final String geocode = matcher.group().toUpperCase(Locale.US);
+            if (ConnectorFactory.getConnector(geocode) != ConnectorFactory.UNKNOWN_CONNECTOR) {
                 return geocode;
             }
         }
@@ -973,7 +1071,7 @@ public class GPXParser {
     // date parsing: tolerant of the handful of date formats found in real-world GPX files
     // ---------------------------------------------------------------------------------------------------
 
-    private static final Pattern PATTERN_MILLISECONDS = Pattern.compile("\\.\\d{3,7}");
+    private static final Pattern PATTERN_MILLISECONDS = Pattern.compile("\\.\\d+");
 
     @Nullable
     private static Date parseDate(final String input) {
@@ -983,17 +1081,19 @@ public class GPXParser {
         String body = input.trim();
         body = PATTERN_MILLISECONDS.matcher(body).replaceFirst("");
         final String[] patterns = {
-            "yyyy-MM-dd'T'HH:mm:ss'Z'",
-            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ssXXX",
+            "yyyy-MM-dd'T'HH:mm:ssXX",
             "yyyy-MM-dd'T'HH:mm:ss",
             "yyyy-MM-dd",
         };
         for (final String pattern : patterns) {
-            try {
-                final SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.US);
-                return format.parse(body);
-            } catch (final ParseException ignored) {
-                // try next pattern
+            final SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.US);
+            format.setLenient(false);
+            format.setTimeZone(TimeZone.getDefault());
+            final ParsePosition position = new ParsePosition(0);
+            final Date parsed = format.parse(body, position);
+            if (parsed != null && position.getIndex() == body.length()) {
+                return parsed;
             }
         }
         return null;
@@ -1033,7 +1133,8 @@ public class GPXParser {
     @Nullable
     private static String xmlNodeChildText(final XmlNode node, final String name, final Set<String> namespaces) {
         final XmlNode c = xmlNodeChild(node, name, namespaces);
-        return c == null ? null : c.getValue();
+        // A present, empty element must be able to clear an earlier fallback value.
+        return c == null ? null : StringUtils.defaultString(c.getValue());
     }
 
     /** Like {@link #xmlNodeChild}, but returns ALL matching children (namespace-tolerant, by local name), not just the first. */
@@ -1051,26 +1152,27 @@ public class GPXParser {
     private static Geopoint xmlNodeReadLatLon(final XmlNode node) {
         final String lat = xmlNodeAttrValue(node, "lat", null);
         final String lon = xmlNodeAttrValue(node, "lon", null);
-        return toGeopoint(lat, lon);
+        return toGeopoint(lat, lon, false);
     }
 
     @Nullable
-    private static Geopoint xmlNodeReadLatLon(final XmlPullParser parser) {
-        return toGeopoint(attr(parser, "lat"), attr(parser, "lon"));
+    private static Geopoint toGeopoint(final String lat, final String lon, final boolean zeroFill) {
+        final Double latitude = parseCoordinate(lat, 90);
+        final Double longitude = parseCoordinate(lon, 180);
+        if (!zeroFill && (latitude == null || longitude == null || (latitude == 0 && longitude == 0))) {
+            return null;
+        }
+        return new Geopoint(latitude == null ? 0 : latitude, longitude == null ? 0 : longitude);
     }
 
     @Nullable
-    private static Geopoint toGeopoint(final String lat, final String lon) {
-        if (StringUtils.isBlank(lat) || StringUtils.isBlank(lon)) {
+    private static Double parseCoordinate(final String value, final int limit) {
+        if (StringUtils.isBlank(value)) {
             return null;
         }
         try {
-            final double latD = Double.parseDouble(lat);
-            final double lonD = Double.parseDouble(lon);
-            if (latD == 0 && lonD == 0) {
-                return null;
-            }
-            return new Geopoint(latD, lonD);
+            final double coordinate = Double.parseDouble(value.trim());
+            return Double.isFinite(coordinate) && Math.abs(coordinate) <= limit ? coordinate : null;
         } catch (final NumberFormatException e) {
             return null;
         }
@@ -1091,8 +1193,14 @@ public class GPXParser {
         return XmlUtils.getLocalName(raw);
     }
 
-    private static WptParseMode orDefault(final WptParseMode candidate, final WptParseMode fallback) {
-        return candidate == null ? fallback : candidate;
+    private ParseMode adjustParsemode(final ParseMode candidate) {
+        if (candidate != null) {
+            this.mode = candidate;
+        }
+        if (this.mode == ParseMode.ABORT) {
+            throw new AbortException();
+        }
+        return this.mode;
     }
 
     /** Reads the text content of the element the parser is currently positioned at (a {@code START_TAG}). */
@@ -1128,16 +1236,3 @@ public class GPXParser {
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
@@ -36,6 +36,9 @@ public final class GPXUtils {
     private static final String GPX_EXTENSION = ".gpx";
     private static final String DEFAULT_ENTRY_NAME_ENCODING = "UTF-8";
 
+    private static final Set<String> GPX_EXTENDED_NODES = Set.of("wpt", "rtept", "trkpt");
+    private static final String GPX_EXTENSIONS_NODENAME = "extensions";
+
     private GPXUtils() {
         // utility class
     }
@@ -105,7 +108,7 @@ public final class GPXUtils {
 
     @Nullable
     public static String readLinkUrl(@Nullable final XmlNode link) {
-        return StringUtils.defaultIfBlank(gpxNodeAttrValue(link, "href", null), gpxNodeChildText(link, "href", null));
+        return StringUtils.defaultIfBlank(gpxAttrValue(link, "href", null), gpxChildText(link, "href", null));
     }
 
     @Nullable
@@ -127,65 +130,90 @@ public final class GPXUtils {
      */
     @Nullable
     public static XmlNode extensionsBase(final XmlNode wptNode) {
-        final XmlNode extensions = gpxNodeChild(wptNode, "extensions", null);
-        return extensions != null ? extensions : wptNode;
+        return wptNode;
+        //final XmlNode extensions = gpxChild(wptNode, "extensions", null);
+        //return extensions != null ? extensions : wptNode;
     }
 
     @Nullable
-    public static XmlNode gpxNodeChild(final XmlNode node, final String name, final Set<String> namespaces) {
-        return node == null ? null : node.getChild(name, namespaces, true);
+    public static XmlNode gpxChild(final XmlNode node, final String name, final Set<String> namespaces) {
+        if (node == null) {
+            return null;
+        }
+        if (GPX_EXTENDED_NODES.contains(node.getLocalName())) {
+            final XmlNode extensions = node.getChild(GPX_EXTENSIONS_NODENAME, null, true);
+            if (extensions != null) {
+                final XmlNode extResult = extensions.getChild(name, namespaces, true);
+                if (extResult != null) {
+                    return extResult;
+                }
+            }
+        }
+        return node.getChild(name, namespaces, true);
     }
 
     @Nullable
-    public static String gpxNodeChildText(final XmlNode node, final String name, final Set<String> namespaces) {
-        final XmlNode c = gpxNodeChild(node, name, namespaces);
+    public static String gpxChildText(final XmlNode node, final String name, final Set<String> namespaces) {
+        final XmlNode c = gpxChild(node, name, namespaces);
         // A present, empty element must be able to clear an earlier fallback value.
         return c == null ? null : StringUtils.defaultString(c.getValue());
     }
 
     @Nullable
-    public static Date gpxNodeChildDate(final XmlNode node, final String name, final Set<String> namespaces, final Date defaultValue) {
-        final XmlNode c = gpxNodeChild(node, name, namespaces);
+    public static Date gpxChildDate(final XmlNode node, final String name, final Set<String> namespaces, final Date defaultValue) {
+        final XmlNode c = gpxChild(node, name, namespaces);
         // A present, empty element must be able to clear an earlier fallback value.
         return c == null ? null : XmlUtils.toDate(c.getValue(), defaultValue);
     }
 
     @Nullable
-    public static Float gpxNodeChildFloat(final XmlNode node, final String name, final Set<String> namespaces, final Float defaultValue) {
-        final XmlNode c = gpxNodeChild(node, name, namespaces);
+    public static Float gpxChildFloat(final XmlNode node, final String name, final Set<String> namespaces, final Float defaultValue) {
+        final XmlNode c = gpxChild(node, name, namespaces);
         // A present, empty element must be able to clear an earlier fallback value.
         return c == null ? null : XmlUtils.toFloat(c.getValue(), defaultValue);
     }
 
     @Nullable
-    public static Integer gpxNodeChildInt(final XmlNode node, final String name, final Set<String> namespaces, final Integer defaultValue) {
-        final XmlNode c = gpxNodeChild(node, name, namespaces);
+    public static Integer gpxChildInt(final XmlNode node, final String name, final Set<String> namespaces, final Integer defaultValue) {
+        final XmlNode c = gpxChild(node, name, namespaces);
         // A present, empty element must be able to clear an earlier fallback value.
         return c == null ? null : XmlUtils.toInteger(c.getValue(), defaultValue);
     }
 
     @Nullable
-    public static Boolean gpxNodeChildBoolean(final XmlNode node, final String name, final Set<String> namespaces, final Boolean defaultValue) {
-        final XmlNode c = gpxNodeChild(node, name, namespaces);
+    public static Boolean gpxChildBoolean(final XmlNode node, final String name, final Set<String> namespaces, final Boolean defaultValue) {
+        final XmlNode c = gpxChild(node, name, namespaces);
         // A present, empty element must be able to clear an earlier fallback value.
         return c == null || c.getValue() == null ? null : XmlUtils.toBoolean(c.getValue(), defaultValue);
     }
 
-    /** Like {@link #gpxNodeChild}, but returns ALL matching children (namespace-tolerant, by local name), not just the first. */
+    /** Like {@link #gpxChild}, but returns ALL matching children (namespace-tolerant, by local name), not just the first. */
     @Nullable
-    public static List<XmlNode> gpxNodeChildren(final XmlNode node, final String name) {
-        return node == null ? null : node.getChildrenAsList(name);
+    public static List<XmlNode> gpxChildren(final XmlNode node, final String name, final Set<String> namespaces) {
+        if (node == null) {
+            return null;
+        }
+        if (GPX_EXTENDED_NODES.contains(node.getLocalName())) {
+            final XmlNode extensions = node.getChild(GPX_EXTENSIONS_NODENAME, namespaces, true);
+            if (extensions != null) {
+                final List<XmlNode> extResult = extensions.getChildrenAsList(name, namespaces, true);
+                if (extResult != null) {
+                    return extResult;
+                }
+            }
+        }
+        return node.getChildrenAsList(name, namespaces, true);
     }
 
     @Nullable
-    public static String gpxNodeAttrValue(final XmlNode node, final String attributeName, final Set<String> namespaces) {
-        return gpxNodeChildText(node, XmlNode.ATTRIBUTE_PRAEFIX + attributeName, namespaces);
+    public static String gpxAttrValue(final XmlNode node, final String attributeName, final Set<String> namespaces) {
+        return gpxChildText(node, XmlNode.ATTRIBUTE_PRAEFIX + attributeName, namespaces);
     }
 
     @Nullable
-    public static Geopoint gpxNodeReadLatLon(final XmlNode node) {
-        final String lat = gpxNodeAttrValue(node, "lat", null);
-        final String lon = gpxNodeAttrValue(node, "lon", null);
+    public static Geopoint gpxGeopoint(final XmlNode node) {
+        final String lat = gpxAttrValue(node, "lat", null);
+        final String lon = gpxAttrValue(node, "lon", null);
         return XmlUtils.parseGeopoint(lat, lon, false);
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
@@ -1,6 +1,9 @@
 package cgeo.geocaching.utils.gpx;
 
+import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.xml.XmlNode;
+import cgeo.geocaching.utils.xml.XmlUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -10,13 +13,16 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 /**
@@ -95,5 +101,79 @@ public final class GPXUtils {
         }
         return result;
     }
+
+    @Nullable
+    public static String readLinkUrl(@Nullable final XmlNode link) {
+        return StringUtils.defaultIfBlank(gpxNodeAttrValue(link, "href", null), gpxNodeChildText(link, "href", null));
+    }
+
+    @Nullable
+    public static String readWaypointUrl(final XmlNode node) {
+        return StringUtils.defaultIfBlank(node.getChildValue("url"), readLinkUrl(node.getChild("link")));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // date parsing: tolerant of the handful of date formats found in real-world GPX files
+    // ---------------------------------------------------------------------------------------------------
+
+    // ---------------------------------------------------------------------------------------------------
+    // XmlNode helpers: namespace-tolerant lookup by local name (D-namespace tolerance, point 34)
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * For GPX 1.1 files, extension fields live inside a {@code <extensions>} child; for GPX 1.0 files, they are
+     * direct children of the {@code wpt}/{@code rtept}/{@code trkpt} element itself. .
+     */
+    @Nullable
+    public static XmlNode extensionsBase(final XmlNode wptNode) {
+        final XmlNode extensions = gpxNodeChild(wptNode, "extensions", null);
+        return extensions != null ? extensions : wptNode;
+    }
+
+    @Nullable
+    public static XmlNode gpxNodeChild(final XmlNode node, final String name, final Set<String> namespaces) {
+        return XmlNode.getChild(node, name, namespaces);
+    }
+
+    @Nullable
+    public static String gpxNodeChildText(final XmlNode node, final String name, final Set<String> namespaces) {
+        final XmlNode c = gpxNodeChild(node, name, namespaces);
+        // A present, empty element must be able to clear an earlier fallback value.
+        return c == null ? null : StringUtils.defaultString(c.getValue());
+    }
+
+    /** Like {@link #gpxNodeChild}, but returns ALL matching children (namespace-tolerant, by local name), not just the first. */
+    @Nullable
+    public static List<XmlNode> gpxNodeChildren(final XmlNode node, final String name) {
+        return node == null ? null : node.getChildrenAsList(name);
+    }
+
+    @Nullable
+    public static String gpxNodeAttrValue(final XmlNode node, final String attributeName, final Set<String> namespaces) {
+        return gpxNodeChildText(node, XmlNode.ATTRIBUTE_PRAEFIX + attributeName, namespaces);
+    }
+
+    @Nullable
+    public static Geopoint gpxNodeReadLatLon(final XmlNode node) {
+        final String lat = gpxNodeAttrValue(node, "lat", null);
+        final String lon = gpxNodeAttrValue(node, "lon", null);
+        return XmlUtils.parseGeopoint(lat, lon, false);
+    }
+
+    @Nullable
+    public static String attr(final XmlPullParser parser, final String name) {
+        for (int i = 0; i < parser.getAttributeCount(); i++) {
+            if (name.equals(localName(parser.getAttributeName(i)))) {
+                return parser.getAttributeValue(i);
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    public static String localName(final String raw) {
+        return XmlUtils.getLocalName(raw);
+    }
+
 }
 

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
@@ -1,0 +1,99 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.utils.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.xmlpull.v1.XmlPullParserException;
+
+/**
+ * Utilities around parsing GPX files.
+ */
+public final class GPXUtils {
+
+    /** Groundspeak Pocket Query convention: additional waypoints for the caches in "X.gpx" are in "X-wpts.gpx". */
+    private static final String WAYPOINTS_FILE_SUFFIX_AND_EXTENSION = "-wpts.gpx";
+    private static final String GPX_EXTENSION = ".gpx";
+    private static final String DEFAULT_ENTRY_NAME_ENCODING = "UTF-8";
+
+    private GPXUtils() {
+        // utility class
+    }
+
+    public static int parseZip(@NonNull final InputStream zipStream, @NonNull final GPXParser parser, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
+        return parseZip(zipStream, parser, hooks, null);
+    }
+
+    /**
+     * Parses all {@code .gpx} entries contained in the given ZIP stream with {@code parser}, notifying
+     * {@code hooks}. ZIP must be read multiple times, because the order of cache and waypoint files is not guaranteed.
+     * <br>
+     * This method does not close {@code zipStream} (the caller opened it, the caller closes it).
+     *
+     * @param zipStream         the ZIP archive to read
+     * @param parser            the parser to use; reused across all entries
+     * @param hooks             callback for parsed business elements
+     * @param entryNameEncoding character encoding of entry names inside the ZIP;
+     *                          {@code null}/blank falls back to UTF-8.
+     * @return number of {@code .gpx} entries found and parsed; if 0, a warning is logged (nothing thrown)
+     */
+    public static int parseZip(@NonNull final InputStream zipStream, @NonNull final GPXParser parser, @NonNull final IGPXParseHooks hooks,
+                                @Nullable final String entryNameEncoding) throws IOException, XmlPullParserException {
+        final Map<String, byte[]> gpxEntries = bufferGpxEntries(zipStream, StringUtils.defaultIfBlank(entryNameEncoding, DEFAULT_ENTRY_NAME_ENCODING));
+
+        if (gpxEntries.isEmpty()) {
+            Log.w("GPXUtils.parseZip: ZIP contains no ." + GPX_EXTENSION.substring(1) + " entries");
+            return 0;
+        }
+
+        // pass 1: everything except "-wpts" files (caches and any other GPX content), so their geocodes get
+        // indexed (see GPXParser#reset()) before...
+        for (final Map.Entry<String, byte[]> entry : gpxEntries.entrySet()) {
+            if (!Strings.CI.endsWith(entry.getKey(), WAYPOINTS_FILE_SUFFIX_AND_EXTENSION)) {
+                parseBuffered(parser, hooks, entry.getValue());
+            }
+        }
+        // pass 2: ...the "-wpts" files are parsed, regardless of the order they actually appear in the ZIP
+        for (final Map.Entry<String, byte[]> entry : gpxEntries.entrySet()) {
+            if (Strings.CI.endsWith(entry.getKey(), WAYPOINTS_FILE_SUFFIX_AND_EXTENSION)) {
+                parseBuffered(parser, hooks, entry.getValue());
+            }
+        }
+
+        return gpxEntries.size();
+    }
+
+    private static void parseBuffered(final GPXParser parser, final IGPXParseHooks hooks, final byte[] content) throws IOException, XmlPullParserException {
+        try (InputStream is = new ByteArrayInputStream(content)) {
+            parser.parse(is, hooks);
+        }
+    }
+
+    /** Reads {@code zipStream} once, returning the content of every {@code .gpx} entry, in encounter order. */
+    @NonNull
+    private static Map<String, byte[]> bufferGpxEntries(final InputStream zipStream, final String entryNameEncoding) throws IOException {
+        final Map<String, byte[]> result = new LinkedHashMap<>();
+        final ZipArchiveInputStream zis = new ZipArchiveInputStream(new BufferedInputStream(zipStream), entryNameEncoding);
+        for (ZipEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {
+            final String name = entry.getName();
+            if (Strings.CI.endsWith(name, GPX_EXTENSION)) {
+                result.put(name, IOUtils.toByteArray(zis));
+            }
+        }
+        return result;
+    }
+}
+

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
@@ -1,7 +1,6 @@
 package cgeo.geocaching.utils.gpx;
 
 import cgeo.geocaching.location.Geopoint;
-import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.xml.XmlNode;
 import cgeo.geocaching.utils.xml.XmlUtils;
 
@@ -17,6 +16,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
@@ -43,47 +44,47 @@ public final class GPXUtils {
         // utility class
     }
 
-    public static int parseZip(@NonNull final InputStream zipStream, @NonNull final GPXParser parser, @NonNull final IGPXParseHooks hooks) throws IOException, XmlPullParserException {
-        return parseZip(zipStream, parser, hooks, null);
-    }
-
     /**
-     * Parses all {@code .gpx} entries contained in the given ZIP stream with {@code parser}, notifying
-     * {@code hooks}. ZIP must be read multiple times, because the order of cache and waypoint files is not guaranteed.
-     * <br>
-     * This method does not close {@code zipStream} (the caller opened it, the caller closes it).
+     * Parses all {@code .gpx} entries contained a ZIP stream with {@code parser}, notifying
+     * {@code hooks}. ZIP must be read multiple times, this is why a Supplier must be provided to (re-)create a
+     * stream for the file. Method does close all created streams.
      *
-     * @param zipStream         the ZIP archive to read
+     * @param zipStreamSupplier the ZIP archive to read. Supplier should provide a simple InputStream!
      * @param parser            the parser to use; reused across all entries
      * @param hooks             callback for parsed business elements
      * @param entryNameEncoding character encoding of entry names inside the ZIP;
      *                          {@code null}/blank falls back to UTF-8.
      * @return number of {@code .gpx} entries found and parsed; if 0, a warning is logged (nothing thrown)
      */
+    public static int parseZip(@NonNull final Supplier<InputStream> zipStreamSupplier, @NonNull final GPXParser parser, @NonNull final IGPXParseHooks hooks,
+                               @Nullable final String entryNameEncoding) throws IOException, XmlPullParserException {
+
+        int cnt = 0;
+        //pass 1: read non-wpts-files
+        try (InputStream zipStream = zipStreamSupplier.get()) {
+            cnt += parseZip(zipStream, parser, hooks, entryNameEncoding, name -> Strings.CI.endsWith(name, GPX_EXTENSION) && !Strings.CI.endsWith(name, WAYPOINTS_FILE_SUFFIX_AND_EXTENSION));
+        }
+        //pass 2: read wpts-files
+        try (InputStream zipStream = zipStreamSupplier.get()) {
+            cnt += parseZip(zipStream, parser, hooks, entryNameEncoding, name -> Strings.CI.endsWith(name, GPX_EXTENSION) && Strings.CI.endsWith(name, WAYPOINTS_FILE_SUFFIX_AND_EXTENSION));
+        }
+        return cnt;
+    }
+
+    /** doesn't close stream, caller must do that */
     public static int parseZip(@NonNull final InputStream zipStream, @NonNull final GPXParser parser, @NonNull final IGPXParseHooks hooks,
-                                @Nullable final String entryNameEncoding) throws IOException, XmlPullParserException {
-        final Map<String, byte[]> gpxEntries = bufferGpxEntries(zipStream, StringUtils.defaultIfBlank(entryNameEncoding, DEFAULT_ENTRY_NAME_ENCODING));
-
-        if (gpxEntries.isEmpty()) {
-            Log.w("GPXUtils.parseZip: ZIP contains no ." + GPX_EXTENSION.substring(1) + " entries");
-            return 0;
-        }
-
-        // pass 1: everything except "-wpts" files (caches and any other GPX content), so their geocodes get
-        // indexed (see GPXParser#reset()) before...
-        for (final Map.Entry<String, byte[]> entry : gpxEntries.entrySet()) {
-            if (!Strings.CI.endsWith(entry.getKey(), WAYPOINTS_FILE_SUFFIX_AND_EXTENSION)) {
-                parseBuffered(parser, hooks, entry.getValue());
+                            @Nullable final String entryNameEncoding, final Predicate<String> filenameCondition) throws IOException, XmlPullParserException {
+        int count = 0;
+        final ZipArchiveInputStream zis = new ZipArchiveInputStream(new BufferedInputStream(zipStream), entryNameEncoding);
+        ZipEntry entry;
+        while ((entry = zis.getNextEntry()) != null) {
+            final String name = entry.getName();
+            if (filenameCondition.test(name)) {
+                parser.parse(zis, hooks);
+                count++;
             }
         }
-        // pass 2: ...the "-wpts" files are parsed, regardless of the order they actually appear in the ZIP
-        for (final Map.Entry<String, byte[]> entry : gpxEntries.entrySet()) {
-            if (Strings.CI.endsWith(entry.getKey(), WAYPOINTS_FILE_SUFFIX_AND_EXTENSION)) {
-                parseBuffered(parser, hooks, entry.getValue());
-            }
-        }
-
-        return gpxEntries.size();
+    return count;
     }
 
     private static void parseBuffered(final GPXParser parser, final IGPXParseHooks hooks, final byte[] content) throws IOException, XmlPullParserException {

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GPXUtils.java
@@ -12,6 +12,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +133,7 @@ public final class GPXUtils {
 
     @Nullable
     public static XmlNode gpxNodeChild(final XmlNode node, final String name, final Set<String> namespaces) {
-        return XmlNode.getChild(node, name, namespaces);
+        return node == null ? null : node.getChild(name, namespaces, true);
     }
 
     @Nullable
@@ -140,6 +141,34 @@ public final class GPXUtils {
         final XmlNode c = gpxNodeChild(node, name, namespaces);
         // A present, empty element must be able to clear an earlier fallback value.
         return c == null ? null : StringUtils.defaultString(c.getValue());
+    }
+
+    @Nullable
+    public static Date gpxNodeChildDate(final XmlNode node, final String name, final Set<String> namespaces, final Date defaultValue) {
+        final XmlNode c = gpxNodeChild(node, name, namespaces);
+        // A present, empty element must be able to clear an earlier fallback value.
+        return c == null ? null : XmlUtils.toDate(c.getValue(), defaultValue);
+    }
+
+    @Nullable
+    public static Float gpxNodeChildFloat(final XmlNode node, final String name, final Set<String> namespaces, final Float defaultValue) {
+        final XmlNode c = gpxNodeChild(node, name, namespaces);
+        // A present, empty element must be able to clear an earlier fallback value.
+        return c == null ? null : XmlUtils.toFloat(c.getValue(), defaultValue);
+    }
+
+    @Nullable
+    public static Integer gpxNodeChildInt(final XmlNode node, final String name, final Set<String> namespaces, final Integer defaultValue) {
+        final XmlNode c = gpxNodeChild(node, name, namespaces);
+        // A present, empty element must be able to clear an earlier fallback value.
+        return c == null ? null : XmlUtils.toInteger(c.getValue(), defaultValue);
+    }
+
+    @Nullable
+    public static Boolean gpxNodeChildBoolean(final XmlNode node, final String name, final Set<String> namespaces, final Boolean defaultValue) {
+        final XmlNode c = gpxNodeChild(node, name, namespaces);
+        // A present, empty element must be able to clear an earlier fallback value.
+        return c == null || c.getValue() == null ? null : XmlUtils.toBoolean(c.getValue(), defaultValue);
     }
 
     /** Like {@link #gpxNodeChild}, but returns ALL matching children (namespace-tolerant, by local name), not just the first. */

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
@@ -27,15 +27,15 @@ public class GSAKGPXExtension implements IGPXExtension {
 
     @Override
     public void enrichGeocache(final XmlNode wptType, final Geocache cache) {
-        final XmlNode gsak = GPXUtils.gpxNodeChild(wptType, "wptExtension", GSAK_NS);
+        final XmlNode gsak = GPXUtils.gpxChild(wptType, "wptExtension", GSAK_NS);
         if (gsak == null) {
             return;
         }
-        final Boolean watch = GPXUtils.gpxNodeChildBoolean(gsak, "Watch", GSAK_NS, null);
+        final Boolean watch = GPXUtils.gpxChildBoolean(gsak, "Watch", GSAK_NS, null);
         if (watch != null) {
             cache.setOnWatchlist(watch);
         }
-        final String favPoints = GPXUtils.gpxNodeChildText(gsak, "FavPoints", GSAK_NS);
+        final String favPoints = GPXUtils.gpxChildText(gsak, "FavPoints", GSAK_NS);
         if (favPoints != null) {
             try {
                 cache.setFavoritePoints(Integer.parseInt(favPoints.trim()));
@@ -43,40 +43,40 @@ public class GSAKGPXExtension implements IGPXExtension {
                 // ignore malformed favorite points
             }
         }
-        final String gcNote = GPXUtils.gpxNodeChildText(gsak, "GcNote", GSAK_NS);
+        final String gcNote = GPXUtils.gpxChildText(gsak, "GcNote", GSAK_NS);
         if (StringUtils.isNotBlank(gcNote)) {
             cache.setPersonalNote(StringUtils.trim(gcNote), true);
         }
-        final String isPremium = GPXUtils.gpxNodeChildText(gsak, "IsPremium", GSAK_NS);
+        final String isPremium = GPXUtils.gpxChildText(gsak, "IsPremium", GSAK_NS);
         if (isPremium != null) {
             cache.setPremiumMembersOnly(Boolean.parseBoolean(isPremium.trim()));
         }
-        final String code = GPXUtils.gpxNodeChildText(gsak, "Code", GSAK_NS);
+        final String code = GPXUtils.gpxChildText(gsak, "Code", GSAK_NS);
         if (StringUtils.isNotBlank(code)) {
             cache.setGeocode(StringUtils.trim(code));
         }
-        final String dnf = GPXUtils.gpxNodeChildText(gsak, "DNF", GSAK_NS);
+        final String dnf = GPXUtils.gpxChildText(gsak, "DNF", GSAK_NS);
         if (dnf != null && !cache.isFound()) {
             cache.setDNF(Boolean.parseBoolean(dnf.trim()));
         }
-        final Date dnfDate = GPXUtils.gpxNodeChildDate(gsak, "DNFDate", GSAK_NS, null);
+        final Date dnfDate = GPXUtils.gpxChildDate(gsak, "DNFDate", GSAK_NS, null);
         if (dnfDate != null && cache.getVisitedDate() == 0) {
             cache.setVisitedDate(dnfDate.getTime());
         }
-        final Date userFound = GPXUtils.gpxNodeChildDate(gsak, "UserFound", GSAK_NS, null);
+        final Date userFound = GPXUtils.gpxChildDate(gsak, "UserFound", GSAK_NS, null);
         if (userFound != null && cache.getVisitedDate() == 0) {
             cache.setVisitedDate(userFound.getTime());
         }
 
         final StringBuilder userDataNote = new StringBuilder();
-        appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "UserData", GSAK_NS));
+        appendUserData(userDataNote, GPXUtils.gpxChildText(gsak, "UserData", GSAK_NS));
         for (int i = 2; i <= 4; i++) {
-            appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "User" + i, GSAK_NS));
+            appendUserData(userDataNote, GPXUtils.gpxChildText(gsak, "User" + i, GSAK_NS));
         }
         if (StringUtils.isBlank(cache.getPersonalNote()) && userDataNote.length() > 0) {
             cache.setPersonalNote(userDataNote.toString().trim(), true);
         }
-        final Geopoint originalCoords = XmlUtils.parseGeopoint(GPXUtils.gpxNodeChildText(gsak, "LatBeforeCorrect", GSAK_NS), GPXUtils.gpxNodeChildText(gsak, "LonBeforeCorrect", GSAK_NS), false);
+        final Geopoint originalCoords = XmlUtils.parseGeopoint(GPXUtils.gpxChildText(gsak, "LatBeforeCorrect", GSAK_NS), GPXUtils.gpxChildText(gsak, "LonBeforeCorrect", GSAK_NS), false);
         if (originalCoords != null) {
             final Waypoint original = new Waypoint(WaypointType.ORIGINAL.gpx, WaypointType.ORIGINAL, false);
             original.setGeocode(cache.getGeocode());
@@ -88,11 +88,11 @@ public class GSAKGPXExtension implements IGPXExtension {
 
     @Override
     public void enrichWaypoint(final XmlNode wptNode, final Waypoint waypoint) {
-        final XmlNode gsak = GPXUtils.gpxNodeChild(wptNode, "wptExtension", GSAK_NS);
+        final XmlNode gsak = GPXUtils.gpxChild(wptNode, "wptExtension", GSAK_NS);
         if (gsak == null) {
             return;
         }
-        final String userdefined = GPXUtils.gpxNodeChildText(gsak, "Child_ByGSAK", GSAK_NS);
+        final String userdefined = GPXUtils.gpxChildText(gsak, "Child_ByGSAK", GSAK_NS);
         if (Boolean.parseBoolean(StringUtils.trim(userdefined))) {
             waypoint.setUserDefined();
         }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
@@ -31,9 +31,9 @@ public class GSAKGPXExtension implements IGPXExtension {
         if (gsak == null) {
             return;
         }
-        final String watch = GPXUtils.gpxNodeChildText(gsak, "Watch", GSAK_NS);
+        final Boolean watch = GPXUtils.gpxNodeChildBoolean(gsak, "Watch", GSAK_NS, null);
         if (watch != null) {
-            cache.setOnWatchlist(Boolean.parseBoolean(watch.trim()));
+            cache.setOnWatchlist(watch);
         }
         final String favPoints = GPXUtils.gpxNodeChildText(gsak, "FavPoints", GSAK_NS);
         if (favPoints != null) {
@@ -59,19 +59,13 @@ public class GSAKGPXExtension implements IGPXExtension {
         if (dnf != null && !cache.isFound()) {
             cache.setDNF(Boolean.parseBoolean(dnf.trim()));
         }
-        final String dnfDate = GPXUtils.gpxNodeChildText(gsak, "DNFDate", GSAK_NS);
+        final Date dnfDate = GPXUtils.gpxNodeChildDate(gsak, "DNFDate", GSAK_NS, null);
         if (dnfDate != null && cache.getVisitedDate() == 0) {
-            final Date parsed = XmlUtils.parseDate(dnfDate);
-            if (parsed != null) {
-                cache.setVisitedDate(parsed.getTime());
-            }
+            cache.setVisitedDate(dnfDate.getTime());
         }
-        final String userFound = GPXUtils.gpxNodeChildText(gsak, "UserFound", GSAK_NS);
+        final Date userFound = GPXUtils.gpxNodeChildDate(gsak, "UserFound", GSAK_NS, null);
         if (userFound != null && cache.getVisitedDate() == 0) {
-            final Date parsed = XmlUtils.parseDate(userFound);
-            if (parsed != null) {
-                cache.setVisitedDate(parsed.getTime());
-            }
+            cache.setVisitedDate(userFound.getTime());
         }
 
         final StringBuilder userDataNote = new StringBuilder();

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
@@ -92,6 +92,18 @@ public class GSAKGPXExtension implements IGPXExtension {
         }
     }
 
+    @Override
+    public void enrichWaypoint(final XmlNode wptNode, final Waypoint waypoint) {
+        final XmlNode gsak = GPXUtils.gpxNodeChild(wptNode, "wptExtension", GSAK_NS);
+        if (gsak == null) {
+            return;
+        }
+        final String userdefined = GPXUtils.gpxNodeChildText(gsak, "Child_ByGSAK", GSAK_NS);
+        if (Boolean.parseBoolean(StringUtils.trim(userdefined))) {
+            waypoint.setUserDefined();
+        }
+    }
+
     private static void appendUserData(final StringBuilder buffer, final String userData) {
         if (StringUtils.isNotBlank(userData)) {
             buffer.append(' ').append(userData);

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GSAKGPXExtension.java
@@ -1,0 +1,101 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.utils.xml.XmlNode;
+import cgeo.geocaching.utils.xml.XmlUtils;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class GSAKGPXExtension implements IGPXExtension {
+
+    //Namespaces of extensions
+    public static final Set<String> GSAK_NS = Set.of(
+            "http://www.gsak.net/xmlv1/1",
+            "http://www.gsak.net/xmlv1/2",
+            "http://www.gsak.net/xmlv1/3",
+            "http://www.gsak.net/xmlv1/4",
+            "http://www.gsak.net/xmlv1/5",
+            "http://www.gsak.net/xmlv1/6"
+    );
+
+    @Override
+    public void enrichGeocache(final XmlNode wptType, final Geocache cache) {
+        final XmlNode gsak = GPXUtils.gpxNodeChild(wptType, "wptExtension", GSAK_NS);
+        if (gsak == null) {
+            return;
+        }
+        final String watch = GPXUtils.gpxNodeChildText(gsak, "Watch", GSAK_NS);
+        if (watch != null) {
+            cache.setOnWatchlist(Boolean.parseBoolean(watch.trim()));
+        }
+        final String favPoints = GPXUtils.gpxNodeChildText(gsak, "FavPoints", GSAK_NS);
+        if (favPoints != null) {
+            try {
+                cache.setFavoritePoints(Integer.parseInt(favPoints.trim()));
+            } catch (final NumberFormatException ignored) {
+                // ignore malformed favorite points
+            }
+        }
+        final String gcNote = GPXUtils.gpxNodeChildText(gsak, "GcNote", GSAK_NS);
+        if (StringUtils.isNotBlank(gcNote)) {
+            cache.setPersonalNote(StringUtils.trim(gcNote), true);
+        }
+        final String isPremium = GPXUtils.gpxNodeChildText(gsak, "IsPremium", GSAK_NS);
+        if (isPremium != null) {
+            cache.setPremiumMembersOnly(Boolean.parseBoolean(isPremium.trim()));
+        }
+        final String code = GPXUtils.gpxNodeChildText(gsak, "Code", GSAK_NS);
+        if (StringUtils.isNotBlank(code)) {
+            cache.setGeocode(StringUtils.trim(code));
+        }
+        final String dnf = GPXUtils.gpxNodeChildText(gsak, "DNF", GSAK_NS);
+        if (dnf != null && !cache.isFound()) {
+            cache.setDNF(Boolean.parseBoolean(dnf.trim()));
+        }
+        final String dnfDate = GPXUtils.gpxNodeChildText(gsak, "DNFDate", GSAK_NS);
+        if (dnfDate != null && cache.getVisitedDate() == 0) {
+            final Date parsed = XmlUtils.parseDate(dnfDate);
+            if (parsed != null) {
+                cache.setVisitedDate(parsed.getTime());
+            }
+        }
+        final String userFound = GPXUtils.gpxNodeChildText(gsak, "UserFound", GSAK_NS);
+        if (userFound != null && cache.getVisitedDate() == 0) {
+            final Date parsed = XmlUtils.parseDate(userFound);
+            if (parsed != null) {
+                cache.setVisitedDate(parsed.getTime());
+            }
+        }
+
+        final StringBuilder userDataNote = new StringBuilder();
+        appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "UserData", GSAK_NS));
+        for (int i = 2; i <= 4; i++) {
+            appendUserData(userDataNote, GPXUtils.gpxNodeChildText(gsak, "User" + i, GSAK_NS));
+        }
+        if (StringUtils.isBlank(cache.getPersonalNote()) && userDataNote.length() > 0) {
+            cache.setPersonalNote(userDataNote.toString().trim(), true);
+        }
+        final Geopoint originalCoords = XmlUtils.parseGeopoint(GPXUtils.gpxNodeChildText(gsak, "LatBeforeCorrect", GSAK_NS), GPXUtils.gpxNodeChildText(gsak, "LonBeforeCorrect", GSAK_NS), false);
+        if (originalCoords != null) {
+            final Waypoint original = new Waypoint(WaypointType.ORIGINAL.gpx, WaypointType.ORIGINAL, false);
+            original.setGeocode(cache.getGeocode());
+            original.setCoords(originalCoords);
+            cache.setWaypoints(Collections.singletonList(original));
+            cache.setUserModifiedCoords(true);
+        }
+    }
+
+    private static void appendUserData(final StringBuilder buffer, final String userData) {
+        if (StringUtils.isNotBlank(userData)) {
+            buffer.append(' ').append(userData);
+        }
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GroundspeakGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GroundspeakGPXExtension.java
@@ -80,11 +80,11 @@ public class GroundspeakGPXExtension implements IGPXExtension {
         if (StringUtils.isNotBlank(container)) {
             cache.setSize(CacheSize.getById(XmlUtils.validate(container)));
         }
-        final Float difficulty = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "difficulty", GROUNDSPEAK_NS));
+        final Float difficulty = GPXUtils.gpxNodeChildFloat(gcCache, "difficulty", GROUNDSPEAK_NS, null);
         if (difficulty != null) {
             cache.setDifficulty(difficulty);
         }
-        final Float terrain = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "terrain", GROUNDSPEAK_NS));
+        final Float terrain = GPXUtils.gpxNodeChildFloat(gcCache, "terrain", GROUNDSPEAK_NS, null);
         if (terrain != null) {
             cache.setTerrain(terrain);
         }
@@ -143,7 +143,7 @@ public class GroundspeakGPXExtension implements IGPXExtension {
                     // ignore malformed id
                 }
             }
-            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", GROUNDSPEAK_NS));
+            final Date date = GPXUtils.gpxNodeChildDate(logNode, "date", GROUNDSPEAK_NS, null);
             if (date != null) {
                 builder.setDate(date.getTime());
             }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GroundspeakGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GroundspeakGPXExtension.java
@@ -1,0 +1,225 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCUtils;
+import cgeo.geocaching.enumerations.CacheAttribute;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Trackable;
+import cgeo.geocaching.utils.xml.XmlNode;
+import cgeo.geocaching.utils.xml.XmlUtils;
+
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class GroundspeakGPXExtension implements IGPXExtension {
+
+    //Namespaces of extensions
+    private static final Set<String> GROUNDSPEAK_NS = Set.of(
+            "http://www.groundspeak.com/cache/1/1", // PQ 1.1
+            "http://www.groundspeak.com/cache/1/0/1", // PQ 1.0.1
+            "http://www.groundspeak.com/cache/1/0" // PQ 1.0
+    );
+
+    /**
+     * Groundspeak cache extension, used by geocaching.com pocket queries and most third-party tools (GSAK, ...).
+     * Schema/namespace (any of 3 historic versions, unified here by local name only): PQ 1.1
+     * {@code http://www.groundspeak.com/cache/1/1}, PQ 1.0.1 {@code http://www.groundspeak.com/cache/1/0/1},
+     * PQ 1.0 {@code http://www.groundspeak.com/cache/1/0}. Element {@code <cache>}.
+     */
+    @Override
+    public void enrichGeocache(final XmlNode wptNode, final Geocache cache) {
+        final XmlNode gcCache = GPXUtils.gpxNodeChild(wptNode, "cache", GROUNDSPEAK_NS);
+        if (gcCache == null) {
+            return;
+        }
+        final String id = GPXUtils.gpxNodeAttrValue(gcCache, "id", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(id)) {
+            cache.setCacheId(id);
+        }
+        final String archived = GPXUtils.gpxNodeAttrValue(gcCache, "archived", GROUNDSPEAK_NS);
+        if (archived != null) {
+            cache.setArchived("true".equalsIgnoreCase(archived));
+        }
+        final String available = GPXUtils.gpxNodeAttrValue(gcCache, "available", GROUNDSPEAK_NS);
+        if (available != null) {
+            cache.setDisabled(!"true".equalsIgnoreCase(available));
+        }
+
+        final String name = GPXUtils.gpxNodeChildText(gcCache, "name", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(name)) {
+            cache.setName(XmlUtils.validate(name));
+        }
+        final String owner = GPXUtils.gpxNodeChildText(gcCache, "owner", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(owner)) {
+            cache.setOwnerUserId(XmlUtils.validate(owner));
+        }
+        final String placedBy = GPXUtils.gpxNodeChildText(gcCache, "placed_by", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(placedBy)) {
+            cache.setOwnerDisplayName(XmlUtils.validate(placedBy));
+        }
+        final String gcType = GPXUtils.gpxNodeChildText(gcCache, "type", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(gcType)) {
+            String body = XmlUtils.validate(gcType);
+            if (body.startsWith("Geocache|")) {
+                body = StringUtils.substringAfter(body, "Geocache|").trim();
+            }
+            cache.setType(CacheType.getByPattern(body));
+        }
+        final String container = GPXUtils.gpxNodeChildText(gcCache, "container", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(container)) {
+            cache.setSize(CacheSize.getById(XmlUtils.validate(container)));
+        }
+        final Float difficulty = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "difficulty", GROUNDSPEAK_NS));
+        if (difficulty != null) {
+            cache.setDifficulty(difficulty);
+        }
+        final Float terrain = XmlUtils.parseFloat(GPXUtils.gpxNodeChildText(gcCache, "terrain", GROUNDSPEAK_NS));
+        if (terrain != null) {
+            cache.setTerrain(terrain);
+        }
+        final String country = GPXUtils.gpxNodeChildText(gcCache, "country", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(country)) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? XmlUtils.validate(country) : cache.getLocation() + ", " + country.trim());
+        }
+        final String state = GPXUtils.gpxNodeChildText(gcCache, "state", GROUNDSPEAK_NS);
+        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? XmlUtils.validate(state) : state.trim() + ", " + cache.getLocation());
+        }
+        final String hints = GPXUtils.gpxNodeChildText(gcCache, "encoded_hints", GROUNDSPEAK_NS);
+        if (hints != null) {
+            cache.setHint(XmlUtils.validate(hints));
+        }
+        final String shortDesc = GPXUtils.gpxNodeChildText(gcCache, "short_description", GROUNDSPEAK_NS);
+        if (shortDesc != null) {
+            cache.setShortDescription(XmlUtils.validate(shortDesc));
+        }
+        final String longDesc = GPXUtils.gpxNodeChildText(gcCache, "long_description", GROUNDSPEAK_NS);
+        if (longDesc != null) {
+            cache.setDescription(XmlUtils.validate(longDesc));
+        }
+
+        parseGroundspeakAttributes(gcCache, cache);
+        parseGroundspeakTravelbugs(gcCache, cache);
+    }
+
+    @Nullable
+    @Override
+    public List<LogEntry> extractLogs(final XmlNode wptNode, final Geocache cache) {
+        final XmlNode gcNode = GPXUtils.gpxNodeChild(wptNode, "cache", GROUNDSPEAK_NS);
+        if (gcNode == null) {
+            return null;
+        }
+        final boolean gcConnector = ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector;
+        final XmlNode logsNode = GPXUtils.gpxNodeChild(gcNode, "logs", GROUNDSPEAK_NS);
+        if (logsNode == null) {
+            return null;
+        }
+        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
+        if (logNodes == null) {
+            return null;
+        }
+        final List<LogEntry> result = new ArrayList<>();
+        for (final XmlNode logNode : logNodes) {
+            final LogEntry.Builder builder = new LogEntry.Builder();
+            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", GROUNDSPEAK_NS);
+            if (idText != null) {
+                try {
+                    builder.setId(Integer.parseInt(idText.trim()));
+                    if (gcConnector) {
+                        builder.setServiceLogId(GCUtils.logIdToLogCode(builder.getId()));
+                    }
+                } catch (final NumberFormatException ignored) {
+                    // ignore malformed id
+                }
+            }
+            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", GROUNDSPEAK_NS));
+            if (date != null) {
+                builder.setDate(date.getTime());
+            }
+            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", GROUNDSPEAK_NS);
+            if (typeText != null) {
+                builder.setLogType(LogType.getByType(XmlUtils.validate(typeText)));
+            }
+            final String finder = GPXUtils.gpxNodeChildText(logNode, "finder", GROUNDSPEAK_NS);
+            if (finder != null) {
+                builder.setAuthor(XmlUtils.validate(finder));
+            }
+            final String text = GPXUtils.gpxNodeChildText(logNode, "text", GROUNDSPEAK_NS);
+            if (text != null) {
+                builder.setLog(XmlUtils.validate(text));
+            }
+            final LogEntry log = builder.build();
+            if (log.logType != LogType.UNKNOWN) {
+                result.add(log);
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    private void parseGroundspeakAttributes(final XmlNode gcCache, final Geocache cache) {
+        final XmlNode attributes = GPXUtils.gpxNodeChild(gcCache, "attributes", GROUNDSPEAK_NS);
+        if (attributes == null) {
+            return;
+        }
+        final List<XmlNode> attributeNodes = GPXUtils.gpxNodeChildren(attributes, "attribute");
+        if (attributeNodes == null) {
+            return;
+        }
+        final List<String> result = new ArrayList<>();
+        for (final XmlNode attributeNode : attributeNodes) {
+            final String idText = GPXUtils.gpxNodeAttrValue(attributeNode, "id", GROUNDSPEAK_NS);
+            final String incText = GPXUtils.gpxNodeAttrValue(attributeNode, "inc", GROUNDSPEAK_NS);
+            if (idText == null || incText == null) {
+                continue;
+            }
+            try {
+                final int attributeId = Integer.parseInt(idText.trim());
+                final boolean active = Integer.parseInt(incText.trim()) != 0;
+                final CacheAttribute attribute = CacheAttribute.getById(attributeId);
+                if (attribute != null) {
+                    result.add(attribute.getValue(active));
+                }
+            } catch (final NumberFormatException ignored) {
+                // ignore malformed attribute entries
+            }
+        }
+        cache.setAttributes(result);
+    }
+
+    private void parseGroundspeakTravelbugs(final XmlNode gcCache, final Geocache cache) {
+        final XmlNode travelbugs = GPXUtils.gpxNodeChild(gcCache, "travelbugs", GROUNDSPEAK_NS);
+        if (travelbugs == null) {
+            return;
+        }
+        final List<XmlNode> tbNodes = GPXUtils.gpxNodeChildren(travelbugs, "travelbug");
+        if (tbNodes == null) {
+            return;
+        }
+        for (final XmlNode tbNode : tbNodes) {
+            final Trackable trackable = new Trackable();
+            final String ref = GPXUtils.gpxNodeAttrValue(tbNode, "ref", GROUNDSPEAK_NS);
+            if (ref != null) {
+                trackable.setGeocode(ref);
+            }
+            final String tbName = GPXUtils.gpxNodeChildText(tbNode, "name", GROUNDSPEAK_NS);
+            if (tbName != null) {
+                trackable.setName(XmlUtils.validate(tbName));
+            }
+            if (StringUtils.isNotBlank(trackable.getGeocode()) && StringUtils.isNotBlank(trackable.getName())) {
+                cache.addInventoryItem(trackable);
+            }
+        }
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/GroundspeakGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/GroundspeakGPXExtension.java
@@ -39,36 +39,36 @@ public class GroundspeakGPXExtension implements IGPXExtension {
      */
     @Override
     public void enrichGeocache(final XmlNode wptNode, final Geocache cache) {
-        final XmlNode gcCache = GPXUtils.gpxNodeChild(wptNode, "cache", GROUNDSPEAK_NS);
+        final XmlNode gcCache = GPXUtils.gpxChild(wptNode, "cache", GROUNDSPEAK_NS);
         if (gcCache == null) {
             return;
         }
-        final String id = GPXUtils.gpxNodeAttrValue(gcCache, "id", GROUNDSPEAK_NS);
+        final String id = GPXUtils.gpxAttrValue(gcCache, "id", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(id)) {
             cache.setCacheId(id);
         }
-        final String archived = GPXUtils.gpxNodeAttrValue(gcCache, "archived", GROUNDSPEAK_NS);
+        final String archived = GPXUtils.gpxAttrValue(gcCache, "archived", GROUNDSPEAK_NS);
         if (archived != null) {
             cache.setArchived("true".equalsIgnoreCase(archived));
         }
-        final String available = GPXUtils.gpxNodeAttrValue(gcCache, "available", GROUNDSPEAK_NS);
+        final String available = GPXUtils.gpxAttrValue(gcCache, "available", GROUNDSPEAK_NS);
         if (available != null) {
             cache.setDisabled(!"true".equalsIgnoreCase(available));
         }
 
-        final String name = GPXUtils.gpxNodeChildText(gcCache, "name", GROUNDSPEAK_NS);
+        final String name = GPXUtils.gpxChildText(gcCache, "name", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(name)) {
             cache.setName(XmlUtils.validate(name));
         }
-        final String owner = GPXUtils.gpxNodeChildText(gcCache, "owner", GROUNDSPEAK_NS);
+        final String owner = GPXUtils.gpxChildText(gcCache, "owner", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(owner)) {
             cache.setOwnerUserId(XmlUtils.validate(owner));
         }
-        final String placedBy = GPXUtils.gpxNodeChildText(gcCache, "placed_by", GROUNDSPEAK_NS);
+        final String placedBy = GPXUtils.gpxChildText(gcCache, "placed_by", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(placedBy)) {
             cache.setOwnerDisplayName(XmlUtils.validate(placedBy));
         }
-        final String gcType = GPXUtils.gpxNodeChildText(gcCache, "type", GROUNDSPEAK_NS);
+        final String gcType = GPXUtils.gpxChildText(gcCache, "type", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(gcType)) {
             String body = XmlUtils.validate(gcType);
             if (body.startsWith("Geocache|")) {
@@ -76,35 +76,35 @@ public class GroundspeakGPXExtension implements IGPXExtension {
             }
             cache.setType(CacheType.getByPattern(body));
         }
-        final String container = GPXUtils.gpxNodeChildText(gcCache, "container", GROUNDSPEAK_NS);
+        final String container = GPXUtils.gpxChildText(gcCache, "container", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(container)) {
             cache.setSize(CacheSize.getById(XmlUtils.validate(container)));
         }
-        final Float difficulty = GPXUtils.gpxNodeChildFloat(gcCache, "difficulty", GROUNDSPEAK_NS, null);
+        final Float difficulty = GPXUtils.gpxChildFloat(gcCache, "difficulty", GROUNDSPEAK_NS, null);
         if (difficulty != null) {
             cache.setDifficulty(difficulty);
         }
-        final Float terrain = GPXUtils.gpxNodeChildFloat(gcCache, "terrain", GROUNDSPEAK_NS, null);
+        final Float terrain = GPXUtils.gpxChildFloat(gcCache, "terrain", GROUNDSPEAK_NS, null);
         if (terrain != null) {
             cache.setTerrain(terrain);
         }
-        final String country = GPXUtils.gpxNodeChildText(gcCache, "country", GROUNDSPEAK_NS);
+        final String country = GPXUtils.gpxChildText(gcCache, "country", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(country)) {
             cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? XmlUtils.validate(country) : cache.getLocation() + ", " + country.trim());
         }
-        final String state = GPXUtils.gpxNodeChildText(gcCache, "state", GROUNDSPEAK_NS);
+        final String state = GPXUtils.gpxChildText(gcCache, "state", GROUNDSPEAK_NS);
         if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
             cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? XmlUtils.validate(state) : state.trim() + ", " + cache.getLocation());
         }
-        final String hints = GPXUtils.gpxNodeChildText(gcCache, "encoded_hints", GROUNDSPEAK_NS);
+        final String hints = GPXUtils.gpxChildText(gcCache, "encoded_hints", GROUNDSPEAK_NS);
         if (hints != null) {
             cache.setHint(XmlUtils.validate(hints));
         }
-        final String shortDesc = GPXUtils.gpxNodeChildText(gcCache, "short_description", GROUNDSPEAK_NS);
+        final String shortDesc = GPXUtils.gpxChildText(gcCache, "short_description", GROUNDSPEAK_NS);
         if (shortDesc != null) {
             cache.setShortDescription(XmlUtils.validate(shortDesc));
         }
-        final String longDesc = GPXUtils.gpxNodeChildText(gcCache, "long_description", GROUNDSPEAK_NS);
+        final String longDesc = GPXUtils.gpxChildText(gcCache, "long_description", GROUNDSPEAK_NS);
         if (longDesc != null) {
             cache.setDescription(XmlUtils.validate(longDesc));
         }
@@ -116,23 +116,23 @@ public class GroundspeakGPXExtension implements IGPXExtension {
     @Nullable
     @Override
     public List<LogEntry> extractLogs(final XmlNode wptNode, final Geocache cache) {
-        final XmlNode gcNode = GPXUtils.gpxNodeChild(wptNode, "cache", GROUNDSPEAK_NS);
+        final XmlNode gcNode = GPXUtils.gpxChild(wptNode, "cache", GROUNDSPEAK_NS);
         if (gcNode == null) {
             return null;
         }
         final boolean gcConnector = ConnectorFactory.getConnector(cache.getGeocode()) instanceof GCConnector;
-        final XmlNode logsNode = GPXUtils.gpxNodeChild(gcNode, "logs", GROUNDSPEAK_NS);
+        final XmlNode logsNode = GPXUtils.gpxChild(gcNode, "logs", GROUNDSPEAK_NS);
         if (logsNode == null) {
             return null;
         }
-        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
+        final List<XmlNode> logNodes = GPXUtils.gpxChildren(logsNode, "log", GROUNDSPEAK_NS);
         if (logNodes == null) {
             return null;
         }
         final List<LogEntry> result = new ArrayList<>();
         for (final XmlNode logNode : logNodes) {
             final LogEntry.Builder builder = new LogEntry.Builder();
-            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", GROUNDSPEAK_NS);
+            final String idText = GPXUtils.gpxAttrValue(logNode, "id", GROUNDSPEAK_NS);
             if (idText != null) {
                 try {
                     builder.setId(Integer.parseInt(idText.trim()));
@@ -143,19 +143,19 @@ public class GroundspeakGPXExtension implements IGPXExtension {
                     // ignore malformed id
                 }
             }
-            final Date date = GPXUtils.gpxNodeChildDate(logNode, "date", GROUNDSPEAK_NS, null);
+            final Date date = GPXUtils.gpxChildDate(logNode, "date", GROUNDSPEAK_NS, null);
             if (date != null) {
                 builder.setDate(date.getTime());
             }
-            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", GROUNDSPEAK_NS);
+            final String typeText = GPXUtils.gpxChildText(logNode, "type", GROUNDSPEAK_NS);
             if (typeText != null) {
                 builder.setLogType(LogType.getByType(XmlUtils.validate(typeText)));
             }
-            final String finder = GPXUtils.gpxNodeChildText(logNode, "finder", GROUNDSPEAK_NS);
+            final String finder = GPXUtils.gpxChildText(logNode, "finder", GROUNDSPEAK_NS);
             if (finder != null) {
                 builder.setAuthor(XmlUtils.validate(finder));
             }
-            final String text = GPXUtils.gpxNodeChildText(logNode, "text", GROUNDSPEAK_NS);
+            final String text = GPXUtils.gpxChildText(logNode, "text", GROUNDSPEAK_NS);
             if (text != null) {
                 builder.setLog(XmlUtils.validate(text));
             }
@@ -168,18 +168,18 @@ public class GroundspeakGPXExtension implements IGPXExtension {
     }
 
     private void parseGroundspeakAttributes(final XmlNode gcCache, final Geocache cache) {
-        final XmlNode attributes = GPXUtils.gpxNodeChild(gcCache, "attributes", GROUNDSPEAK_NS);
+        final XmlNode attributes = GPXUtils.gpxChild(gcCache, "attributes", GROUNDSPEAK_NS);
         if (attributes == null) {
             return;
         }
-        final List<XmlNode> attributeNodes = GPXUtils.gpxNodeChildren(attributes, "attribute");
+        final List<XmlNode> attributeNodes = GPXUtils.gpxChildren(attributes, "attribute", GROUNDSPEAK_NS);
         if (attributeNodes == null) {
             return;
         }
         final List<String> result = new ArrayList<>();
         for (final XmlNode attributeNode : attributeNodes) {
-            final String idText = GPXUtils.gpxNodeAttrValue(attributeNode, "id", GROUNDSPEAK_NS);
-            final String incText = GPXUtils.gpxNodeAttrValue(attributeNode, "inc", GROUNDSPEAK_NS);
+            final String idText = GPXUtils.gpxAttrValue(attributeNode, "id", GROUNDSPEAK_NS);
+            final String incText = GPXUtils.gpxAttrValue(attributeNode, "inc", GROUNDSPEAK_NS);
             if (idText == null || incText == null) {
                 continue;
             }
@@ -198,21 +198,21 @@ public class GroundspeakGPXExtension implements IGPXExtension {
     }
 
     private void parseGroundspeakTravelbugs(final XmlNode gcCache, final Geocache cache) {
-        final XmlNode travelbugs = GPXUtils.gpxNodeChild(gcCache, "travelbugs", GROUNDSPEAK_NS);
+        final XmlNode travelbugs = GPXUtils.gpxChild(gcCache, "travelbugs", GROUNDSPEAK_NS);
         if (travelbugs == null) {
             return;
         }
-        final List<XmlNode> tbNodes = GPXUtils.gpxNodeChildren(travelbugs, "travelbug");
+        final List<XmlNode> tbNodes = GPXUtils.gpxChildren(travelbugs, "travelbug", GROUNDSPEAK_NS);
         if (tbNodes == null) {
             return;
         }
         for (final XmlNode tbNode : tbNodes) {
             final Trackable trackable = new Trackable();
-            final String ref = GPXUtils.gpxNodeAttrValue(tbNode, "ref", GROUNDSPEAK_NS);
+            final String ref = GPXUtils.gpxAttrValue(tbNode, "ref", GROUNDSPEAK_NS);
             if (ref != null) {
                 trackable.setGeocode(ref);
             }
-            final String tbName = GPXUtils.gpxNodeChildText(tbNode, "name", GROUNDSPEAK_NS);
+            final String tbName = GPXUtils.gpxChildText(tbNode, "name", GROUNDSPEAK_NS);
             if (tbName != null) {
                 trackable.setName(XmlUtils.validate(tbName));
             }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXExtension.java
@@ -9,15 +9,15 @@ import java.util.List;
 
 public interface IGPXExtension {
 
-    default void enrichGeocache(XmlNode wptNode, Geocache cache) {
+    default void enrichGeocache(final XmlNode wptNode, final Geocache cache) {
         //do nothing
     }
 
-    default void enrichWaypoint(XmlNode wptNode, Waypoint waypoint) {
+    default void enrichWaypoint(final XmlNode wptNode, final Waypoint waypoint) {
         //do nothing
     }
 
-    default List<LogEntry> extractLogs(XmlNode wptNode, Geocache cache) {
+    default List<LogEntry> extractLogs(final XmlNode wptNode, final Geocache cache) {
         return null;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXExtension.java
@@ -1,0 +1,23 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.utils.xml.XmlNode;
+
+import java.util.List;
+
+public interface IGPXExtension {
+
+    default void enrichGeocache(XmlNode wptNode, Geocache cache) {
+        //do nothing
+    }
+
+    default void enrichWaypoint(XmlNode wptNode, Waypoint waypoint) {
+        //do nothing
+    }
+
+    default List<LogEntry> extractLogs(XmlNode wptNode, Geocache cache) {
+        return null;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXParseHooks.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXParseHooks.java
@@ -15,55 +15,55 @@ import java.util.List;
 public interface IGPXParseHooks {
 
     /** Called once, right after the root {@code <gpx>} element (and its {@code creator} attribute, if any) was read. */
-    GPXParser.ParseMode onInit(@Nullable String gpxCreatorOrName);
+    ParseMode onInit(@Nullable String gpxCreatorOrName);
 
     /**
-     * Called only when {@code geocacheParseMode} is {@link GPXParser.ParseMode#FULL}
+     * Called only when {@code geocacheParseMode} is {@link ParseMode#FULL}
      * @param logs the geocache's logs, in document order; {@code null} if no log tag was found
      */
-    GPXParser.ParseMode onGeocache(@NonNull Geocache geocache, @Nullable List<LogEntry> logs);
+    ParseMode onGeocache(@NonNull Geocache geocache, @Nullable List<LogEntry> logs);
 
     /**
-     * Called only when {@code waypointParseMode} is {@link GPXParser.ParseMode#FULL}
+     * Called only when {@code waypointParseMode} is {@link ParseMode#FULL}
      * Coordinates may be {@code null}, e.g. for an unsolved stage. Extension flags, prefix and
      * listing/user notes are populated before this callback. Attaching the waypoint to its parent
      * (and marking that parent's coordinates as user-modified for an ORIGINAL waypoint) is the caller's responsibility.
      * @param parentGeocode best-effort resolved parent geocode (see D1/D6); may be {@code null}
      */
-    GPXParser.ParseMode onWaypoint(@NonNull Waypoint waypoint, @Nullable String parentGeocode);
+    ParseMode onWaypoint(@NonNull Waypoint waypoint, @Nullable String parentGeocode);
 
     /** Bare coordinate; missing or invalid latitude/longitude components are replaced with zero. */
-    GPXParser.ParseMode onCoordinate(ICoordinate coordinate);
+    ParseMode onCoordinate(ICoordinate coordinate);
 
     /** Named coordinate; missing or invalid latitude/longitude components are replaced with zero. */
-    GPXParser.ParseMode onNamedCoordinate(NamedGeoCoordinate coordinate);
+    ParseMode onNamedCoordinate(NamedGeoCoordinate coordinate);
 
-    /** @return the {@link GPXParser.ParseMode} to use for this specific route (null for default) */
+    /** @return the {@link ParseMode} to use for this specific route (null for default) */
     @Nullable
-    GPXParser.ParseMode onRouteStart();
+    ParseMode onRouteStart();
 
     /**
      * @param name       the route's {@code <name>}, if any; may be {@code null}
      * @param pointCount number of {@code <rtept>} children, including entries with missing/invalid coordinates and skipped entries
      */
-    GPXParser.ParseMode onRouteEnd(@Nullable String name, int pointCount);
+    ParseMode onRouteEnd(@Nullable String name, int pointCount);
 
-    /** @return the {@link GPXParser.ParseMode} to use for this specific track; (null for default) */
+    /** @return the {@link ParseMode} to use for this specific track; (null for default) */
     @Nullable
-    GPXParser.ParseMode onTrackStart();
+    ParseMode onTrackStart();
 
-    /** @return the {@link GPXParser.ParseMode} to use for this specific track segment; (null for default) */
+    /** @return the {@link ParseMode} to use for this specific track segment; (null for default) */
     @Nullable
-    GPXParser.ParseMode onTrackSegmentStart();
+    ParseMode onTrackSegmentStart();
 
     /**
      * @param name       the track segment's {@code <name>}, if any; may be {@code null}
      * @param pointCount number of {@code <trkpt>} children, including entries with missing/invalid coordinates and skipped entries
      */
-    GPXParser.ParseMode onTrackSegmentEnd(@Nullable String name, int pointCount);
+    ParseMode onTrackSegmentEnd(@Nullable String name, int pointCount);
 
     /**@param name the track's {@code <name>}, if any; may be {@code null} */
-    GPXParser.ParseMode onTrackEnd(@Nullable String name, int segmentCount, int totalPointCount);
+    ParseMode onTrackEnd(@Nullable String name, int segmentCount, int totalPointCount);
 }
 
 

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXParseHooks.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXParseHooks.java
@@ -15,52 +15,55 @@ import java.util.List;
 public interface IGPXParseHooks {
 
     /** Called once, right after the root {@code <gpx>} element (and its {@code creator} attribute, if any) was read. */
-    void onInit(@Nullable String gpxCreatorOrName);
+    GPXParser.ParseMode onInit(@Nullable String gpxCreatorOrName);
 
     /**
-     * Called only when {@code geocacheParseMode} is {@link GPXParser.WptParseMode#FULL}
+     * Called only when {@code geocacheParseMode} is {@link GPXParser.ParseMode#FULL}
      * @param logs the geocache's logs, in document order; {@code null} if no log tag was found
      */
-    void onGeocache(@NonNull Geocache geocache, @Nullable List<LogEntry> logs);
+    GPXParser.ParseMode onGeocache(@NonNull Geocache geocache, @Nullable List<LogEntry> logs);
 
     /**
-     * Called only when {@code waypointParseMode} is {@link GPXParser.WptParseMode#FULL}
+     * Called only when {@code waypointParseMode} is {@link GPXParser.ParseMode#FULL}
+     * Coordinates may be {@code null}, e.g. for an unsolved stage. Extension flags, prefix and
+     * listing/user notes are populated before this callback. Attaching the waypoint to its parent
+     * (and marking that parent's coordinates as user-modified for an ORIGINAL waypoint) is the caller's responsibility.
      * @param parentGeocode best-effort resolved parent geocode (see D1/D6); may be {@code null}
      */
-    void onWaypoint(@NonNull Waypoint waypoint, @Nullable String parentGeocode);
+    GPXParser.ParseMode onWaypoint(@NonNull Waypoint waypoint, @Nullable String parentGeocode);
 
-    /** Bare coordinate: only lat/lon, nothing else usable. */
-    void onCoordinate(ICoordinate coordinate);
+    /** Bare coordinate; missing or invalid latitude/longitude components are replaced with zero. */
+    GPXParser.ParseMode onCoordinate(ICoordinate coordinate);
 
-    /** Has a name and/or elevation and/or geocode, but wasn't classified as geocache/waypoint. */
-    void onNamedCoordinate(NamedGeoCoordinate coordinate);
+    /** Named coordinate; missing or invalid latitude/longitude components are replaced with zero. */
+    GPXParser.ParseMode onNamedCoordinate(NamedGeoCoordinate coordinate);
 
-    /** @return the {@link GPXParser.WptParseMode} to use for this specific route (null for default) */
+    /** @return the {@link GPXParser.ParseMode} to use for this specific route (null for default) */
     @Nullable
-    GPXParser.WptParseMode onRouteStart();
+    GPXParser.ParseMode onRouteStart();
 
     /**
      * @param name       the route's {@code <name>}, if any; may be {@code null}
-     * @param pointCount number of {@code <rtept>} children with valid lat/lon
+     * @param pointCount number of {@code <rtept>} children, including entries with missing/invalid coordinates and skipped entries
      */
-    void onRouteEnd(@Nullable String name, int pointCount);
+    GPXParser.ParseMode onRouteEnd(@Nullable String name, int pointCount);
 
-    /** @return the {@link GPXParser.WptParseMode} to use for this specific track; (null for default) */
+    /** @return the {@link GPXParser.ParseMode} to use for this specific track; (null for default) */
     @Nullable
-    GPXParser.WptParseMode onTrackStart();
+    GPXParser.ParseMode onTrackStart();
 
-    /** @return the {@link GPXParser.WptParseMode} to use for this specific track segment; (null for default) */
+    /** @return the {@link GPXParser.ParseMode} to use for this specific track segment; (null for default) */
     @Nullable
-    GPXParser.WptParseMode onTrackSegmentStart();
+    GPXParser.ParseMode onTrackSegmentStart();
 
     /**
      * @param name       the track segment's {@code <name>}, if any; may be {@code null}
-     * @param pointCount number of {@code <trkpt>} children with valid lat/lon
+     * @param pointCount number of {@code <trkpt>} children, including entries with missing/invalid coordinates and skipped entries
      */
-    void onTrackSegmentEnd(@Nullable String name, int pointCount);
+    GPXParser.ParseMode onTrackSegmentEnd(@Nullable String name, int pointCount);
 
     /**@param name the track's {@code <name>}, if any; may be {@code null} */
-    void onTrackEnd(@Nullable String name, int segmentCount, int totalPointCount);
+    GPXParser.ParseMode onTrackEnd(@Nullable String name, int segmentCount, int totalPointCount);
 }
 
 

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXParseHooks.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/IGPXParseHooks.java
@@ -1,0 +1,67 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.ICoordinate;
+import cgeo.geocaching.models.NamedGeoCoordinate;
+import cgeo.geocaching.models.Waypoint;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+/** Callback interface for {@link GPXParser}. */
+public interface IGPXParseHooks {
+
+    /** Called once, right after the root {@code <gpx>} element (and its {@code creator} attribute, if any) was read. */
+    void onInit(@Nullable String gpxCreatorOrName);
+
+    /**
+     * Called only when {@code geocacheParseMode} is {@link GPXParser.WptParseMode#FULL}
+     * @param logs the geocache's logs, in document order; {@code null} if no log tag was found
+     */
+    void onGeocache(@NonNull Geocache geocache, @Nullable List<LogEntry> logs);
+
+    /**
+     * Called only when {@code waypointParseMode} is {@link GPXParser.WptParseMode#FULL}
+     * @param parentGeocode best-effort resolved parent geocode (see D1/D6); may be {@code null}
+     */
+    void onWaypoint(@NonNull Waypoint waypoint, @Nullable String parentGeocode);
+
+    /** Bare coordinate: only lat/lon, nothing else usable. */
+    void onCoordinate(ICoordinate coordinate);
+
+    /** Has a name and/or elevation and/or geocode, but wasn't classified as geocache/waypoint. */
+    void onNamedCoordinate(NamedGeoCoordinate coordinate);
+
+    /** @return the {@link GPXParser.WptParseMode} to use for this specific route (null for default) */
+    @Nullable
+    GPXParser.WptParseMode onRouteStart();
+
+    /**
+     * @param name       the route's {@code <name>}, if any; may be {@code null}
+     * @param pointCount number of {@code <rtept>} children with valid lat/lon
+     */
+    void onRouteEnd(@Nullable String name, int pointCount);
+
+    /** @return the {@link GPXParser.WptParseMode} to use for this specific track; (null for default) */
+    @Nullable
+    GPXParser.WptParseMode onTrackStart();
+
+    /** @return the {@link GPXParser.WptParseMode} to use for this specific track segment; (null for default) */
+    @Nullable
+    GPXParser.WptParseMode onTrackSegmentStart();
+
+    /**
+     * @param name       the track segment's {@code <name>}, if any; may be {@code null}
+     * @param pointCount number of {@code <trkpt>} children with valid lat/lon
+     */
+    void onTrackSegmentEnd(@Nullable String name, int pointCount);
+
+    /**@param name the track's {@code <name>}, if any; may be {@code null} */
+    void onTrackEnd(@Nullable String name, int segmentCount, int totalPointCount);
+}
+
+
+

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/OpenCachingGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/OpenCachingGPXExtension.java
@@ -17,19 +17,19 @@ public class OpenCachingGPXExtension implements IGPXExtension {
 
     @Override
     public void enrichGeocache(final XmlNode wptNode, final Geocache cache) {
-        final XmlNode ocCache = GPXUtils.gpxNodeChild(wptNode, "cache", OPENCACHING_NS);
+        final XmlNode ocCache = GPXUtils.gpxChild(wptNode, "cache", OPENCACHING_NS);
         if (ocCache == null) {
             return;
         }
-        final Boolean requiresPassword = GPXUtils.gpxNodeChildBoolean(ocCache, "requires_password", OPENCACHING_NS, null);
+        final Boolean requiresPassword = GPXUtils.gpxChildBoolean(ocCache, "requires_password", OPENCACHING_NS, null);
         if (requiresPassword != null) {
             cache.setLogPasswordRequired(requiresPassword);
         }
-        final String otherCode = GPXUtils.gpxNodeChildText(ocCache, "other_code", OPENCACHING_NS);
+        final String otherCode = GPXUtils.gpxChildText(ocCache, "other_code", OPENCACHING_NS);
         if (StringUtils.isNotBlank(otherCode)) {
             cache.setDescription(Geocache.getAlternativeListingText(otherCode.trim()) + cache.getDescription());
         }
-        final String size = GPXUtils.gpxNodeChildText(ocCache, "size", OPENCACHING_NS);
+        final String size = GPXUtils.gpxChildText(ocCache, "size", OPENCACHING_NS);
         if (StringUtils.isNotBlank(size)) {
             final CacheSize cacheSize = CacheSize.getById(size);
             if (cacheSize != CacheSize.UNKNOWN) {

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/OpenCachingGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/OpenCachingGPXExtension.java
@@ -1,0 +1,42 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.xml.XmlNode;
+
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class OpenCachingGPXExtension implements IGPXExtension {
+
+    //Namespaces of extensions
+    private static final Set<String> OPENCACHING_NS = Set.of(
+            "https://github.com/opencaching/gpx-extension-v1"
+    );
+
+    @Override
+    public void enrichGeocache(final XmlNode wptNode, final Geocache cache) {
+        final XmlNode ocCache = GPXUtils.gpxNodeChild(wptNode, "cache", OPENCACHING_NS);
+        if (ocCache == null) {
+            return;
+        }
+        final String requiresPassword = GPXUtils.gpxNodeChildText(ocCache, "requires_password", OPENCACHING_NS);
+        if (requiresPassword != null) {
+            cache.setLogPasswordRequired(Boolean.parseBoolean(requiresPassword.trim()));
+        }
+        final String otherCode = GPXUtils.gpxNodeChildText(ocCache, "other_code", OPENCACHING_NS);
+        if (StringUtils.isNotBlank(otherCode)) {
+            cache.setDescription(Geocache.getAlternativeListingText(otherCode.trim()) + cache.getDescription());
+        }
+        final String size = GPXUtils.gpxNodeChildText(ocCache, "size", OPENCACHING_NS);
+        if (StringUtils.isNotBlank(size)) {
+            final CacheSize cacheSize = CacheSize.getById(size);
+            if (cacheSize != CacheSize.UNKNOWN) {
+                cache.setSize(cacheSize);
+            }
+        }
+    }
+
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/OpenCachingGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/OpenCachingGPXExtension.java
@@ -21,9 +21,9 @@ public class OpenCachingGPXExtension implements IGPXExtension {
         if (ocCache == null) {
             return;
         }
-        final String requiresPassword = GPXUtils.gpxNodeChildText(ocCache, "requires_password", OPENCACHING_NS);
+        final Boolean requiresPassword = GPXUtils.gpxNodeChildBoolean(ocCache, "requires_password", OPENCACHING_NS, null);
         if (requiresPassword != null) {
-            cache.setLogPasswordRequired(Boolean.parseBoolean(requiresPassword.trim()));
+            cache.setLogPasswordRequired(requiresPassword);
         }
         final String otherCode = GPXUtils.gpxNodeChildText(ocCache, "other_code", OPENCACHING_NS);
         if (StringUtils.isNotBlank(otherCode)) {

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/ParseMode.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/ParseMode.java
@@ -1,0 +1,23 @@
+package cgeo.geocaching.utils.gpx;
+
+/**
+ * Controls how wptTypes are parsed.
+ */
+public enum ParseMode {
+    /**
+     * Parse/collect complete information.
+     */
+    FULL,
+    /**
+     * Parse only basic data per wptType (name + coordinate)
+     */
+    COORDINATES_ONLY,
+    /**
+     * Do not collect wptType data.
+     */
+    SKIP,
+    /**
+     * Flag to use to abort parsing completely
+     */
+    ABORT
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/RecordingGPXParseHooks.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/RecordingGPXParseHooks.java
@@ -18,145 +18,87 @@ import java.util.List;
  */
 public class RecordingGPXParseHooks implements IGPXParseHooks {
 
-    /** kind of a single, top-level (or route-/track-embedded) recorded item; see {@link #getItems()} */
+    /** kind of a single, top-level (or route-/track-embedded) recorded item; see {@link #getGlobalItems()} */
     public enum ItemKind { GEOCACHE, WAYPOINT, NAMED_COORDINATE, COORDINATE }
 
     /** a single recorded geocache/waypoint/(named) coordinate, in the order it was encountered */
-    public static final class RecordedItem {
-        private final ItemKind kind;
-        private final ICoordinate coordinate;
-        private final String parentGeocode;
-        private final List<LogEntry> logs;
+    public static final class Item {
+        public final ItemKind kind;
+        public final ICoordinate coordinate;
+        public final String parentGeocode;
+        public final List<LogEntry> logs;
 
-        RecordedItem(final ItemKind kind, final ICoordinate coordinate, final String parentGeocode) {
-            this(kind, coordinate, parentGeocode, null);
-        }
-
-        RecordedItem(final ItemKind kind, final ICoordinate coordinate, final String parentGeocode, final List<LogEntry> logs) {
-            this.kind = kind;
+        Item(final ICoordinate coordinate, final String parentGeocode, final List<LogEntry> logs) {
+            this.kind = calculateKind(coordinate);
             this.coordinate = coordinate;
             this.parentGeocode = parentGeocode;
             this.logs = logs;
         }
 
-        public ItemKind getKind() {
-            return kind;
+        private ItemKind calculateKind(final ICoordinate coordinate) {
+            if (coordinate instanceof Geocache) {
+                return ItemKind.GEOCACHE;
+            } else if (coordinate instanceof Waypoint) {
+                return ItemKind.WAYPOINT;
+            } else if (coordinate instanceof NamedGeoCoordinate) {
+                return ItemKind.NAMED_COORDINATE;
+            } else {
+                return ItemKind.COORDINATE;
+            }
         }
 
-        public ICoordinate getCoordinate() {
-            return coordinate;
-        }
-
-        /** only set for {@link ItemKind#WAYPOINT}; the best-effort resolved parent geocode, may be {@code null} */
-        @Nullable
-        public String getParentGeocode() {
-            return parentGeocode;
-        }
-
-        /** only set for {@link ItemKind#GEOCACHE}; the geocache's logs, {@code null} if none were found */
-        @Nullable
-        public List<LogEntry> getLogs() {
-            return logs;
-        }
     }
 
     /** a single recorded route ({@code <rte>}) */
-    public static final class RecordedRoute {
-        private final String name;
-        private final int pointCount;
-        private final List<ICoordinate> points;
+    public static final class NamedCoordinateList {
+        public final String name;
+        public final int pointCount;
+        public final List<ICoordinate> points;
 
-        RecordedRoute(final String name, final int pointCount, final List<ICoordinate> points) {
+        NamedCoordinateList(final String name, final int pointCount, final List<ICoordinate> points) {
             this.name = name;
             this.pointCount = pointCount;
             this.points = points;
-        }
-
-        @Nullable
-        public String getName() {
-            return name;
-        }
-
-        /** authoritative count of valid points, see {@link IGPXParseHooks#onRouteEnd}; may exceed {@link #getPoints()}'s size under {@link GPXParser.WptParseMode#SKIP} */
-        public int getPointCount() {
-            return pointCount;
-        }
-
-        /** points actually reported via hooks while this route was being parsed; empty under {@link GPXParser.WptParseMode#SKIP} */
-        public List<ICoordinate> getPoints() {
-            return points;
-        }
-    }
-
-    /** a single recorded track segment ({@code <trkseg>}) */
-    public static final class RecordedTrackSegment {
-        private final String name;
-        private final int pointCount;
-        private final List<ICoordinate> points;
-
-        RecordedTrackSegment(final String name, final int pointCount, final List<ICoordinate> points) {
-            this.name = name;
-            this.pointCount = pointCount;
-            this.points = points;
-        }
-
-        @Nullable
-        public String getName() {
-            return name;
-        }
-
-        public int getPointCount() {
-            return pointCount;
-        }
-
-        public List<ICoordinate> getPoints() {
-            return points;
         }
     }
 
     /** a single recorded track ({@code <trk>}), made up of its recorded segments */
-    public static final class RecordedTrack {
-        private final String name;
-        private final int segmentCount;
-        private final int totalPointCount;
-        private final List<RecordedTrackSegment> segments;
+    public static final class Track {
+        public final String name;
+        public final int segmentCount;
+        public final int totalPointCount;
+        public final List<NamedCoordinateList> segments;
 
-        RecordedTrack(final String name, final int segmentCount, final int totalPointCount, final List<RecordedTrackSegment> segments) {
+        Track(final String name, final int segmentCount, final int totalPointCount, final List<NamedCoordinateList> segments) {
             this.name = name;
             this.segmentCount = segmentCount;
             this.totalPointCount = totalPointCount;
             this.segments = segments;
         }
 
-        @Nullable
-        public String getName() {
-            return name;
-        }
-
-        public List<RecordedTrackSegment> getSegments() {
-            return segments;
-        }
-
-        public int getSegmentCount() {
-            return segmentCount;
-        }
-
-        public int getTotalPointCount() {
-            return totalPointCount;
-        }
     }
 
     private String gpxCreatorOrName;
-    private final List<RecordedItem> items = new ArrayList<>();
-    private final List<RecordedRoute> routes = new ArrayList<>();
-    private final List<RecordedTrack> tracks = new ArrayList<>();
+    private final List<Item> globalItems = new ArrayList<>();
+    private final List<NamedCoordinateList> routes = new ArrayList<>();
+    private final List<Track> tracks = new ArrayList<>();
 
     /** points recorded so far for the currently-open route; non-null only between onRouteStart and onRouteEnd */
     private List<ICoordinate> currentRoutePoints;
     /** points recorded so far for the currently-open track segment; non-null only between onTrackSegmentStart and onTrackSegmentEnd */
     private List<ICoordinate> currentSegmentPoints;
     /** segments recorded so far for the currently-open track; non-null only between onTrackStart and onTrackEnd */
-    private List<RecordedTrackSegment> currentTrackSegments;
+    private List<NamedCoordinateList> currentTrackSegments;
+
+    private GPXParser.ParseMode parseModeGlobal;
+    private GPXParser.ParseMode parseModeRoutes;
+    private GPXParser.ParseMode parseModeTracks;
+
+    public void setModes(final GPXParser.ParseMode global, final GPXParser.ParseMode routes, final GPXParser.ParseMode tracks) {
+        this.parseModeGlobal = global;
+        this.parseModeRoutes = routes;
+        this.parseModeTracks = tracks;
+    }
 
     @Nullable
     public String getGpxCreatorOrName() {
@@ -164,23 +106,23 @@ public class RecordingGPXParseHooks implements IGPXParseHooks {
     }
 
     /** all top-level (and route-/track-embedded) geocaches/waypoints/coordinates, in document order */
-    public List<RecordedItem> getItems() {
-        return items;
+    public List<Item> getGlobalItems() {
+        return globalItems;
     }
 
-    public List<RecordedRoute> getRoutes() {
+    public List<NamedCoordinateList> getRoutes() {
         return routes;
     }
 
-    public List<RecordedTrack> getTracks() {
+    public List<Track> getTracks() {
         return tracks;
     }
 
     public List<Geocache> getGeocaches() {
         final List<Geocache> result = new ArrayList<>();
-        for (final RecordedItem item : items) {
-            if (item.getKind() == ItemKind.GEOCACHE && item.getCoordinate() instanceof Geocache) {
-                result.add((Geocache) item.getCoordinate());
+        for (final Item item : globalItems) {
+            if (item.coordinate instanceof Geocache) {
+                result.add((Geocache) item.coordinate);
             }
         }
         return result;
@@ -188,87 +130,95 @@ public class RecordingGPXParseHooks implements IGPXParseHooks {
 
     public List<Waypoint> getWaypoints() {
         final List<Waypoint> result = new ArrayList<>();
-        for (final RecordedItem item : items) {
-            if (item.getKind() == ItemKind.WAYPOINT && item.getCoordinate() instanceof Waypoint) {
-                result.add((Waypoint) item.getCoordinate());
+        for (final Item item : globalItems) {
+            if (item.coordinate instanceof Waypoint) {
+                result.add((Waypoint) item.coordinate);
             }
         }
         return result;
     }
 
     /** records {@code item} globally, and additionally into the currently-open route's/segment's point list, if any */
-    private void record(final RecordedItem item) {
-        items.add(item);
+    private void record(final Item item) {
+        globalItems.add(item);
         if (currentRoutePoints != null) {
-            currentRoutePoints.add(item.getCoordinate());
+            currentRoutePoints.add(item.coordinate);
         }
         if (currentSegmentPoints != null) {
-            currentSegmentPoints.add(item.getCoordinate());
+            currentSegmentPoints.add(item.coordinate);
         }
     }
 
     @Override
-    public void onInit(@Nullable final String gpxCreatorOrName) {
+    public GPXParser.ParseMode onInit(@Nullable final String gpxCreatorOrName) {
         this.gpxCreatorOrName = gpxCreatorOrName;
+        return parseModeGlobal;
     }
 
     @Override
-    public void onGeocache(@NonNull final Geocache geocache, @Nullable final List<LogEntry> logs) {
-        record(new RecordedItem(ItemKind.GEOCACHE, geocache, null, logs));
+    public GPXParser.ParseMode onGeocache(@NonNull final Geocache geocache, @Nullable final List<LogEntry> logs) {
+        record(new Item(geocache, null, logs));
+        return null;
     }
 
     @Override
-    public void onWaypoint(@NonNull final Waypoint waypoint, @Nullable final String parentGeocode) {
-        record(new RecordedItem(ItemKind.WAYPOINT, waypoint, parentGeocode));
+    public GPXParser.ParseMode onWaypoint(@NonNull final Waypoint waypoint, @Nullable final String parentGeocode) {
+        record(new Item(waypoint, parentGeocode, null));
+        return null;
     }
 
     @Override
-    public void onCoordinate(final ICoordinate coordinate) {
-        record(new RecordedItem(ItemKind.COORDINATE, coordinate, null));
+    public GPXParser.ParseMode onCoordinate(final ICoordinate coordinate) {
+        record(new Item(coordinate, null, null));
+        return null;
     }
 
     @Override
-    public void onNamedCoordinate(final NamedGeoCoordinate coordinate) {
-        record(new RecordedItem(ItemKind.NAMED_COORDINATE, coordinate, null));
+    public GPXParser.ParseMode onNamedCoordinate(final NamedGeoCoordinate coordinate) {
+        record(new Item(coordinate, null, null));
+        return null;
     }
 
     @Nullable
     @Override
-    public GPXParser.WptParseMode onRouteStart() {
+    public GPXParser.ParseMode onRouteStart() {
         currentRoutePoints = new ArrayList<>();
-        return null; // defer to GPXParser's configured default route mode
+        return parseModeRoutes; // defer to GPXParser's configured default route mode
     }
 
     @Override
-    public void onRouteEnd(@Nullable final String name, final int pointCount) {
-        routes.add(new RecordedRoute(name, pointCount, currentRoutePoints));
+    public GPXParser.ParseMode onRouteEnd(@Nullable final String name, final int pointCount) {
+        routes.add(new NamedCoordinateList(name, pointCount, currentRoutePoints));
         currentRoutePoints = null;
+        return parseModeGlobal;
     }
 
     @Nullable
     @Override
-    public GPXParser.WptParseMode onTrackStart() {
+    public GPXParser.ParseMode onTrackStart() {
         currentTrackSegments = new ArrayList<>();
-        return null; // defer to GPXParser's configured default track mode
+        return parseModeTracks; // defer to GPXParser's configured default track mode
     }
 
     @Nullable
     @Override
-    public GPXParser.WptParseMode onTrackSegmentStart() {
+    public GPXParser.ParseMode onTrackSegmentStart() {
         currentSegmentPoints = new ArrayList<>();
         return null; // defer to the mode in effect for the enclosing track
     }
 
     @Override
-    public void onTrackSegmentEnd(@Nullable final String name, final int pointCount) {
-        currentTrackSegments.add(new RecordedTrackSegment(name, pointCount, currentSegmentPoints));
+    public GPXParser.ParseMode onTrackSegmentEnd(@Nullable final String name, final int pointCount) {
+        currentTrackSegments.add(new NamedCoordinateList(name, pointCount, currentSegmentPoints));
         currentSegmentPoints = null;
+        return null;
     }
 
     @Override
-    public void onTrackEnd(@Nullable final String name, final int segmentCount, final int totalPointCount) {
-        tracks.add(new RecordedTrack(name, segmentCount, totalPointCount, currentTrackSegments));
+    public GPXParser.ParseMode onTrackEnd(@Nullable final String name, final int segmentCount, final int totalPointCount) {
+        tracks.add(new Track(name, segmentCount, totalPointCount, currentTrackSegments));
         currentTrackSegments = null;
+        return parseModeGlobal;
     }
 }
 

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/RecordingGPXParseHooks.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/RecordingGPXParseHooks.java
@@ -1,0 +1,276 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.ICoordinate;
+import cgeo.geocaching.models.NamedGeoCoordinate;
+import cgeo.geocaching.models.Waypoint;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of {@link IGPXParseHooks} which simply records everything encountered during a
+ * parse run, in document order.
+ */
+public class RecordingGPXParseHooks implements IGPXParseHooks {
+
+    /** kind of a single, top-level (or route-/track-embedded) recorded item; see {@link #getItems()} */
+    public enum ItemKind { GEOCACHE, WAYPOINT, NAMED_COORDINATE, COORDINATE }
+
+    /** a single recorded geocache/waypoint/(named) coordinate, in the order it was encountered */
+    public static final class RecordedItem {
+        private final ItemKind kind;
+        private final ICoordinate coordinate;
+        private final String parentGeocode;
+        private final List<LogEntry> logs;
+
+        RecordedItem(final ItemKind kind, final ICoordinate coordinate, final String parentGeocode) {
+            this(kind, coordinate, parentGeocode, null);
+        }
+
+        RecordedItem(final ItemKind kind, final ICoordinate coordinate, final String parentGeocode, final List<LogEntry> logs) {
+            this.kind = kind;
+            this.coordinate = coordinate;
+            this.parentGeocode = parentGeocode;
+            this.logs = logs;
+        }
+
+        public ItemKind getKind() {
+            return kind;
+        }
+
+        public ICoordinate getCoordinate() {
+            return coordinate;
+        }
+
+        /** only set for {@link ItemKind#WAYPOINT}; the best-effort resolved parent geocode, may be {@code null} */
+        @Nullable
+        public String getParentGeocode() {
+            return parentGeocode;
+        }
+
+        /** only set for {@link ItemKind#GEOCACHE}; the geocache's logs, {@code null} if none were found */
+        @Nullable
+        public List<LogEntry> getLogs() {
+            return logs;
+        }
+    }
+
+    /** a single recorded route ({@code <rte>}) */
+    public static final class RecordedRoute {
+        private final String name;
+        private final int pointCount;
+        private final List<ICoordinate> points;
+
+        RecordedRoute(final String name, final int pointCount, final List<ICoordinate> points) {
+            this.name = name;
+            this.pointCount = pointCount;
+            this.points = points;
+        }
+
+        @Nullable
+        public String getName() {
+            return name;
+        }
+
+        /** authoritative count of valid points, see {@link IGPXParseHooks#onRouteEnd}; may exceed {@link #getPoints()}'s size under {@link GPXParser.WptParseMode#SKIP} */
+        public int getPointCount() {
+            return pointCount;
+        }
+
+        /** points actually reported via hooks while this route was being parsed; empty under {@link GPXParser.WptParseMode#SKIP} */
+        public List<ICoordinate> getPoints() {
+            return points;
+        }
+    }
+
+    /** a single recorded track segment ({@code <trkseg>}) */
+    public static final class RecordedTrackSegment {
+        private final String name;
+        private final int pointCount;
+        private final List<ICoordinate> points;
+
+        RecordedTrackSegment(final String name, final int pointCount, final List<ICoordinate> points) {
+            this.name = name;
+            this.pointCount = pointCount;
+            this.points = points;
+        }
+
+        @Nullable
+        public String getName() {
+            return name;
+        }
+
+        public int getPointCount() {
+            return pointCount;
+        }
+
+        public List<ICoordinate> getPoints() {
+            return points;
+        }
+    }
+
+    /** a single recorded track ({@code <trk>}), made up of its recorded segments */
+    public static final class RecordedTrack {
+        private final String name;
+        private final int segmentCount;
+        private final int totalPointCount;
+        private final List<RecordedTrackSegment> segments;
+
+        RecordedTrack(final String name, final int segmentCount, final int totalPointCount, final List<RecordedTrackSegment> segments) {
+            this.name = name;
+            this.segmentCount = segmentCount;
+            this.totalPointCount = totalPointCount;
+            this.segments = segments;
+        }
+
+        @Nullable
+        public String getName() {
+            return name;
+        }
+
+        public List<RecordedTrackSegment> getSegments() {
+            return segments;
+        }
+
+        public int getSegmentCount() {
+            return segmentCount;
+        }
+
+        public int getTotalPointCount() {
+            return totalPointCount;
+        }
+    }
+
+    private String gpxCreatorOrName;
+    private final List<RecordedItem> items = new ArrayList<>();
+    private final List<RecordedRoute> routes = new ArrayList<>();
+    private final List<RecordedTrack> tracks = new ArrayList<>();
+
+    /** points recorded so far for the currently-open route; non-null only between onRouteStart and onRouteEnd */
+    private List<ICoordinate> currentRoutePoints;
+    /** points recorded so far for the currently-open track segment; non-null only between onTrackSegmentStart and onTrackSegmentEnd */
+    private List<ICoordinate> currentSegmentPoints;
+    /** segments recorded so far for the currently-open track; non-null only between onTrackStart and onTrackEnd */
+    private List<RecordedTrackSegment> currentTrackSegments;
+
+    @Nullable
+    public String getGpxCreatorOrName() {
+        return gpxCreatorOrName;
+    }
+
+    /** all top-level (and route-/track-embedded) geocaches/waypoints/coordinates, in document order */
+    public List<RecordedItem> getItems() {
+        return items;
+    }
+
+    public List<RecordedRoute> getRoutes() {
+        return routes;
+    }
+
+    public List<RecordedTrack> getTracks() {
+        return tracks;
+    }
+
+    public List<Geocache> getGeocaches() {
+        final List<Geocache> result = new ArrayList<>();
+        for (final RecordedItem item : items) {
+            if (item.getKind() == ItemKind.GEOCACHE && item.getCoordinate() instanceof Geocache) {
+                result.add((Geocache) item.getCoordinate());
+            }
+        }
+        return result;
+    }
+
+    public List<Waypoint> getWaypoints() {
+        final List<Waypoint> result = new ArrayList<>();
+        for (final RecordedItem item : items) {
+            if (item.getKind() == ItemKind.WAYPOINT && item.getCoordinate() instanceof Waypoint) {
+                result.add((Waypoint) item.getCoordinate());
+            }
+        }
+        return result;
+    }
+
+    /** records {@code item} globally, and additionally into the currently-open route's/segment's point list, if any */
+    private void record(final RecordedItem item) {
+        items.add(item);
+        if (currentRoutePoints != null) {
+            currentRoutePoints.add(item.getCoordinate());
+        }
+        if (currentSegmentPoints != null) {
+            currentSegmentPoints.add(item.getCoordinate());
+        }
+    }
+
+    @Override
+    public void onInit(@Nullable final String gpxCreatorOrName) {
+        this.gpxCreatorOrName = gpxCreatorOrName;
+    }
+
+    @Override
+    public void onGeocache(@NonNull final Geocache geocache, @Nullable final List<LogEntry> logs) {
+        record(new RecordedItem(ItemKind.GEOCACHE, geocache, null, logs));
+    }
+
+    @Override
+    public void onWaypoint(@NonNull final Waypoint waypoint, @Nullable final String parentGeocode) {
+        record(new RecordedItem(ItemKind.WAYPOINT, waypoint, parentGeocode));
+    }
+
+    @Override
+    public void onCoordinate(final ICoordinate coordinate) {
+        record(new RecordedItem(ItemKind.COORDINATE, coordinate, null));
+    }
+
+    @Override
+    public void onNamedCoordinate(final NamedGeoCoordinate coordinate) {
+        record(new RecordedItem(ItemKind.NAMED_COORDINATE, coordinate, null));
+    }
+
+    @Nullable
+    @Override
+    public GPXParser.WptParseMode onRouteStart() {
+        currentRoutePoints = new ArrayList<>();
+        return null; // defer to GPXParser's configured default route mode
+    }
+
+    @Override
+    public void onRouteEnd(@Nullable final String name, final int pointCount) {
+        routes.add(new RecordedRoute(name, pointCount, currentRoutePoints));
+        currentRoutePoints = null;
+    }
+
+    @Nullable
+    @Override
+    public GPXParser.WptParseMode onTrackStart() {
+        currentTrackSegments = new ArrayList<>();
+        return null; // defer to GPXParser's configured default track mode
+    }
+
+    @Nullable
+    @Override
+    public GPXParser.WptParseMode onTrackSegmentStart() {
+        currentSegmentPoints = new ArrayList<>();
+        return null; // defer to the mode in effect for the enclosing track
+    }
+
+    @Override
+    public void onTrackSegmentEnd(@Nullable final String name, final int pointCount) {
+        currentTrackSegments.add(new RecordedTrackSegment(name, pointCount, currentSegmentPoints));
+        currentSegmentPoints = null;
+    }
+
+    @Override
+    public void onTrackEnd(@Nullable final String name, final int segmentCount, final int totalPointCount) {
+        tracks.add(new RecordedTrack(name, segmentCount, totalPointCount, currentTrackSegments));
+        currentTrackSegments = null;
+    }
+}
+
+
+

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/RecordingGPXParseHooks.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/RecordingGPXParseHooks.java
@@ -90,11 +90,11 @@ public class RecordingGPXParseHooks implements IGPXParseHooks {
     /** segments recorded so far for the currently-open track; non-null only between onTrackStart and onTrackEnd */
     private List<NamedCoordinateList> currentTrackSegments;
 
-    private GPXParser.ParseMode parseModeGlobal;
-    private GPXParser.ParseMode parseModeRoutes;
-    private GPXParser.ParseMode parseModeTracks;
+    private ParseMode parseModeGlobal;
+    private ParseMode parseModeRoutes;
+    private ParseMode parseModeTracks;
 
-    public void setModes(final GPXParser.ParseMode global, final GPXParser.ParseMode routes, final GPXParser.ParseMode tracks) {
+    public void setModes(final ParseMode global, final ParseMode routes, final ParseMode tracks) {
         this.parseModeGlobal = global;
         this.parseModeRoutes = routes;
         this.parseModeTracks = tracks;
@@ -150,44 +150,44 @@ public class RecordingGPXParseHooks implements IGPXParseHooks {
     }
 
     @Override
-    public GPXParser.ParseMode onInit(@Nullable final String gpxCreatorOrName) {
+    public ParseMode onInit(@Nullable final String gpxCreatorOrName) {
         this.gpxCreatorOrName = gpxCreatorOrName;
         return parseModeGlobal;
     }
 
     @Override
-    public GPXParser.ParseMode onGeocache(@NonNull final Geocache geocache, @Nullable final List<LogEntry> logs) {
+    public ParseMode onGeocache(@NonNull final Geocache geocache, @Nullable final List<LogEntry> logs) {
         record(new Item(geocache, null, logs));
         return null;
     }
 
     @Override
-    public GPXParser.ParseMode onWaypoint(@NonNull final Waypoint waypoint, @Nullable final String parentGeocode) {
+    public ParseMode onWaypoint(@NonNull final Waypoint waypoint, @Nullable final String parentGeocode) {
         record(new Item(waypoint, parentGeocode, null));
         return null;
     }
 
     @Override
-    public GPXParser.ParseMode onCoordinate(final ICoordinate coordinate) {
+    public ParseMode onCoordinate(final ICoordinate coordinate) {
         record(new Item(coordinate, null, null));
         return null;
     }
 
     @Override
-    public GPXParser.ParseMode onNamedCoordinate(final NamedGeoCoordinate coordinate) {
+    public ParseMode onNamedCoordinate(final NamedGeoCoordinate coordinate) {
         record(new Item(coordinate, null, null));
         return null;
     }
 
     @Nullable
     @Override
-    public GPXParser.ParseMode onRouteStart() {
+    public ParseMode onRouteStart() {
         currentRoutePoints = new ArrayList<>();
         return parseModeRoutes; // defer to GPXParser's configured default route mode
     }
 
     @Override
-    public GPXParser.ParseMode onRouteEnd(@Nullable final String name, final int pointCount) {
+    public ParseMode onRouteEnd(@Nullable final String name, final int pointCount) {
         routes.add(new NamedCoordinateList(name, pointCount, currentRoutePoints));
         currentRoutePoints = null;
         return parseModeGlobal;
@@ -195,27 +195,27 @@ public class RecordingGPXParseHooks implements IGPXParseHooks {
 
     @Nullable
     @Override
-    public GPXParser.ParseMode onTrackStart() {
+    public ParseMode onTrackStart() {
         currentTrackSegments = new ArrayList<>();
         return parseModeTracks; // defer to GPXParser's configured default track mode
     }
 
     @Nullable
     @Override
-    public GPXParser.ParseMode onTrackSegmentStart() {
+    public ParseMode onTrackSegmentStart() {
         currentSegmentPoints = new ArrayList<>();
         return null; // defer to the mode in effect for the enclosing track
     }
 
     @Override
-    public GPXParser.ParseMode onTrackSegmentEnd(@Nullable final String name, final int pointCount) {
+    public ParseMode onTrackSegmentEnd(@Nullable final String name, final int pointCount) {
         currentTrackSegments.add(new NamedCoordinateList(name, pointCount, currentSegmentPoints));
         currentSegmentPoints = null;
         return null;
     }
 
     @Override
-    public GPXParser.ParseMode onTrackEnd(@Nullable final String name, final int segmentCount, final int totalPointCount) {
+    public ParseMode onTrackEnd(@Nullable final String name, final int segmentCount, final int totalPointCount) {
         tracks.add(new Track(name, segmentCount, totalPointCount, currentTrackSegments));
         currentTrackSegments = null;
         return parseModeGlobal;

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/TerraCachingGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/TerraCachingGPXExtension.java
@@ -1,0 +1,122 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.connector.tc.TerraCachingLogType;
+import cgeo.geocaching.connector.tc.TerraCachingType;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.html.HtmlUtils;
+import cgeo.geocaching.utils.xml.XmlNode;
+import cgeo.geocaching.utils.xml.XmlUtils;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+
+public class TerraCachingGPXExtension implements IGPXExtension {
+
+    //Namespaces of extensions
+    private static final Set<String> TERRA_NS = Set.of(
+            "http://www.TerraCaching.com/GPX/1/0"
+    );
+
+    /** TerraCaching extension. */
+    @Override
+    public void enrichGeocache(final XmlNode wptType, final Geocache cache) {
+        final XmlNode terraCache = GPXUtils.gpxNodeChild(wptType, "terracache", TERRA_NS);
+        if (terraCache == null) {
+            return;
+        }
+        final String name = GPXUtils.gpxNodeChildText(terraCache, "name", TERRA_NS);
+        if (StringUtils.isNotBlank(name)) {
+            cache.setName(StringUtils.trim(name));
+        }
+        final String owner = GPXUtils.gpxNodeChildText(terraCache, "owner", TERRA_NS);
+        if (StringUtils.isNotBlank(owner)) {
+            cache.setOwnerDisplayName(XmlUtils.validate(owner));
+        }
+        final String style = GPXUtils.gpxNodeChildText(terraCache, "style", TERRA_NS);
+        if (StringUtils.isNotBlank(style)) {
+            cache.setType(TerraCachingType.getCacheType(style));
+        }
+        final String size = GPXUtils.gpxNodeChildText(terraCache, "size", TERRA_NS);
+        if (StringUtils.isNotBlank(size)) {
+            cache.setSize(CacheSize.getById(size));
+        }
+        final String country = GPXUtils.gpxNodeChildText(terraCache, "country", TERRA_NS);
+        if (StringUtils.isNotBlank(country)) {
+            cache.setLocation(StringUtils.trim(country));
+        }
+        final String state = GPXUtils.gpxNodeChildText(terraCache, "state", TERRA_NS);
+        if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
+            cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? XmlUtils.validate(state) : state.trim() + ", " + cache.getLocation());
+        }
+        final String description = GPXUtils.gpxNodeChildText(terraCache, "description", TERRA_NS);
+        if (description != null) {
+            cache.setDescription(trimHtml(description));
+        }
+        final String hint = GPXUtils.gpxNodeChildText(terraCache, "hint", TERRA_NS);
+        if (hint != null) {
+            cache.setHint(HtmlUtils.extractText(hint));
+        }
+    }
+
+    /** TerraCaching logs ({@code <terracache><logs><log>...}). */
+    public List<LogEntry> extractLogs(final XmlNode wptNode, final Geocache cache) {
+        final XmlNode terraCache = GPXUtils.gpxNodeChild(wptNode, "terracache", TERRA_NS);
+        if (terraCache == null) {
+            return null;
+        }
+        final XmlNode logsNode = GPXUtils.gpxNodeChild(terraCache, "logs", TERRA_NS);
+        if (logsNode == null) {
+            return null;
+        }
+        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
+        if (logNodes == null) {
+            return null;
+        }
+        final List<LogEntry> result = new ArrayList<>();
+        for (final XmlNode logNode : logNodes) {
+            final LogEntry.Builder builder = new LogEntry.Builder();
+            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", TERRA_NS);
+            if (idText != null) {
+                try {
+                    builder.setId(Integer.parseInt(idText.trim()));
+                } catch (final NumberFormatException ignored) {
+                    // ignore malformed id
+                }
+            }
+            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", TERRA_NS));
+            if (date != null) {
+                builder.setDate(date.getTime());
+            }
+            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", TERRA_NS);
+            if (typeText != null) {
+                builder.setLogType(TerraCachingLogType.getLogType(XmlUtils.validate(typeText)));
+            }
+            final String finder = GPXUtils.gpxNodeChildText(logNode, "user", TERRA_NS);
+            if (finder != null) {
+                builder.setAuthor(XmlUtils.validate(finder));
+            }
+            final String text = GPXUtils.gpxNodeChildText(logNode, "entry", TERRA_NS);
+            if (text != null) {
+                builder.setLog(trimHtml(XmlUtils.validate(text)));
+            }
+            final LogEntry log = builder.build();
+            if (log.logType != LogType.UNKNOWN) {
+                result.add(log);
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    private static String trimHtml(final String html) {
+        return StringUtils.trim(Strings.CS.removeEnd(Strings.CS.removeStart(html, "<br>"), "<br>"));
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/TerraCachingGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/TerraCachingGPXExtension.java
@@ -83,15 +83,11 @@ public class TerraCachingGPXExtension implements IGPXExtension {
         final List<LogEntry> result = new ArrayList<>();
         for (final XmlNode logNode : logNodes) {
             final LogEntry.Builder builder = new LogEntry.Builder();
-            final String idText = GPXUtils.gpxNodeAttrValue(logNode, "id", TERRA_NS);
+            final Integer idText = XmlUtils.toInteger(GPXUtils.gpxNodeAttrValue(logNode, "id", TERRA_NS), null);
             if (idText != null) {
-                try {
-                    builder.setId(Integer.parseInt(idText.trim()));
-                } catch (final NumberFormatException ignored) {
-                    // ignore malformed id
-                }
+                builder.setId(idText);
             }
-            final Date date = XmlUtils.parseDate(GPXUtils.gpxNodeChildText(logNode, "date", TERRA_NS));
+            final Date date = GPXUtils.gpxNodeChildDate(logNode, "date", TERRA_NS, null);
             if (date != null) {
                 builder.setDate(date.getTime());
             }

--- a/main/src/main/java/cgeo/geocaching/utils/gpx/TerraCachingGPXExtension.java
+++ b/main/src/main/java/cgeo/geocaching/utils/gpx/TerraCachingGPXExtension.java
@@ -28,39 +28,39 @@ public class TerraCachingGPXExtension implements IGPXExtension {
     /** TerraCaching extension. */
     @Override
     public void enrichGeocache(final XmlNode wptType, final Geocache cache) {
-        final XmlNode terraCache = GPXUtils.gpxNodeChild(wptType, "terracache", TERRA_NS);
+        final XmlNode terraCache = GPXUtils.gpxChild(wptType, "terracache", TERRA_NS);
         if (terraCache == null) {
             return;
         }
-        final String name = GPXUtils.gpxNodeChildText(terraCache, "name", TERRA_NS);
+        final String name = GPXUtils.gpxChildText(terraCache, "name", TERRA_NS);
         if (StringUtils.isNotBlank(name)) {
             cache.setName(StringUtils.trim(name));
         }
-        final String owner = GPXUtils.gpxNodeChildText(terraCache, "owner", TERRA_NS);
+        final String owner = GPXUtils.gpxChildText(terraCache, "owner", TERRA_NS);
         if (StringUtils.isNotBlank(owner)) {
             cache.setOwnerDisplayName(XmlUtils.validate(owner));
         }
-        final String style = GPXUtils.gpxNodeChildText(terraCache, "style", TERRA_NS);
+        final String style = GPXUtils.gpxChildText(terraCache, "style", TERRA_NS);
         if (StringUtils.isNotBlank(style)) {
             cache.setType(TerraCachingType.getCacheType(style));
         }
-        final String size = GPXUtils.gpxNodeChildText(terraCache, "size", TERRA_NS);
+        final String size = GPXUtils.gpxChildText(terraCache, "size", TERRA_NS);
         if (StringUtils.isNotBlank(size)) {
             cache.setSize(CacheSize.getById(size));
         }
-        final String country = GPXUtils.gpxNodeChildText(terraCache, "country", TERRA_NS);
+        final String country = GPXUtils.gpxChildText(terraCache, "country", TERRA_NS);
         if (StringUtils.isNotBlank(country)) {
             cache.setLocation(StringUtils.trim(country));
         }
-        final String state = GPXUtils.gpxNodeChildText(terraCache, "state", TERRA_NS);
+        final String state = GPXUtils.gpxChildText(terraCache, "state", TERRA_NS);
         if (StringUtils.isNotBlank(state) && StringUtils.isNotEmpty(state.trim())) {
             cache.setLocation(StringUtils.isBlank(cache.getLocation()) ? XmlUtils.validate(state) : state.trim() + ", " + cache.getLocation());
         }
-        final String description = GPXUtils.gpxNodeChildText(terraCache, "description", TERRA_NS);
+        final String description = GPXUtils.gpxChildText(terraCache, "description", TERRA_NS);
         if (description != null) {
             cache.setDescription(trimHtml(description));
         }
-        final String hint = GPXUtils.gpxNodeChildText(terraCache, "hint", TERRA_NS);
+        final String hint = GPXUtils.gpxChildText(terraCache, "hint", TERRA_NS);
         if (hint != null) {
             cache.setHint(HtmlUtils.extractText(hint));
         }
@@ -68,38 +68,38 @@ public class TerraCachingGPXExtension implements IGPXExtension {
 
     /** TerraCaching logs ({@code <terracache><logs><log>...}). */
     public List<LogEntry> extractLogs(final XmlNode wptNode, final Geocache cache) {
-        final XmlNode terraCache = GPXUtils.gpxNodeChild(wptNode, "terracache", TERRA_NS);
+        final XmlNode terraCache = GPXUtils.gpxChild(wptNode, "terracache", TERRA_NS);
         if (terraCache == null) {
             return null;
         }
-        final XmlNode logsNode = GPXUtils.gpxNodeChild(terraCache, "logs", TERRA_NS);
+        final XmlNode logsNode = GPXUtils.gpxChild(terraCache, "logs", TERRA_NS);
         if (logsNode == null) {
             return null;
         }
-        final List<XmlNode> logNodes = GPXUtils.gpxNodeChildren(logsNode, "log");
+        final List<XmlNode> logNodes = GPXUtils.gpxChildren(logsNode, "log", TERRA_NS);
         if (logNodes == null) {
             return null;
         }
         final List<LogEntry> result = new ArrayList<>();
         for (final XmlNode logNode : logNodes) {
             final LogEntry.Builder builder = new LogEntry.Builder();
-            final Integer idText = XmlUtils.toInteger(GPXUtils.gpxNodeAttrValue(logNode, "id", TERRA_NS), null);
+            final Integer idText = XmlUtils.toInteger(GPXUtils.gpxAttrValue(logNode, "id", TERRA_NS), null);
             if (idText != null) {
                 builder.setId(idText);
             }
-            final Date date = GPXUtils.gpxNodeChildDate(logNode, "date", TERRA_NS, null);
+            final Date date = GPXUtils.gpxChildDate(logNode, "date", TERRA_NS, null);
             if (date != null) {
                 builder.setDate(date.getTime());
             }
-            final String typeText = GPXUtils.gpxNodeChildText(logNode, "type", TERRA_NS);
+            final String typeText = GPXUtils.gpxChildText(logNode, "type", TERRA_NS);
             if (typeText != null) {
                 builder.setLogType(TerraCachingLogType.getLogType(XmlUtils.validate(typeText)));
             }
-            final String finder = GPXUtils.gpxNodeChildText(logNode, "user", TERRA_NS);
+            final String finder = GPXUtils.gpxChildText(logNode, "user", TERRA_NS);
             if (finder != null) {
                 builder.setAuthor(XmlUtils.validate(finder));
             }
-            final String text = GPXUtils.gpxNodeChildText(logNode, "entry", TERRA_NS);
+            final String text = GPXUtils.gpxChildText(logNode, "entry", TERRA_NS);
             if (text != null) {
                 builder.setLog(trimHtml(XmlUtils.validate(text)));
             }

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
@@ -21,7 +21,7 @@ import org.xmlpull.v1.XmlPullParserException;
  * <br>
  * Instances of this class are optimized for fast random access to child nodes by their local name.
  * Lists (=many child nodes with same local name) are supported. Note that tags with same local name but different namespace are also stored in list.
- * Order of tags from original document is not preserved.
+ * Child insertion order is available separately from the local-name index.
  */
 public class XmlNode {
 
@@ -32,6 +32,7 @@ public class XmlNode {
 
     private String value;
     private Map<String, Object> childrenMap;
+    private List<XmlNode> orderedChildren;
 
     public XmlNode(final String name, final String namespace) {
         this.localName = XmlUtils.getLocalName(name);
@@ -51,7 +52,9 @@ public class XmlNode {
 
         if (childrenMap == null) {
             childrenMap = new HashMap<>();
+            orderedChildren = new ArrayList<>();
         }
+        orderedChildren.add(child);
         final Object currentValue = childrenMap.get(child.localName);
         if (currentValue instanceof XmlNode) {
             final List<XmlNode> list = new ArrayList<>();
@@ -68,7 +71,13 @@ public class XmlNode {
     public void removeChild(final String name) {
         if (childrenMap != null) {
             childrenMap.remove(name);
+            orderedChildren.removeIf(child -> child.localName.equals(name));
         }
+    }
+
+    /** All children (including attribute nodes) in insertion order. */
+    public List<XmlNode> getChildrenInOrder() {
+        return orderedChildren == null ? Collections.emptyList() : Collections.unmodifiableList(orderedChildren);
     }
 
     public boolean hasChild(final String name) {

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
@@ -194,16 +194,16 @@ public class XmlNode {
     }
 
     @Nullable
-    public static XmlNode getChild(@Nullable final XmlNode node, @Nullable final String name, @Nullable final Set<String> namespaces) {
+    public static XmlNode getChild(@Nullable final XmlNode node, @Nullable final String name, @Nullable final Set<String> preferredNamespace) {
         if (node == null) {
             return null;
         }
-        if (node.countChildren(name) <= 1 || namespaces == null) {
+        if (node.countChildren(name) <= 1 || preferredNamespace == null) {
             return node.getChild(name);
         }
         final List<XmlNode> children = node.getChildrenAsList(name);
         for (XmlNode child : children) {
-            if (namespaces.contains(child.getNamespace())) {
+            if (preferredNamespace.contains(child.getNamespace())) {
                 return child;
             }
         }

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
@@ -16,11 +16,10 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 /**
- * Represents the content of an XML Node and its children. Sort of a poor-mans DOM model.
+ * Represents the content of an XML Node and its children.
  * <br>
  * Instances of this class are optimized for fast random access to child nodes by their local name.
  * Lists (=many child nodes with same local name) are supported. Note that tags with same local name but different namespace are also stored in list.
- * Child insertion order is available separately from the local-name index.
  */
 public class XmlNode {
 
@@ -31,10 +30,12 @@ public class XmlNode {
 
     private String value;
     private Map<String, Object> childrenMap;
+    private final int tagIdx;
 
-    public XmlNode(final String name, final String namespace) {
+    private XmlNode(final String name, final String namespace, final int tagIdx) {
         this.localName = XmlUtils.getLocalName(name);
-        this.namespace = namespace;
+        this.namespace = StringUtils.isBlank(namespace) ? null : namespace.trim();
+        this.tagIdx = tagIdx;
     }
 
     public String getLocalName() {
@@ -43,6 +44,10 @@ public class XmlNode {
 
     public String getNamespace() {
         return namespace;
+    }
+
+    public int getTagIdx() {
+        return tagIdx;
     }
 
     @SuppressWarnings("unchecked")
@@ -65,43 +70,57 @@ public class XmlNode {
     }
 
     public boolean hasChild(final String name) {
-        return childrenMap != null && childrenMap.containsKey(name);
+        return hasChild(name, null, true);
     }
 
-    public int countChildren(final String name) {
-        final Object value = childrenMap == null ? null : childrenMap.get(name);
-        if (value == null) {
-            return 0;
+    public boolean hasChild(final String name, final Set<String> namespaces, final boolean allowNullNamespace) {
+        if (childrenMap == null || !childrenMap.containsKey(name)) {
+            return false;
         }
-        if (value instanceof List) {
-            return ((List<?>) value).size();
-        }
-        return 1;
+        return getChild(name, namespaces, allowNullNamespace) != null;
     }
 
-    @SuppressWarnings("unchecked")
     public List<XmlNode> getChildrenAsList(final String name) {
-        final Object value = childrenMap == null ? null : childrenMap.get(name);
-        if (value == null) {
-            return null;
-        }
-        if (value instanceof List) {
-            return (List<XmlNode>) value;
-        }
-        return Collections.singletonList((XmlNode) value);
+        return getChildrenAsList(name, null, true);
     }
 
     @SuppressWarnings("unchecked")
-    public XmlNode getChild(final String name) {
+    public List<XmlNode> getChildrenAsList(final String name, final Set<String> namespaces, final boolean allowNullNamespace) {
         final Object value = childrenMap == null ? null : childrenMap.get(name);
         if (value == null) {
             return null;
         }
-        if (value instanceof List) {
-            final List<XmlNode> list = (List<XmlNode>) value;
-            return list.isEmpty() ? null : list.get(0);
+        if (value instanceof XmlNode) {
+            return namespaceMatches((XmlNode) value, namespaces, allowNullNamespace) ? Collections.singletonList((XmlNode) value) : null;
         }
-        return (XmlNode) value;
+        final List<XmlNode> children = (List<XmlNode>) value;
+        if (namespaces == null) {
+            return children;
+        }
+
+        final boolean allValid = children.stream().allMatch(child -> namespaceMatches(child, namespaces, allowNullNamespace));
+        return allValid ? (List<XmlNode>) value : ((List<XmlNode>) value).stream().filter(child -> namespaceMatches(child, namespaces, allowNullNamespace)).toList();
+    }
+
+    public XmlNode getChild(final String name) {
+        return getChild(name, null, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public XmlNode getChild(final String name, final Set<String> namespaces, final boolean allowNullNamespace) {
+        final Object value = childrenMap == null ? null : childrenMap.get(name);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof XmlNode) {
+            return namespaceMatches((XmlNode) value, namespaces, allowNullNamespace) ? (XmlNode) value : null;
+        }
+        for (XmlNode child : (List<XmlNode>) value) {
+            if (namespaceMatches(child, namespaces, allowNullNamespace)) {
+                return child;
+            }
+        }
+        return null;
     }
 
     @Nullable
@@ -110,9 +129,13 @@ public class XmlNode {
         return child == null ? null : child.getValue();
     }
 
+    private static boolean namespaceMatches(@NonNull final XmlNode node, final Set<String> namespaces, final boolean allowNullNamespace) {
+        return namespaces == null || (node.namespace == null ? allowNullNamespace : namespaces.contains(node.namespace));
+    }
+
     /** Sets the textual value of this node */
-    public void setValue(final String value) {
-        if (value == null || StringUtils.isBlank(value)) {
+    private void setValue(final String value) {
+        if (value == null || StringUtils.isBlank(value) || "nil".equals(value)) {
             this.value = null;
         } else {
             this.value = value;
@@ -137,12 +160,16 @@ public class XmlNode {
      * When this method returns, pull parser will be placed on the corresponding END_TAG element.
      */
     public static XmlNode scanNode(final XmlPullParser parser) throws XmlPullParserException, IOException {
-        if (parser.getEventType() != XmlPullParser.START_TAG) {
+        return scanNode(parser, new int[] { 0 });
+    }
+
+    private static XmlNode scanNode(final XmlPullParser parser, final int[] tagIdx) throws XmlPullParserException, IOException {
+            if (parser.getEventType() != XmlPullParser.START_TAG) {
             throw new XmlPullParserException("Not a start tag: " + parser);
         }
-        final XmlNode node = new XmlNode(parser.getName(), parser.getNamespace());
+        final XmlNode node = new XmlNode(parser.getName(), parser.getNamespace(), tagIdx[0]);
         for (int i = 0; i < parser.getAttributeCount(); i++) {
-            final XmlNode attNode = new XmlNode(ATTRIBUTE_PRAEFIX + parser.getAttributeName(i), parser.getAttributeNamespace(i));
+            final XmlNode attNode = new XmlNode(ATTRIBUTE_PRAEFIX + parser.getAttributeName(i), parser.getAttributeNamespace(i), -1);
             attNode.setValue(parser.getAttributeValue(i));
             node.addChild(attNode);
         }
@@ -152,32 +179,16 @@ public class XmlNode {
                 case XmlPullParser.END_TAG:
                     return node;
                 case XmlPullParser.START_TAG:
-                    node.addChild(scanNode(parser));
+                    tagIdx[0]++;
+                    node.addChild(scanNode(parser, tagIdx));
                     break;
                 case XmlPullParser.TEXT:
                     node.setValue(parser.getText());
                     break;
                 default:
-                    throw new XmlPullParserException("Unexpected element tyoe: " + parser.getEventType());
+                    throw new XmlPullParserException("Unexpected element type: " + parser.getEventType());
             }
         }
-    }
-
-    @Nullable
-    public static XmlNode getChild(@Nullable final XmlNode node, @Nullable final String name, @Nullable final Set<String> preferredNamespace) {
-        if (node == null) {
-            return null;
-        }
-        if (node.countChildren(name) <= 1 || preferredNamespace == null) {
-            return node.getChild(name);
-        }
-        final List<XmlNode> children = node.getChildrenAsList(name);
-        for (XmlNode child : children) {
-            if (preferredNamespace.contains(child.getNamespace())) {
-                return child;
-            }
-        }
-        return children.get(0);
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.utils.xml;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -8,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.StringUtils;
@@ -15,33 +17,29 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 /**
- * Reprents the content of an XML Node and it's children. Sort of a poor-mans DOM model.
+ * Represents the content of an XML Node and its children. Sort of a poor-mans DOM model.
  * <br>
- * Instances of this class are optimized for fast random access to child nodes by their (local) name.
- * Although lists (=many children of same node with same common name) are also supported, order
- * of tags from original document is not preserved.
+ * Instances of this class are optimized for fast random access to child nodes by their local name.
+ * Lists (=many child nodes with same local name) are supported. Note that tags with same local name but different namespace are also stored in list.
+ * Order of tags from original document is not preserved.
  */
 public class XmlNode {
 
     public static final String ATTRIBUTE_PRAEFIX = "@";
 
-    private final String name;
+    private final String localName;
     private final String namespace;
 
     private String value;
     private Map<String, Object> childrenMap;
 
-    public XmlNode(final String name) {
-        this(name, null);
-    }
-
     public XmlNode(final String name, final String namespace) {
-        this.name = name;
+        this.localName = XmlUtils.getLocalName(name);
         this.namespace = namespace;
     }
 
-    public String getName() {
-        return name;
+    public String getLocalName() {
+        return localName;
     }
 
     public String getNamespace() {
@@ -49,36 +47,47 @@ public class XmlNode {
     }
 
     @SuppressWarnings("unchecked")
-    public void add(final XmlNode child) {
+    public void addChild(final XmlNode child) {
 
         if (childrenMap == null) {
             childrenMap = new HashMap<>();
         }
-        final Object currentValue = childrenMap.get(child.name);
+        final Object currentValue = childrenMap.get(child.localName);
         if (currentValue instanceof XmlNode) {
             final List<XmlNode> list = new ArrayList<>();
             list.add((XmlNode) currentValue);
             list.add(child);
-            childrenMap.put(child.name, list);
+            childrenMap.put(child.localName, list);
         } else if (currentValue instanceof List) {
             ((List<XmlNode>) currentValue).add(child);
         } else {
-            childrenMap.put(child.name, child);
+            childrenMap.put(child.localName, child);
         }
     }
 
-    public void remove(final String name) {
+    public void removeChild(final String name) {
         if (childrenMap != null) {
             childrenMap.remove(name);
         }
     }
 
-    public boolean has(final String name) {
+    public boolean hasChild(final String name) {
         return childrenMap != null && childrenMap.containsKey(name);
     }
 
+    public int countChildren(final String name) {
+        final Object value = childrenMap == null ? null : childrenMap.get(name);
+        if (value == null) {
+            return 0;
+        }
+        if (value instanceof List) {
+            return ((List<?>) value).size();
+        }
+        return 1;
+    }
+
     @SuppressWarnings("unchecked")
-    public List<XmlNode> getAsList(final String name) {
+    public List<XmlNode> getChildrenAsList(final String name) {
         final Object value = childrenMap == null ? null : childrenMap.get(name);
         if (value == null) {
             return null;
@@ -90,7 +99,7 @@ public class XmlNode {
     }
 
     @SuppressWarnings("unchecked")
-    public XmlNode get(final String name) {
+    public XmlNode getChild(final String name) {
         final Object value = childrenMap == null ? null : childrenMap.get(name);
         if (value == null) {
             return null;
@@ -100,6 +109,12 @@ public class XmlNode {
             return list.isEmpty() ? null : list.get(0);
         }
         return (XmlNode) value;
+    }
+
+    @Nullable
+    public String getChildValue(final String name) {
+        final XmlNode child = getChild(name);
+        return child == null ? null : child.getValue();
     }
 
     /** Sets the textual value of this node */
@@ -117,6 +132,9 @@ public class XmlNode {
 
     @SuppressWarnings("unchecked")
     public void forEach(final Consumer<XmlNode> action) {
+        if (childrenMap == null) {
+            return;
+        }
         for (Map.Entry<String, Object> entry : childrenMap.entrySet()) {
             if (entry.getValue() instanceof List) {
                 ((List<XmlNode>) entry.getValue()).forEach(action);
@@ -129,7 +147,7 @@ public class XmlNode {
     @NonNull
     @Override
     public String toString() {
-        return (namespace == null ? "" : namespace + ":") + name +
+        return (namespace == null ? "" : namespace + ":") + localName +
             (value == null ? "" : ":'" + value + "'") +
             (childrenMap == null ? "" : "[" + childrenMap.values() + "]");
     }
@@ -147,7 +165,7 @@ public class XmlNode {
         for (int i = 0; i < parser.getAttributeCount(); i++) {
             final XmlNode attNode = new XmlNode(ATTRIBUTE_PRAEFIX + parser.getAttributeName(i), parser.getAttributeNamespace(i));
             attNode.setValue(parser.getAttributeValue(i));
-            node.add(attNode);
+            node.addChild(attNode);
         }
 
         while (true) {
@@ -155,7 +173,7 @@ public class XmlNode {
                 case XmlPullParser.END_TAG:
                     return node;
                 case XmlPullParser.START_TAG:
-                    node.add(scanNode(parser));
+                    node.addChild(scanNode(parser));
                     break;
                 case XmlPullParser.TEXT:
                     node.setValue(parser.getText());
@@ -164,6 +182,23 @@ public class XmlNode {
                     throw new XmlPullParserException("Unexpected element tyoe: " + parser.getEventType());
             }
         }
+    }
+
+    @Nullable
+    public static XmlNode getChild(@Nullable final XmlNode node, @Nullable final String name, @Nullable final Set<String> namespaces) {
+        if (node == null) {
+            return null;
+        }
+        if (node.countChildren(name) <= 1 || namespaces == null) {
+            return node.getChild(name);
+        }
+        final List<XmlNode> children = node.getChildrenAsList(name);
+        for (XmlNode child : children) {
+            if (namespaces.contains(child.getNamespace())) {
+                return child;
+            }
+        }
+        return children.get(0);
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlNode.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xmlpull.v1.XmlPullParser;
@@ -32,7 +31,6 @@ public class XmlNode {
 
     private String value;
     private Map<String, Object> childrenMap;
-    private List<XmlNode> orderedChildren;
 
     public XmlNode(final String name, final String namespace) {
         this.localName = XmlUtils.getLocalName(name);
@@ -48,13 +46,11 @@ public class XmlNode {
     }
 
     @SuppressWarnings("unchecked")
-    public void addChild(final XmlNode child) {
+    private void addChild(final XmlNode child) {
 
         if (childrenMap == null) {
             childrenMap = new HashMap<>();
-            orderedChildren = new ArrayList<>();
         }
-        orderedChildren.add(child);
         final Object currentValue = childrenMap.get(child.localName);
         if (currentValue instanceof XmlNode) {
             final List<XmlNode> list = new ArrayList<>();
@@ -66,18 +62,6 @@ public class XmlNode {
         } else {
             childrenMap.put(child.localName, child);
         }
-    }
-
-    public void removeChild(final String name) {
-        if (childrenMap != null) {
-            childrenMap.remove(name);
-            orderedChildren.removeIf(child -> child.localName.equals(name));
-        }
-    }
-
-    /** All children (including attribute nodes) in insertion order. */
-    public List<XmlNode> getChildrenInOrder() {
-        return orderedChildren == null ? Collections.emptyList() : Collections.unmodifiableList(orderedChildren);
     }
 
     public boolean hasChild(final String name) {
@@ -137,20 +121,6 @@ public class XmlNode {
 
     public String getValue() {
         return value;
-    }
-
-    @SuppressWarnings("unchecked")
-    public void forEach(final Consumer<XmlNode> action) {
-        if (childrenMap == null) {
-            return;
-        }
-        for (Map.Entry<String, Object> entry : childrenMap.entrySet()) {
-            if (entry.getValue() instanceof List) {
-                ((List<XmlNode>) entry.getValue()).forEach(action);
-            } else {
-                action.accept((XmlNode) entry.getValue());
-            }
-        }
     }
 
     @NonNull

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
@@ -20,6 +20,14 @@ public final class XmlUtils {
         // Do not instantiate
     }
 
+    public static String getLocalName(final String name) {
+        if (name == null) {
+            return null;
+        }
+        final int lastColon = name.lastIndexOf(':');
+        return lastColon < 0 ? name : name.substring(lastColon + 1);
+    }
+
     /**
      * Insert an attribute-less tag with enclosed text in a XML serializer output.
      *
@@ -51,10 +59,10 @@ public final class XmlUtils {
     }
 
     public static XmlPullParser createParser(@NonNull final InputStream input, final boolean namespaceAware) throws XmlPullParserException {
-        return createParser(input, namespaceAware, "UTF-8");
+        return createParser(input, namespaceAware, false, "UTF-8");
     }
 
-    public static XmlPullParser createParser(@NonNull final InputStream input, final boolean namespaceAware, final String inputEncoding) throws XmlPullParserException {
+    public static XmlPullParser createParser(@NonNull final InputStream input, final boolean namespaceAware, final boolean relaxed, final String inputEncoding) throws XmlPullParserException {
         if (XPP_FACTORY == null) {
             throw new XmlPullParserException("XmlUtils: can't create XML Parser, no factory available");
         }
@@ -62,6 +70,7 @@ public final class XmlUtils {
         synchronized (XPP_FACTORY) {
             final XmlPullParser parser = XPP_FACTORY.newPullParser();
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, namespaceAware);
+            parser.setFeature("http://xmlpull.org/v1/doc/features.html#relaxed", relaxed);
             parser.setInput(input, inputEncoding);
             return parser;
         }

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
@@ -1,17 +1,27 @@
 package cgeo.geocaching.utils.xml;
 
 import cgeo.geocaching.files.InvalidXMLCharacterFilterReader;
+import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.utils.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.input.BOMInputStream;
+import org.apache.commons.lang3.StringUtils;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -20,6 +30,7 @@ import org.xmlpull.v1.XmlSerializer;
 public final class XmlUtils {
 
     private static final XmlPullParserFactory XPP_FACTORY = safeCreateFactory();
+    private static final Pattern PATTERN_MILLISECONDS = Pattern.compile("\\.\\d+");
 
     private XmlUtils() {
         // Do not instantiate
@@ -114,5 +125,108 @@ public final class XmlUtils {
             Log.e("XmlUtils: could not create a XmlPullParserFactory, e");
         }
         return null;
+    }
+
+    @Nullable
+    public static Date parseDate(final String input) {
+        if (StringUtils.isBlank(input)) {
+            return null;
+        }
+        String body = input.trim();
+        body = PATTERN_MILLISECONDS.matcher(body).replaceFirst("");
+        final String[] patterns = {
+            "yyyy-MM-dd'T'HH:mm:ssXXX",
+            "yyyy-MM-dd'T'HH:mm:ssXX",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd",
+        };
+        for (final String pattern : patterns) {
+            final SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.US);
+            format.setLenient(false);
+            format.setTimeZone(TimeZone.getDefault());
+            final ParsePosition position = new ParsePosition(0);
+            final Date parsed = format.parse(body, position);
+            if (parsed != null && position.getIndex() == body.length()) {
+                return parsed;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    public static Float parseFloat(final String input) {
+        if (StringUtils.isBlank(input)) {
+            return null;
+        }
+        try {
+            return Float.parseFloat(input.trim());
+        } catch (final NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    public static Geopoint parseGeopoint(final String lat, final String lon, final boolean zeroFill) {
+        final Double latitude = parseCoordinate(lat, 90);
+        final Double longitude = parseCoordinate(lon, 180);
+        if (!zeroFill && (latitude == null || longitude == null || (latitude == 0 && longitude == 0))) {
+            return null;
+        }
+        return new Geopoint(latitude == null ? 0 : latitude, longitude == null ? 0 : longitude);
+    }
+
+    @Nullable
+    private static Double parseCoordinate(final String value, final int limit) {
+        if (StringUtils.isBlank(value)) {
+            return null;
+        }
+        try {
+            final double coordinate = Double.parseDouble(value.trim());
+            return Double.isFinite(coordinate) && Math.abs(coordinate) <= limit ? coordinate : null;
+        } catch (final NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** Reads the text content of the element the parser is currently positioned at (a {@code START_TAG}). */
+    public static String parseText(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        final StringBuilder sb = new StringBuilder();
+        performAction(parser, (p, event) -> {
+            if (event == XmlPullParser.TEXT) {
+                if (sb.length() > 0) {
+                    sb.append(' ');
+                }
+                sb.append(p.getText());
+            }
+        });
+        return sb.length() == 0 ? null : sb.toString();
+    }
+
+    /**
+     * Skips the subtree of the element the parser is currently positioned at (a {@code START_TAG}), leaving the
+     * parser positioned at the corresponding {@code END_TAG}.
+     */
+    public static void skipSubtree(final XmlPullParser parser) throws IOException, XmlPullParserException {
+        performAction(parser, null);
+    }
+
+    /** performs an action for every subevent of a START tag (recursive) until END tag is reached */
+    public static void performAction(final XmlPullParser parser, final BiConsumer<XmlPullParser, Integer> action) throws IOException, XmlPullParserException {
+        if (parser.getEventType() != XmlPullParser.START_TAG) {
+            throw new XmlPullParserException("Parser not positioned at START_TAG");
+        }
+        int depth = 1;
+        while (depth > 0) {
+            final int event = parser.next();
+            if (event == XmlPullParser.START_TAG) {
+                depth++;
+            } else if (event == XmlPullParser.END_TAG) {
+                depth--;
+            } else if (event == XmlPullParser.END_DOCUMENT) {
+                throw new XmlPullParserException("Unexpected end of document while skipping subtree");
+            } else if (action != null) {
+                action.accept(parser, event);
+            }
+        }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
@@ -229,4 +229,11 @@ public final class XmlUtils {
             }
         }
     }
+
+    public static String validate(final String input) {
+        if ("nil".equalsIgnoreCase(input)) {
+            return "";
+        }
+        return input.trim();
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
@@ -128,9 +128,9 @@ public final class XmlUtils {
     }
 
     @Nullable
-    public static Date parseDate(final String input) {
+    public static Date toDate(final String input, final Date defaultValue) {
         if (StringUtils.isBlank(input)) {
-            return null;
+            return defaultValue;
         }
         String body = input.trim();
         body = PATTERN_MILLISECONDS.matcher(body).replaceFirst("");
@@ -150,18 +150,42 @@ public final class XmlUtils {
                 return parsed;
             }
         }
-        return null;
+        return defaultValue;
     }
 
     @Nullable
-    public static Float parseFloat(final String input) {
+    public static Float toFloat(final String input, final Float defaultValue) {
         if (StringUtils.isBlank(input)) {
-            return null;
+            return defaultValue;
         }
         try {
             return Float.parseFloat(input.trim());
         } catch (final NumberFormatException e) {
-            return null;
+            return defaultValue;
+        }
+    }
+
+    @Nullable
+    public static Integer toInteger(final String input, final Integer defaultValue) {
+        if (StringUtils.isBlank(input)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(input.trim());
+        } catch (final NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    @Nullable
+    public static Boolean toBoolean(final String input, final Boolean defaultValue) {
+        if (StringUtils.isBlank(input)) {
+            return defaultValue;
+        }
+        try {
+            return Boolean.parseBoolean(input.trim());
+        } catch (final NumberFormatException e) {
+            return defaultValue;
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/xml/XmlUtils.java
@@ -1,12 +1,17 @@
 package cgeo.geocaching.utils.xml;
 
+import cgeo.geocaching.files.InvalidXMLCharacterFilterReader;
 import cgeo.geocaching.utils.Log;
 
 import androidx.annotation.NonNull;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.input.BOMInputStream;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -59,10 +64,37 @@ public final class XmlUtils {
     }
 
     public static XmlPullParser createParser(@NonNull final InputStream input, final boolean namespaceAware) throws XmlPullParserException {
-        return createParser(input, namespaceAware, false, "UTF-8");
+        return createParser(input, null, namespaceAware, false);
     }
 
-    public static XmlPullParser createParser(@NonNull final InputStream input, final boolean namespaceAware, final boolean relaxed, final String inputEncoding) throws XmlPullParserException {
+    public static XmlPullParser createParser(@NonNull final InputStream input, final String inputEncoding, final boolean namespaceAware, final boolean relaxed) throws XmlPullParserException {
+        final XmlPullParser parser = createParser(namespaceAware, relaxed);
+        setInput(parser, input, inputEncoding == null ? StandardCharsets.UTF_8.name() : inputEncoding);
+        return parser;
+    }
+
+    /** Creates a parser directly on a reader, e.g. to filter XML characters before parsing. */
+    public static XmlPullParser createParser(@NonNull final Reader input, final boolean namespaceAware) throws XmlPullParserException {
+        final XmlPullParser parser = createParser(namespaceAware, false);
+        setInput(parser, input);
+        return parser;
+    }
+
+    public static void setInput(final XmlPullParser parser, final InputStream input, final String inputEncoding) throws XmlPullParserException {
+        try {
+            final BOMInputStream bomIn = BOMInputStream.builder().setInputStream(input).get();
+            setInput(parser, new InputStreamReader(bomIn, inputEncoding));
+        } catch (IOException e) {
+            throw new XmlPullParserException("Error setting input for parser", parser, e);
+        }
+    }
+
+    public static void setInput(final XmlPullParser parser, final Reader input) throws XmlPullParserException {
+        final Reader reader = new InvalidXMLCharacterFilterReader(input);
+        parser.setInput(reader);
+    }
+
+    public static XmlPullParser createParser(final boolean namespaceAware, final boolean relaxed) throws XmlPullParserException {
         if (XPP_FACTORY == null) {
             throw new XmlPullParserException("XmlUtils: can't create XML Parser, no factory available");
         }
@@ -71,7 +103,6 @@ public final class XmlUtils {
             final XmlPullParser parser = XPP_FACTORY.newPullParser();
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, namespaceAware);
             parser.setFeature("http://xmlpull.org/v1/doc/features.html#relaxed", relaxed);
-            parser.setInput(input, inputEncoding);
             return parser;
         }
     }

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCompatibilityTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCompatibilityTest.java
@@ -223,17 +223,16 @@ public class GPXParserCompatibilityTest {
     }
 
     @Test
-    public void testConflictingUserDefinedFlagsFollowDocumentOrder() throws Exception {
+    public void testConflictingUserDefinedFlagsTrueWins() throws Exception {
         final String gs = "<gsak:wptExtension><gsak:Child_ByGSAK>true</gsak:Child_ByGSAK></gsak:wptExtension>";
         final String cgeo = "<cgeo:userdefined>false</cgeo:userdefined>";
         for (final boolean gsFirst : new boolean[] {false, true}) {
             final String point = "<wpt><name>AA12345</name><type>Waypoint|Reference Point</type><cmt>Note</cmt><extensions>"
                     + (gsFirst ? gs + cgeo : cgeo + gs) + "</extensions></wpt>";
             final Waypoint parsed = parse(document(point), new GPXParser()).getWaypoints().get(0);
-            assertThat(parsed.isUserDefined()).isEqualTo(!gsFirst);
-            assertThat(parsed.getNote()).isEqualTo(gsFirst ? "Note" : "");
-            assertThat(parsed.getUserNote()).isEqualTo(gsFirst ? "" : "Note");
-            assertThat(parsed.isOriginalCoordsEmpty()).isEqualTo(gsFirst);
+            assertThat(parsed.isUserDefined()).isEqualTo(true);
+            assertThat(parsed.getNote()).isEqualTo("");
+            assertThat(parsed.getUserNote()).isEqualTo("Note");
         }
     }
 

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCompatibilityTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCompatibilityTest.java
@@ -147,16 +147,16 @@ public class GPXParserCompatibilityTest {
     }
 
     @Test
-    public void testLogsFromBothSourcesRetainOrderAndDiscardUnknownTypes() throws Exception {
+    public void testLogsFromBothSourcesArePresentAndDiscardUnknownTypes() throws Exception {
         final String gs = "<gs:cache><gs:logs><gs:log id=\"12345\"><gs:type>Found it</gs:type></gs:log>"
                 + "<gs:log><gs:type>Unknown value</gs:type></gs:log></gs:logs></gs:cache>";
         final String tc = "<tc:terracache><tc:logs><tc:log id=\"42\"><tc:type>Note</tc:type></tc:log>"
                 + "<tc:log><tc:type>Unknown value</tc:type></tc:log></tc:logs></tc:terracache>";
         for (final boolean gsFirst : new boolean[] {false, true}) {
             final List<LogEntry> logs = parse(document(cache("GC12345", gsFirst ? gs + tc : tc + gs)), new GPXParser()).getGlobalItems().get(0).logs;
-            assertThat(logs).extracting(log -> log.logType).containsExactly(gsFirst ? LogType.FOUND_IT : LogType.NOTE, gsFirst ? LogType.NOTE : LogType.FOUND_IT);
-            assertThat(logs.get(gsFirst ? 0 : 1).serviceLogId).isEqualTo(GCUtils.logIdToLogCode(12345));
-            assertThat(logs.get(gsFirst ? 1 : 0).serviceLogId).isNull();
+            assertThat(logs).extracting(log -> log.logType).containsExactlyInAnyOrder(gsFirst ? LogType.FOUND_IT : LogType.NOTE, gsFirst ? LogType.NOTE : LogType.FOUND_IT);
+            assertThat(logs.get(0).serviceLogId).isEqualTo(GCUtils.logIdToLogCode(12345));
+            assertThat(logs.get(1).serviceLogId).isNull();
         }
         assertThat(parse(document(cache("OC12345", gs)), new GPXParser()).getGlobalItems().get(0).logs.get(0).serviceLogId).isNull();
     }

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCompatibilityTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCompatibilityTest.java
@@ -1,0 +1,245 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.connector.gc.GCUtils;
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GPXParserCompatibilityTest {
+
+    static String document(final String body) {
+        return "<gpx version=\"1.0\" xmlns=\"http://www.topografix.com/GPX/1/0\""
+                + " xmlns:gs=\"http://www.groundspeak.com/cache/1/0\" xmlns:gsak=\"http://www.gsak.net/xmlv1/6\""
+                + " xmlns:cgeo=\"http://www.cgeo.org/wptext/1/0\" xmlns:oc=\"https://github.com/opencaching/gpx-extension-v1\""
+                + " xmlns:tc=\"http://www.TerraCaching.com/GPX/1/0\">" + body + "</gpx>";
+    }
+
+    static RecordingGPXParseHooks parse(final String xml, final GPXParser parser) throws Exception {
+        return parse(xml, parser, new RecordingGPXParseHooks());
+    }
+
+    static RecordingGPXParseHooks parse(final String xml, final GPXParser parser, final RecordingGPXParseHooks hooks) throws Exception {
+        try (InputStream stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            parser.parse(stream, hooks);
+        }
+        return hooks;
+    }
+
+    private static String cache(final String name, final String fields) {
+        return "<wpt lat=\"48\" lon=\"9\"><name>" + name + "</name><sym>Geocache</sym>" + fields + "</wpt>";
+    }
+
+    private static Geocache parseCache(final String name, final String fields) throws Exception {
+        return parse(document(cache(name, fields)), new GPXParser()).getGeocaches().get(0);
+    }
+
+    @Test
+    public void testFoundSymbolOverridesDnf() throws Exception {
+        final String found = "<wpt><name>GC12345</name><sym>Geocache Found</sym>"
+                + "<gsak:wptExtension><gsak:DNF>true</gsak:DNF></gsak:wptExtension></wpt>";
+        final List<Geocache> caches = parse(document(found + cache("GC23456", "")), new GPXParser()).getGeocaches();
+        assertThat(caches).hasSize(2);
+        assertThat(caches.get(0).isFound()).isTrue();
+        assertThat(caches.get(0).isDNF()).isFalse();
+        assertThat(caches.get(0).getCoords()).isNull();
+        assertThat(caches.get(1).isFound()).isFalse();
+    }
+
+    @Test
+    public void testOriginalCoordinatesFromGsakInBothExtensionLayouts() throws Exception {
+        final String extensions = "<gsak:wptExtension><gsak:LatBeforeCorrect>51.223032</gsak:LatBeforeCorrect>"
+                + "<gsak:LonBeforeCorrect>6.026147</gsak:LonBeforeCorrect><gsak:Code>GC4PGTG</gsak:Code></gsak:wptExtension>";
+        for (final boolean gpx11 : new boolean[] {false, true}) {
+            final Geocache parsed = parseCache("Some name", gpx11 ? "<extensions>" + extensions + "</extensions>" : extensions);
+            assertThat(parsed.hasUserModifiedCoords()).isTrue();
+            assertThat(parsed.getCoords()).isEqualTo(new Geopoint(48, 9));
+            assertThat(parsed.getWaypoints()).hasSize(1);
+            final Waypoint original = parsed.getWaypoints().get(0);
+            assertThat(original.getWaypointType()).isEqualTo(WaypointType.ORIGINAL);
+            assertThat(original.getGeocode()).isEqualTo("GC4PGTG");
+            assertThat(original.getCoords()).isEqualTo(new Geopoint(51.223032, 6.026147));
+        }
+        for (final String latitude : new String[] {"", "NaN", "invalid", "91"}) {
+            final Geocache parsed = parseCache("GC12345", "<gsak:wptExtension><gsak:LatBeforeCorrect>" + latitude
+                    + "</gsak:LatBeforeCorrect><gsak:LonBeforeCorrect>9</gsak:LonBeforeCorrect></gsak:wptExtension>");
+            assertThat(parsed.getWaypoints()).isEmpty();
+            assertThat(parsed.hasUserModifiedCoords()).isFalse();
+        }
+    }
+
+    @Test
+    public void testUrlsAndLinksRestoreGuidAndGeocode() throws Exception {
+        final String guid = "9946f030-a514-46d8-a050-a60e92fd2e1a";
+        final String url = "https://www.geocaching.com/seek/cache_details.aspx?wp=GC31J2H&amp;guid=" + guid + "&amp;other=1";
+        for (final String field : new String[] {"<url>" + url + "</url>", "<link href=\"" + url + "\"/>", "<link><href>" + url + "</href></link>"}) {
+            final Geocache parsed = parseCache("Some title", field);
+            assertThat(parsed.getGeocode()).isEqualTo("GC31J2H");
+            assertThat(parsed.getGuid()).isEqualTo(guid);
+            assertThat(parsed.getCacheId()).isEqualTo("2406611");
+        }
+    }
+
+    @Test
+    public void testWaymarkTitlesFromUrlNameAndLinkText() throws Exception {
+        for (final String title : new String[] {"<urlname>Roman water pipe</urlname>", "<link><text>Roman water pipe</text></link>"}) {
+            final String point = "<wpt><name>WM7BM7</name><sym>Waymark</sym>" + title + "</wpt>";
+            final Geocache parsed = parse(document(point), new GPXParser()).getGeocaches().get(0);
+            assertThat(parsed.getName()).isEqualTo("Roman water pipe");
+        }
+        assertThat(parseCache("WM7BM7", "<urlname>Fallback</urlname><gs:cache><gs:name>Explicit title</gs:name></gs:cache>").getName()).isEqualTo("Explicit title");
+    }
+
+    @Test
+    public void testOpenCachingPasswordAndAlternativeListing() throws Exception {
+        for (final boolean gpx11 : new boolean[] {false, true}) {
+            final String extension = "<oc:cache><oc:requires_password>true</oc:requires_password><oc:other_code>GC12345</oc:other_code></oc:cache>";
+            final Geocache parsed = parseCache("OC12345", "<cmt>Description</cmt>" + (gpx11 ? "<extensions>" + extension + "</extensions>" : extension));
+            assertThat(parsed.isLogPasswordRequired()).isTrue();
+            assertThat(parsed.getDescription()).contains("https://coord.info/GC12345").endsWith("Description");
+        }
+        assertThat(parseCache("OC12345", "<oc:cache><oc:requires_password>false</oc:requires_password></oc:cache>").isLogPasswordRequired()).isFalse();
+    }
+
+    @Test
+    public void testDatesUseOffsetsAndConsumeEntireValue() throws Exception {
+        final TimeZone previous = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT+02:00"));
+            final long expected = Instant.parse("2011-11-07T07:00:00Z").toEpochMilli();
+            for (final String date : new String[] {"2011-11-07T00:00:00.0000000-07:00", "2011-11-07T00:00:00-0700", "2011-11-07T07:00:00Z", "2011-11-07T08:00:00+01:00"}) {
+                final String logs = "<gs:cache><gs:logs><gs:log><gs:type>Found it</gs:type><gs:date>" + date + "</gs:date></gs:log></gs:logs></gs:cache>";
+                final RecordingGPXParseHooks hooks = parse(document(cache("GC12345", "<time>" + date + "</time>" + logs
+                        + "<gsak:wptExtension><gsak:UserFound>" + date + "</gsak:UserFound></gsak:wptExtension>")), new GPXParser());
+                assertThat(hooks.getGeocaches().get(0).getHiddenDate().getTime()).isEqualTo(expected);
+                assertThat(hooks.getGeocaches().get(0).getVisitedDate()).isEqualTo(expected);
+                assertThat(hooks.getGlobalItems().get(0).logs.get(0).date).isEqualTo(expected);
+            }
+            for (final String date : new String[] {"2011-11-07", "2011-11-07T00:00:00"}) {
+                assertThat(parseCache("GC12345", "<time>" + date + "</time>").getHiddenDate().getTime())
+                        .isEqualTo(Instant.parse("2011-11-06T22:00:00Z").toEpochMilli());
+            }
+            for (final String date : new String[] {"2011-11-07T00:00:00garbage", "2011-02-30", "2011-11-07T00:00:00+99:00"}) {
+                assertThat(parseCache("GC12345", "<gsak:wptExtension><gsak:DNFDate>" + date + "</gsak:DNFDate></gsak:wptExtension>").getVisitedDate()).isZero();
+            }
+        } finally {
+            TimeZone.setDefault(previous);
+        }
+    }
+
+    @Test
+    public void testCacheIdCorrectionIsLimitedToGeocachingCom() throws Exception {
+        assertThat(parseCache("GC31J2H", "<gs:cache id=\"123456\"/>").getCacheId()).isEqualTo("2406611");
+        assertThat(parseCache("GC31J2H", "").getCacheId()).isEqualTo("2406611");
+        assertThat(parseCache("OC12345", "<gs:cache id=\"123456\"/>").getCacheId()).isEqualTo("123456");
+    }
+
+    @Test
+    public void testLogsFromBothSourcesRetainOrderAndDiscardUnknownTypes() throws Exception {
+        final String gs = "<gs:cache><gs:logs><gs:log id=\"12345\"><gs:type>Found it</gs:type></gs:log>"
+                + "<gs:log><gs:type>Unknown value</gs:type></gs:log></gs:logs></gs:cache>";
+        final String tc = "<tc:terracache><tc:logs><tc:log id=\"42\"><tc:type>Note</tc:type></tc:log>"
+                + "<tc:log><tc:type>Unknown value</tc:type></tc:log></tc:logs></tc:terracache>";
+        for (final boolean gsFirst : new boolean[] {false, true}) {
+            final List<LogEntry> logs = parse(document(cache("GC12345", gsFirst ? gs + tc : tc + gs)), new GPXParser()).getGlobalItems().get(0).logs;
+            assertThat(logs).extracting(log -> log.logType).containsExactly(gsFirst ? LogType.FOUND_IT : LogType.NOTE, gsFirst ? LogType.NOTE : LogType.FOUND_IT);
+            assertThat(logs.get(gsFirst ? 0 : 1).serviceLogId).isEqualTo(GCUtils.logIdToLogCode(12345));
+            assertThat(logs.get(gsFirst ? 1 : 0).serviceLogId).isNull();
+        }
+        assertThat(parse(document(cache("OC12345", gs)), new GPXParser()).getGlobalItems().get(0).logs.get(0).serviceLogId).isNull();
+    }
+
+    @Test
+    public void testExtremcachingMetadataAndSessionReset() throws Exception {
+        final String points = cache("GCEC12345", "") + "<wpt><name>00EC12345</name><type>Waypoint|Reference Point</type></wpt>";
+        for (final String metadata : new String[] {"<url>https://extremcaching.com</url>", "<creator>extremcaching</creator>", "<metadata><link href=\"https://extremcaching.com\"/></metadata>"}) {
+            final GPXParser parser = new GPXParser();
+            final RecordingGPXParseHooks hooks = parse(document(metadata + points), parser);
+            assertThat(hooks.getGeocaches().get(0).getGeocode()).isEqualTo("EC12345");
+            assertThat(hooks.getWaypoints().get(0).getGeocode()).isEqualTo("EC12345");
+            assertThat(parse(document(cache("GCEC12345", "")), parser).getGeocaches().get(0).getGeocode()).isEqualTo("GCEC12345");
+        }
+        assertThat(parse(document(points).replace("<gpx ", "<gpx creator=\"extremcaching\" "), new GPXParser()).getGeocaches().get(0).getGeocode()).isEqualTo("EC12345");
+    }
+
+    @Test
+    public void testBlankExtensionTextClearsFallbackDescriptions() throws Exception {
+        for (final String blank : new String[] {"", "  ", "nil"}) {
+            final Geocache cache = parseCache("GC12345", "<desc>Short fallback</desc><cmt>Long fallback</cmt><gs:cache>"
+                    + "<gs:short_description>" + blank + "</gs:short_description><gs:long_description>" + blank + "</gs:long_description></gs:cache>");
+            assertThat(cache.getShortDescription()).isEmpty();
+            assertThat(cache.getDescription()).isEmpty();
+        }
+        assertThat(parseCache("GC12345", "<desc>Keep me</desc><gs:cache/>").getShortDescription()).isEqualTo("Keep me");
+    }
+
+    @Test
+    public void testTerraCachingMarkerDoesNotBecomeDescription() throws Exception {
+        assertThat(parseCache("TC12345", "<desc>GC_WayPoint1</desc>").getShortDescription()).isEmpty();
+    }
+
+    @Test
+    public void testGeocodeRecognitionKeepsLongAndUnknownIdentifiers() throws Exception {
+        final String lab = "AL12345678-1234-1234-1234-123456789ABC_1234567890";
+        assertThat(parseCache(lab, "").getGeocode()).isEqualTo(lab);
+        assertThat(parseCache("Unknown title", "<desc>Find (" + lab.toLowerCase(java.util.Locale.US) + ") here</desc>").getGeocode()).isEqualTo(lab);
+        assertThat(parseCache("ABCDE summit", "").getGeocode()).isEqualTo("ABCDE SUMMIT");
+        assertThat(parseCache("12345678-1234-1234-1234-123456789ABC", "").getGeocode()).isEqualTo("12345678-1234-1234-1234-123456789ABC");
+        assertThat(parseCache("Unknown title", "<desc>ABCDE (GC31J2H)</desc>").getGeocode()).isEqualTo("GC31J2H");
+        assertThat(parseCache("Unknown title", "<desc>wordGC31J2Hword</desc>").getGeocode()).isEqualTo("UNKNOWN TITLE");
+        assertThat(parseCache("Unknown title", "<desc>GC1</desc>").getGeocode()).isEqualTo("GC1");
+        assertThat(parseCache("GC12345", "<url>https://coord.info/?wp=GC23456</url><gsak:wptExtension><gsak:Code>OC12345</gsak:Code></gsak:wptExtension>").getGeocode()).isEqualTo("OC12345");
+    }
+
+    @Test
+    public void testCacheExtensionsClassifyEntriesWithoutTypeOrSymbol() throws Exception {
+        for (final String extension : new String[] {"<gs:cache/>", "<tc:terracache/>", "<oc:cache/>"}) {
+            assertThat(parse(document("<wpt><name>GC12345</name>" + extension + "</wpt>"), new GPXParser()).getGeocaches()).hasSize(1);
+        }
+    }
+
+    @Test
+    public void testParentTitleResolutionUsesOnlyCurrentSession() throws Exception {
+        final GPXParser parser = new GPXParser();
+        final String parent = cache("GC12345", "<gs:cache><gs:name>Parent title</gs:name></gs:cache>");
+        final String child = "<wpt><name>AA12345</name><type>Waypoint|Reference Point</type>"
+                + "<gsak:wptExtension><gsak:Parent> parent TITLE </gsak:Parent></gsak:wptExtension></wpt>";
+        assertThat(parse(document(parent + child), parser).getWaypoints().get(0).getGeocode()).isEqualTo("GC12345");
+        assertThat(parse(document(child), parser).getWaypoints().get(0).getGeocode()).isEqualTo("GC12345");
+        parser.reset();
+        assertThat(parse(document(child), parser).getGlobalItems().get(0).parentGeocode).isEqualTo("parent TITLE");
+    }
+
+    @Test
+    public void testConflictingUserDefinedFlagsFollowDocumentOrder() throws Exception {
+        final String gs = "<gsak:wptExtension><gsak:Child_ByGSAK>true</gsak:Child_ByGSAK></gsak:wptExtension>";
+        final String cgeo = "<cgeo:userdefined>false</cgeo:userdefined>";
+        for (final boolean gsFirst : new boolean[] {false, true}) {
+            final String point = "<wpt><name>AA12345</name><type>Waypoint|Reference Point</type><cmt>Note</cmt><extensions>"
+                    + (gsFirst ? gs + cgeo : cgeo + gs) + "</extensions></wpt>";
+            final Waypoint parsed = parse(document(point), new GPXParser()).getWaypoints().get(0);
+            assertThat(parsed.isUserDefined()).isEqualTo(!gsFirst);
+            assertThat(parsed.getNote()).isEqualTo(gsFirst ? "Note" : "");
+            assertThat(parsed.getUserNote()).isEqualTo(gsFirst ? "" : "Note");
+            assertThat(parsed.isOriginalCoordsEmpty()).isEqualTo(gsFirst);
+        }
+    }
+
+    @Test
+    public void testInvalidXmlCharactersAndUtf8Bom() throws Exception {
+        final String body = cache("GC12345", "<desc>A&#x1;B" + (char) 2 + "C&#3;D</desc>");
+        assertThat(parse("\uFEFF" + document(body), new GPXParser()).getGeocaches().get(0).getShortDescription()).isEqualTo("ABCD");
+    }
+}

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCoordinatesTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCoordinatesTest.java
@@ -27,7 +27,7 @@ public class GPXParserCoordinatesTest {
         return GPXParserCompatibilityTest.document(body);
     }
 
-    private static GPXParser parser(final GPXParser.ParseMode mode) {
+    private static GPXParser parser(final ParseMode mode) {
         return new GPXParser().setParseMode(mode);
     }
 
@@ -43,13 +43,13 @@ public class GPXParserCoordinatesTest {
     private static void assertCoordinates(final String attributes, final Geopoint genericCoords, final Geopoint cacheCoords) throws Exception {
         for (final String tag : POINT_TAGS) {
             for (int kind = 0; kind < FIELDS.length; kind++) {
-                for (final GPXParser.ParseMode mode : new GPXParser.ParseMode[] {GPXParser.ParseMode.FULL, GPXParser.ParseMode.COORDINATES_ONLY}) {
+                for (final ParseMode mode : new ParseMode[] {ParseMode.FULL, ParseMode.COORDINATES_ONLY}) {
                     final RecordingGPXParseHooks hooks = GPXParserCompatibilityTest.parse(pointDocument(tag, attributes, FIELDS[kind]), parser(mode));
                     assertThat(hooks.getGlobalItems()).as("%s %s %s %s", tag, kind, mode, attributes).hasSize(1);
                     final RecordingGPXParseHooks.Item item = hooks.getGlobalItems().get(0);
-                    final boolean fullEntity = mode == GPXParser.ParseMode.FULL && kind >= 2;
+                    final boolean fullEntity = mode == ParseMode.FULL && kind >= 2;
                     assertThat(item.coordinate.getCoords()).isEqualTo(fullEntity ? cacheCoords : genericCoords);
-                    assertThat(item.kind).isEqualTo(mode == GPXParser.ParseMode.FULL ? KINDS[kind]
+                    assertThat(item.kind).isEqualTo(mode == ParseMode.FULL ? KINDS[kind]
                             : kind == 0 ? RecordingGPXParseHooks.ItemKind.COORDINATE : RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
                     if (kind == 1) {
                         assertThat(item.coordinate.getElevation()).isEqualTo(123f);
@@ -92,9 +92,9 @@ public class GPXParserCoordinatesTest {
         for (final String tag : POINT_TAGS) {
             for (int kind = 0; kind < FIELDS.length; kind++) {
                 final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
-                hooks.setModes(GPXParser.ParseMode.COORDINATES_ONLY, GPXParser.ParseMode.SKIP, GPXParser.ParseMode.SKIP);
+                hooks.setModes(ParseMode.COORDINATES_ONLY, ParseMode.SKIP, ParseMode.SKIP);
                 final String document = pointDocument(tag, "", FIELDS[kind]);
-                GPXParserCompatibilityTest.parse(document, parser(GPXParser.ParseMode.SKIP), hooks);
+                GPXParserCompatibilityTest.parse(document, parser(ParseMode.SKIP), hooks);
                 // Cache/waypoint SKIP modes doesn't suppress generic top-level coordinates.
                 assertThat(hooks.getGlobalItems()).hasSize("wpt".equals(tag) ? 1 : 0);
                 assertCounts(hooks, tag);

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCoordinatesTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserCoordinatesTest.java
@@ -1,0 +1,116 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.models.ICoordinate;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GPXParserCoordinatesTest {
+
+    private static final String[] POINT_TAGS = {"wpt", "rtept", "trkpt"};
+    private static final String[] FIELDS = {"", "<name>Named point</name><ele>123</ele>",
+        "<name>GC12345</name><sym>Geocache</sym>", "<name>AA12345</name><type>Waypoint|Reference Point</type>"};
+    private static final RecordingGPXParseHooks.ItemKind[] KINDS = {RecordingGPXParseHooks.ItemKind.COORDINATE,
+        RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE, RecordingGPXParseHooks.ItemKind.GEOCACHE, RecordingGPXParseHooks.ItemKind.WAYPOINT};
+
+    private static String pointDocument(final String tag, final String attributes, final String fields) {
+        final String point = "<" + tag + " " + attributes + ">" + fields + "</" + tag + ">";
+        final String body;
+        if ("rtept".equals(tag)) {
+            body = "<rte>" + point + "</rte>";
+        } else if ("trkpt".equals(tag)) {
+            body = "<trk><trkseg>" + point + "</trkseg></trk>";
+        } else {
+            body = point;
+        }
+        return GPXParserCompatibilityTest.document(body);
+    }
+
+    private static GPXParser parser(final GPXParser.ParseMode mode) {
+        return new GPXParser().setParseMode(mode);
+    }
+
+    private static void assertCounts(final RecordingGPXParseHooks hooks, final String tag) {
+        if ("rtept".equals(tag)) {
+            assertThat(hooks.getRoutes().get(0).pointCount).isEqualTo(1);
+        } else if ("trkpt".equals(tag)) {
+            assertThat(hooks.getTracks().get(0).totalPointCount).isEqualTo(1);
+            assertThat(hooks.getTracks().get(0).segments.get(0).pointCount).isEqualTo(1);
+        }
+    }
+
+    private static void assertCoordinates(final String attributes, final Geopoint genericCoords, final Geopoint cacheCoords) throws Exception {
+        for (final String tag : POINT_TAGS) {
+            for (int kind = 0; kind < FIELDS.length; kind++) {
+                for (final GPXParser.ParseMode mode : new GPXParser.ParseMode[] {GPXParser.ParseMode.FULL, GPXParser.ParseMode.COORDINATES_ONLY}) {
+                    final RecordingGPXParseHooks hooks = GPXParserCompatibilityTest.parse(pointDocument(tag, attributes, FIELDS[kind]), parser(mode));
+                    assertThat(hooks.getGlobalItems()).as("%s %s %s %s", tag, kind, mode, attributes).hasSize(1);
+                    final RecordingGPXParseHooks.Item item = hooks.getGlobalItems().get(0);
+                    final boolean fullEntity = mode == GPXParser.ParseMode.FULL && kind >= 2;
+                    assertThat(item.coordinate.getCoords()).isEqualTo(fullEntity ? cacheCoords : genericCoords);
+                    assertThat(item.kind).isEqualTo(mode == GPXParser.ParseMode.FULL ? KINDS[kind]
+                            : kind == 0 ? RecordingGPXParseHooks.ItemKind.COORDINATE : RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
+                    if (kind == 1) {
+                        assertThat(item.coordinate.getElevation()).isEqualTo(123f);
+                    }
+                    assertCounts(hooks, tag);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMissingAndPartialCoordinatesAcrossAllPointTypesAndModes() throws Exception {
+        assertCoordinates("", new Geopoint(0, 0), null);
+        assertCoordinates("lat=\"48\"", new Geopoint(48, 0), null);
+        assertCoordinates("lon=\"9\"", new Geopoint(0, 9), null);
+        assertCoordinates("lat=\" \" lon=\"\"", new Geopoint(0, 0), null);
+    }
+
+    @Test
+    public void testInvalidCoordinatesAreReplacedIndependently() throws Exception {
+        for (final String invalid : new String[] {"invalid", "NaN", "Infinity", "-Infinity", "1e999", "181", "-181"}) {
+            assertCoordinates("lat=\"" + invalid + "\" lon=\"9\"", new Geopoint(0, 9), null);
+            assertCoordinates("lat=\"48\" lon=\"" + invalid + "\"", new Geopoint(48, 0), null);
+        }
+        assertCoordinates("lat=\"91\" lon=\"-180\"", new Geopoint(0, -180), null);
+        assertCoordinates("lat=\"-91\" lon=\"180\"", new Geopoint(0, 180), null);
+    }
+
+    @Test
+    public void testValidZeroAndBoundaryCoordinates() throws Exception {
+        assertCoordinates("lat=\"0\" lon=\"0\"", new Geopoint(0, 0), null);
+        assertCoordinates("lat=\"0\" lon=\"9\"", new Geopoint(0, 9), new Geopoint(0, 9));
+        assertCoordinates("lat=\"48\" lon=\"0\"", new Geopoint(48, 0), new Geopoint(48, 0));
+        assertCoordinates("lat=\"90\" lon=\"180\"", new Geopoint(90, 180), new Geopoint(90, 180));
+        assertCoordinates("lat=\"-90\" lon=\"-180\"", new Geopoint(-90, -180), new Geopoint(-90, -180));
+    }
+
+    @Test
+    public void testSkipStillCountsEveryRouteAndTrackPoint() throws Exception {
+        for (final String tag : POINT_TAGS) {
+            for (int kind = 0; kind < FIELDS.length; kind++) {
+                final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+                hooks.setModes(GPXParser.ParseMode.COORDINATES_ONLY, GPXParser.ParseMode.SKIP, GPXParser.ParseMode.SKIP);
+                final String document = pointDocument(tag, "", FIELDS[kind]);
+                GPXParserCompatibilityTest.parse(document, parser(GPXParser.ParseMode.SKIP), hooks);
+                // Cache/waypoint SKIP modes doesn't suppress generic top-level coordinates.
+                assertThat(hooks.getGlobalItems()).hasSize("wpt".equals(tag) ? 1 : 0);
+                assertCounts(hooks, tag);
+            }
+        }
+    }
+
+    @Test
+    public void testMixedEntriesStayInDocumentOrder() throws Exception {
+        final String body = "<wpt><name>GC12345</name><sym>Geocache</sym></wpt><wpt lon=\"9\"/>"
+                + "<wpt><name>AA12345</name><type>Waypoint|Reference Point</type></wpt><wpt lat=\"48\"><name>Last</name></wpt>";
+        final RecordingGPXParseHooks hooks = GPXParserCompatibilityTest.parse(GPXParserCompatibilityTest.document(body), new GPXParser());
+        assertThat(hooks.getGlobalItems()).extracting(i -> i.kind).containsExactly(
+                RecordingGPXParseHooks.ItemKind.GEOCACHE, RecordingGPXParseHooks.ItemKind.COORDINATE,
+                RecordingGPXParseHooks.ItemKind.WAYPOINT, RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
+        assertThat(hooks.getGlobalItems()).extracting(i -> i.coordinate).extracting(ICoordinate::getCoords)
+                .containsExactly(null, new Geopoint(0, 9), null, new Geopoint(48, 0));
+    }
+}

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserLifecycleTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserLifecycleTest.java
@@ -1,0 +1,76 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.NamedGeoCoordinate;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.utils.gpx.GPXParser.ParseMode;
+import cgeo.geocaching.utils.xml.XmlUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GPXParserLifecycleTest {
+
+    @Test
+    public void testSwitchToFullRetainsMetadataAndPropagatesHookModes() throws Exception {
+        final GPXParser parser = new GPXParser().setParseMode(ParseMode.COORDINATES_ONLY);
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks() {
+            @Override
+            public ParseMode onNamedCoordinate(final NamedGeoCoordinate coordinate) {
+                super.onNamedCoordinate(coordinate);
+                return ParseMode.FULL;
+            }
+
+            @Override
+            public ParseMode onGeocache(final Geocache geocache, final List<LogEntry> logs) {
+                super.onGeocache(geocache, logs);
+                return ParseMode.COORDINATES_ONLY;
+            }
+
+            @Override
+            public ParseMode onWaypoint(final Waypoint waypoint, final String parentGeocode) {
+                super.onWaypoint(waypoint, parentGeocode);
+                return ParseMode.ABORT;
+            }
+        };
+        final String xml = GPXParserCompatibilityTest.document("<metadata><link href=\"https://extremcaching.com\"/></metadata>"
+                + "<wpt><name>Enable full parsing</name></wpt>"
+                + "<wpt><name>GCEC12345</name><sym>Geocache</sym></wpt>"
+                + "<wpt><name>GCEC23456</name><sym>Geocache</sym></wpt>"
+                + "<wpt><name>00EC12345</name><type>Waypoint|Reference Point</type></wpt>"
+                + "<wpt><name>Must not be parsed</name></wpt>");
+        try (InputStream stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            assertThat(parser.parse(XmlUtils.createParser(stream, true), hooks)).isFalse();
+        }
+        assertThat(hooks.getGlobalItems()).extracting(item -> item.kind).containsExactly(
+                RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE,
+                RecordingGPXParseHooks.ItemKind.GEOCACHE,
+                RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE,
+                RecordingGPXParseHooks.ItemKind.WAYPOINT);
+        assertThat(hooks.getGeocaches().get(0).getGeocode()).isEqualTo("EC12345");
+        assertThat(hooks.getWaypoints().get(0).getGeocode()).isEqualTo("EC12345");
+    }
+
+    @Test
+    public void testTerraCachingStateClearedBetweenDocuments() throws Exception {
+        final GPXParser parser = new GPXParser();
+        final String marker = "<wpt><name>TC12345</name><sym>Terracache</sym><desc>GC_WayPoint1</desc></wpt>";
+        final String child = "<wpt><name>TC123451</name><sym>Terracache</sym></wpt>";
+        final RecordingGPXParseHooks first = GPXParserCompatibilityTest.parse(GPXParserCompatibilityTest.document(marker + child), parser);
+        assertThat(first.getGeocaches()).hasSize(1);
+        assertThat(first.getWaypoints()).hasSize(1);
+
+        parser.setParseMode(ParseMode.SKIP);
+        GPXParserCompatibilityTest.parse(GPXParserCompatibilityTest.document(marker), parser);
+        parser.setParseMode(ParseMode.FULL);
+        final RecordingGPXParseHooks next = GPXParserCompatibilityTest.parse(GPXParserCompatibilityTest.document(child), parser);
+        assertThat(next.getGeocaches()).hasSize(1);
+        assertThat(next.getWaypoints()).isEmpty();
+    }
+}

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserLifecycleTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserLifecycleTest.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.NamedGeoCoordinate;
 import cgeo.geocaching.models.Waypoint;
-import cgeo.geocaching.utils.gpx.GPXParser.ParseMode;
 import cgeo.geocaching.utils.xml.XmlUtils;
 
 import java.io.ByteArrayInputStream;

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
@@ -283,7 +283,7 @@ public class GPXParserTest {
     }
 
     // -----------------------------------------------------------------------------------------------------
-    // TerraCaching "GC_WayPoint1" sticky-marker classification (see terraChildWaypoint field doc on GPXParser)
+    // TerraCaching "GC_WayPoint1" sticky-marker classification (see terraChildWaypoint field doc on GPXFullWptParser)
     // -----------------------------------------------------------------------------------------------------
 
     @Test

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
@@ -1,0 +1,357 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.ICoordinate;
+import cgeo.geocaching.models.NamedGeoCoordinate;
+import cgeo.geocaching.models.Waypoint;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Among other things, scans the real-world {@code .gpx} sample files that
+ * already exist in the repository for other (SAX-based) parser tests.
+ */
+public class GPXParserTest {
+
+    /** files under {@code main/src/test/res/xml/} */
+    private static final String[] TEST_RES_XML_FILES = {
+        "/xml/gc3t1xg_gsak_110.gpx",
+        "/xml/ZUG.IN.ZWEI.TEILEN.gpx",
+    };
+
+    /** files under {@code main/src/androidTest/res/raw/} */
+    private static final String[] ANDROID_TEST_RAW_FILES = {
+        "/gc3t1xg_gsak_110.gpx",
+        "/gc3t1xg_gsak.gpx",
+        "/gc3abcd.gpx",
+        "/gc31j2h_wpts_original.gpx",
+        "/gc31j2h_wpts_empty_coord.gpx",
+        "/gc31j2h_wpts.gpx",
+        "/gc31j2h2_bad_cacheid.gpx",
+        "/gc31j2h.gpx",
+        "/gc1bkp3_gpx101.gpx",
+        "/gc1bkp3_gpx100.gpx",
+        "/challenge.gpx",
+        "/zz1000.gpx",
+        "/waymarking_gpx.gpx",
+        "/terracaching_gpx.gpx",
+        "/tcehl_gpx.gpx",
+        "/tcavl_gpx.gpx",
+        "/tc99un_gpx.gpx",
+    };
+
+    static InputStream openResource(final String resourceName) {
+        final InputStream is = GPXParserTest.class.getResourceAsStream(resourceName);
+        return Objects.requireNonNull(is, "test resource not found: " + resourceName);
+    }
+
+    private static RecordingGPXParseHooks parse(final String resourceName) throws IOException, XmlPullParserException {
+        return parse(resourceName, new GPXParser());
+    }
+
+    private static RecordingGPXParseHooks parse(final String resourceName, final GPXParser parser) throws IOException, XmlPullParserException {
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream is = openResource(resourceName)) {
+            parser.parse(is, hooks);
+        }
+        return hooks;
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // targeted tests for well-known sample files
+    // -----------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testParseGsakGeocache() throws Exception {
+        final RecordingGPXParseHooks hooks = parse("/xml/gc3t1xg_gsak_110.gpx");
+
+        assertThat(hooks.getGpxCreatorOrName()).isEqualTo("GSAK");
+        assertThat(hooks.getGeocaches()).hasSize(1);
+
+        final Geocache cache = hooks.getGeocaches().get(0);
+        assertThat(cache.getGeocode()).isEqualTo("GC3T1XG");
+        assertThat(cache.getName()).isEqualTo("Abus");
+        assertThat(cache.getCoords()).isEqualTo(new Geopoint(50.10745, 8.6587));
+        assertThat(cache.getType()).isEqualTo(CacheType.TRADITIONAL);
+        assertThat(cache.getSize()).isEqualTo(CacheSize.SMALL);
+        assertThat(cache.getDifficulty()).isEqualTo(3f);
+        assertThat(cache.getTerrain()).isEqualTo(1f);
+        assertThat(cache.getFavoritePoints()).isEqualTo(615);
+        assertThat(cache.isOnWatchlist()).isFalse();
+        assertThat(cache.getAttributes()).isNotEmpty();
+
+        final List<LogEntry> logs = hooks.getItems().get(0).getLogs();
+        assertThat(logs).hasSize(5);
+        assertThat(logs.get(0).author).isEqualTo("pheenyx");
+        assertThat(logs.get(0).logType).isEqualTo(LogType.FOUND_IT);
+        assertThat(logs.get(2).logType).isEqualTo(LogType.DIDNT_FIND_IT);
+    }
+
+    @Test
+    public void testParseFullGeocacheWithLocationAndOwner() throws Exception {
+        final RecordingGPXParseHooks hooks = parse("/gc31j2h.gpx");
+
+        assertThat(hooks.getGeocaches()).hasSize(1);
+        final Geocache cache = hooks.getGeocaches().get(0);
+        assertThat(cache.getGeocode()).isEqualTo("GC31J2H");
+        assertThat(cache.getName()).isEqualTo("Hockenheimer City-Brunnen");
+        assertThat(cache.getCoords()).isEqualTo(new Geopoint(49.3187, 8.54565));
+        assertThat(cache.getType()).isEqualTo(CacheType.MULTI);
+        assertThat(cache.getSize()).isEqualTo(CacheSize.SMALL);
+        assertThat(cache.getDifficulty()).isEqualTo(2f);
+        assertThat(cache.getTerrain()).isEqualTo(1f);
+        assertThat(cache.getOwnerDisplayName()).isEqualTo("vptsz");
+        assertThat(cache.getLocation()).isEqualTo("Baden-Württemberg, Germany");
+
+        final List<LogEntry> logs = hooks.getItems().get(0).getLogs();
+        assertThat(logs).hasSize(6);
+        assertThat(logs.get(0).author).isEqualTo("hanslinde");
+        assertThat(logs).allMatch(log -> log.logType == LogType.FOUND_IT);
+    }
+
+    @Test
+    public void testWaypointParentResolutionViaNamingConvention() throws Exception {
+        final RecordingGPXParseHooks hooks = parse("/gc31j2h_wpts.gpx");
+
+        assertThat(hooks.getWaypoints()).hasSize(2);
+        assertThat(hooks.getGeocaches()).isEmpty();
+
+        final Waypoint parking = hooks.getWaypoints().get(0);
+        assertThat(parking.getName()).isEqualTo("0031J2H");
+        assertThat(parking.getCoords()).isEqualTo(new Geopoint(49.317517, 8.545083));
+        assertThat(parking.getGeocode()).isEqualTo("GC31J2H");
+
+        final Waypoint stage = hooks.getWaypoints().get(1);
+        assertThat(stage.getName()).isEqualTo("S131J2H");
+        assertThat(stage.getGeocode()).isEqualTo("GC31J2H");
+
+        // order preserved (document order)
+        assertThat(hooks.getItems()).extracting(RecordingGPXParseHooks.RecordedItem::getKind)
+            .containsExactly(RecordingGPXParseHooks.ItemKind.WAYPOINT, RecordingGPXParseHooks.ItemKind.WAYPOINT);
+    }
+
+    @Test
+    public void testParseTrackFileFull() throws Exception {
+        final RecordingGPXParseHooks hooks = parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx");
+
+        // the file name ("train in two parts") reflects that it contains two separate <trk> elements
+        assertThat(hooks.getTracks()).hasSize(2);
+        final int totalPointCount = hooks.getTracks().stream().mapToInt(RecordingGPXParseHooks.RecordedTrack::getTotalPointCount).sum();
+        assertThat(totalPointCount).isEqualTo(648);
+
+        final RecordingGPXParseHooks.RecordedTrack firstTrack = hooks.getTracks().get(0);
+        final List<ICoordinate> firstSegmentPoints = firstTrack.getSegments().get(0).getPoints();
+        assertThat(firstSegmentPoints).isNotEmpty();
+        assertThat(firstTrack.getSegments().get(0).getPointCount()).isEqualTo(firstSegmentPoints.size());
+        final ICoordinate first = firstSegmentPoints.get(0);
+        assertThat(first).isInstanceOf(NamedGeoCoordinate.class);
+        assertThat(first.getCoords()).isEqualTo(new Geopoint(47.464799880981445, 11.045894622802734));
+        assertThat(first.getElevation()).isEqualTo(782.54296875f);
+
+        // every track point is also visible via the global, chronological items list (no classification
+        // applies to plain track points without sym/type, so they all end up as (named) coordinates)
+        assertThat(hooks.getItems()).hasSize(648);
+    }
+
+    @Test
+    public void testParseTrackFileCoordinatesOnly() throws Exception {
+        final GPXParser parser = new GPXParser().setDefaultTrackParseMode(GPXParser.WptParseMode.COORDINATES_ONLY);
+        final RecordingGPXParseHooks hooks = parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser);
+
+        assertThat(hooks.getTracks()).hasSize(2);
+        final int totalPointCount = hooks.getTracks().stream().mapToInt(RecordingGPXParseHooks.RecordedTrack::getTotalPointCount).sum();
+        assertThat(totalPointCount).isEqualTo(648);
+        // COORDINATES_ONLY still reports each point via onCoordinate/onNamedCoordinate (just without ever
+        // attempting geocache/waypoint classification) - callers can build their own point list from this
+        assertThat(hooks.getItems()).hasSize(648);
+        final ICoordinate first = hooks.getTracks().get(0).getSegments().get(0).getPoints().get(0);
+        assertThat(first.getCoords()).isEqualTo(new Geopoint(47.464799880981445, 11.045894622802734));
+        // no geocache/waypoint classification whatsoever happens in COORDINATES_ONLY mode
+        assertThat(hooks.getGeocaches()).isEmpty();
+        assertThat(hooks.getWaypoints()).isEmpty();
+    }
+
+    @Test
+    public void testTrackWithSkipModeStillReportsAccurateCounts() throws Exception {
+        final GPXParser parser = new GPXParser().setDefaultTrackParseMode(GPXParser.WptParseMode.SKIP);
+        final RecordingGPXParseHooks hooks = parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser);
+
+        assertThat(hooks.getTracks()).hasSize(2);
+        final int totalPointCount = hooks.getTracks().stream().mapToInt(RecordingGPXParseHooks.RecordedTrack::getTotalPointCount).sum();
+        assertThat(totalPointCount).isEqualTo(648);
+        // SKIP never fires any per-point hook at all, so nothing is recorded beyond the counts themselves
+        assertThat(hooks.getItems()).isEmpty();
+        for (final RecordingGPXParseHooks.RecordedTrack track : hooks.getTracks()) {
+            for (final RecordingGPXParseHooks.RecordedTrackSegment segment : track.getSegments()) {
+                assertThat(segment.getPoints()).isEmpty();
+                assertThat(segment.getPointCount()).isGreaterThan(0);
+            }
+        }
+    }
+
+    @Test
+    public void testGeocacheSkipModeNeverFiresHook() throws Exception {
+        final GPXParser parser = new GPXParser().setGeocacheParseMode(GPXParser.WptParseMode.SKIP);
+        final RecordingGPXParseHooks hooks = parse("/xml/gc3t1xg_gsak_110.gpx", parser);
+
+        // requirement: SKIP means the hook is never called at all - not even with a placeholder
+        assertThat(hooks.getItems()).isEmpty();
+        assertThat(hooks.getGeocaches()).isEmpty();
+    }
+
+    @Test
+    public void testGeocacheCoordinatesOnlyModeReportedAsNamedCoordinate() throws Exception {
+        final GPXParser parser = new GPXParser().setGeocacheParseMode(GPXParser.WptParseMode.COORDINATES_ONLY);
+        final RecordingGPXParseHooks hooks = parse("/xml/gc3t1xg_gsak_110.gpx", parser);
+
+        // requirement: COORDINATES_ONLY means it is never reported as a Geocache, only as a (named) coordinate
+        assertThat(hooks.getGeocaches()).isEmpty();
+        assertThat(hooks.getItems()).hasSize(1);
+        final RecordingGPXParseHooks.RecordedItem item = hooks.getItems().get(0);
+        assertThat(item.getKind()).isEqualTo(RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
+        assertThat(item.getCoordinate().getCoords()).isEqualTo(new Geopoint(50.10745, 8.6587));
+        // COORDINATES_ONLY never reads extensions, so the name is the wpt's own <name> ("GC3T1XG"), not the
+        // groundspeak:name ("Abus") which lives inside <extensions>
+        assertThat(((NamedGeoCoordinate) item.getCoordinate()).getName()).isEqualTo("GC3T1XG");
+    }
+
+    @Test
+    public void testWaypointSkipAndCoordinatesOnlyModes() throws Exception {
+        final RecordingGPXParseHooks skipHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setWaypointParseMode(GPXParser.WptParseMode.SKIP));
+        assertThat(skipHooks.getItems()).isEmpty();
+
+        final RecordingGPXParseHooks coordHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setWaypointParseMode(GPXParser.WptParseMode.COORDINATES_ONLY));
+        assertThat(coordHooks.getWaypoints()).isEmpty();
+        assertThat(coordHooks.getItems()).hasSize(2);
+        assertThat(coordHooks.getItems()).allMatch(item -> item.getKind() == RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
+    }
+
+    @Test
+    public void testInvalidLatLonIsSkippedSilently() throws Exception {
+        final RecordingGPXParseHooks hooks = parse("/gc31j2h_wpts_empty_coord.gpx");
+
+        // one valid wpt (0031J2H) and one with lat="0" lon="0" (invalid, treated as if it didn't exist)
+        assertThat(hooks.getItems()).hasSize(1);
+        assertThat(hooks.getWaypoints()).hasSize(1);
+        assertThat(hooks.getWaypoints().get(0).getName()).isEqualTo("0031J2H");
+    }
+
+    @Test
+    public void testZzGeocodeWithoutCoordinatesIsStillImported() throws Exception {
+        // legacy parity exception (D23): a geocache-classified entry without valid coordinates is still
+        // reported if its geocode matches c:geo's own "cache without known coordinates" pattern (ZZ...)
+        final RecordingGPXParseHooks hooks = parse("/zz1000.gpx");
+
+        assertThat(hooks.getGeocaches()).hasSize(1);
+        final Geocache cache = hooks.getGeocaches().get(0);
+        assertThat(cache.getGeocode()).isEqualTo("ZZ1000");
+        assertThat(cache.getCoords()).isNull();
+    }
+
+    @Test
+    public void testMalformedFileThrows() {
+        assertThatThrownBy(() -> parse("/gc31j2h_err.gpx"))
+            .isInstanceOfAny(XmlPullParserException.class, IOException.class);
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // TerraCaching "GC_WayPoint1" sticky-marker classification (see terraChildWaypoint field doc on GPXParser)
+    // -----------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testTerraCachingMarkerCacheAndXmlNodeChildWaypoints() throws Exception {
+        final RecordingGPXParseHooks hooks = parse("/tc99un_gpx.gpx");
+
+        // the marker entry itself (desc == GC_WayPoint1) must still be classified as the main geocache,
+        // not as a child waypoint of itself
+        assertThat(hooks.getGeocaches()).hasSize(1);
+        final Geocache cache = hooks.getGeocaches().get(0);
+        assertThat(cache.getGeocode()).isEqualTo("TC99UN");
+        assertThat(cache.getName()).isEqualTo("The Lodges at Heron Pond");
+
+        // all following wpt entries (same "terracache" sym) are its child waypoints, parent = own code minus last char
+        assertThat(hooks.getWaypoints()).hasSize(4);
+        for (final Waypoint waypoint : hooks.getWaypoints()) {
+            assertThat(waypoint.getGeocode()).isEqualTo("TC99UN");
+        }
+        assertThat(hooks.getWaypoints().get(0).getName()).isEqualTo("TC99UN1");
+
+        // order preserved: geocache first, then its 4 child waypoints
+        assertThat(hooks.getItems()).extracting(RecordingGPXParseHooks.RecordedItem::getKind)
+            .containsExactly(
+                RecordingGPXParseHooks.ItemKind.GEOCACHE,
+                RecordingGPXParseHooks.ItemKind.WAYPOINT,
+                RecordingGPXParseHooks.ItemKind.WAYPOINT,
+                RecordingGPXParseHooks.ItemKind.WAYPOINT,
+                RecordingGPXParseHooks.ItemKind.WAYPOINT);
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // reset()
+    // -----------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testResetClearsCrossFileIndex() throws Exception {
+        final GPXParser parser = new GPXParser();
+        // parse the cache first, so its geocode gets indexed by name
+        parse("/gc31j2h.gpx", parser);
+        // without reset(), the waypoint file would additionally benefit from the (here irrelevant, since the
+        // naming convention already resolves it) index; after reset(), the index is empty again
+        parser.reset();
+
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream is = openResource("/gc31j2h_wpts.gpx")) {
+            parser.parse(is, hooks);
+        }
+        // naming convention still resolves the parent regardless of the index, so this must still succeed
+        assertThat(hooks.getWaypoints()).hasSize(2);
+        assertThat(hooks.getWaypoints().get(0).getGeocode()).isEqualTo("GC31J2H");
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // resilience scan: every remaining sample file must parse without error and yield at least one item
+    // -----------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testAllSampleFilesParseWithoutError() throws Exception {
+        for (final String resourceName : TEST_RES_XML_FILES) {
+            assertParsesWithContent(resourceName);
+        }
+        for (final String resourceName : ANDROID_TEST_RAW_FILES) {
+            // note: gc31j2h2_bad_cacheid.gpx deliberately contains an invalid groundspeak cache id;
+            // the parser must tolerate it (not throw) rather than reject the whole file
+            assertParsesWithContent(resourceName);
+        }
+    }
+
+    private static void assertParsesWithContent(final String resourceName) throws Exception {
+        final RecordingGPXParseHooks hooks = parse(resourceName);
+        final int totalItems = hooks.getItems().size()
+            + hooks.getRoutes().size()
+            + hooks.getTracks().size();
+        assertThat(totalItems)
+            .withFailMessage("Expected at least one geocache/waypoint/coordinate/route/track in %s", resourceName)
+            .isGreaterThan(0);
+
+        for (final RecordingGPXParseHooks.RecordedItem item : hooks.getItems()) {
+            assertThat(item.getCoordinate()).withFailMessage("null coordinate in %s", resourceName).isNotNull();
+        }
+    }
+}
+
+
+
+

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
@@ -178,7 +178,7 @@ public class GPXParserTest {
 
     @Test
     public void testParseTrackFileCoordinatesOnly() throws Exception {
-        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY);
+        final GPXParser parser = new GPXParser().setParseMode(ParseMode.COORDINATES_ONLY);
         final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
         parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser, hooks);
 
@@ -197,9 +197,9 @@ public class GPXParserTest {
 
     @Test
     public void testTrackWithSkipModeStillReportsAccurateCounts() throws Exception {
-        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.SKIP);
+        final GPXParser parser = new GPXParser().setParseMode(ParseMode.SKIP);
         final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
-        hooks.setModes(GPXParser.ParseMode.FULL, GPXParser.ParseMode.SKIP, GPXParser.ParseMode.SKIP);
+        hooks.setModes(ParseMode.FULL, ParseMode.SKIP, ParseMode.SKIP);
         parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser, hooks);
 
         assertThat(hooks.getTracks()).hasSize(2);
@@ -217,7 +217,7 @@ public class GPXParserTest {
 
     @Test
     public void testGeocacheSkipModeNeverFiresHook() throws Exception {
-        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.SKIP);
+        final GPXParser parser = new GPXParser().setParseMode(ParseMode.SKIP);
         final RecordingGPXParseHooks hooks = parse("/xml/gc3t1xg_gsak_110.gpx", parser);
 
         // requirement: SKIP means the hook is never called at all - not even with a placeholder
@@ -227,7 +227,7 @@ public class GPXParserTest {
 
     @Test
     public void testGeocacheCoordinatesOnlyModeReportedAsNamedCoordinate() throws Exception {
-        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY);
+        final GPXParser parser = new GPXParser().setParseMode(ParseMode.COORDINATES_ONLY);
         final RecordingGPXParseHooks hooks = parse("/xml/gc3t1xg_gsak_110.gpx", parser);
 
         // requirement: COORDINATES_ONLY means it is never reported as a Geocache, only as a (named) coordinate
@@ -243,10 +243,10 @@ public class GPXParserTest {
 
     @Test
     public void testWaypointSkipAndCoordinatesOnlyModes() throws Exception {
-        final RecordingGPXParseHooks skipHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setParseMode(GPXParser.ParseMode.SKIP));
+        final RecordingGPXParseHooks skipHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setParseMode(ParseMode.SKIP));
         assertThat(skipHooks.getGlobalItems()).isEmpty();
 
-        final RecordingGPXParseHooks coordHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY));
+        final RecordingGPXParseHooks coordHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setParseMode(ParseMode.COORDINATES_ONLY));
         assertThat(coordHooks.getWaypoints()).isEmpty();
         assertThat(coordHooks.getGlobalItems()).hasSize(2);
         assertThat(coordHooks.getGlobalItems()).allMatch(item -> item.kind == RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXParserTest.java
@@ -59,11 +59,18 @@ public class GPXParserTest {
     }
 
     private static RecordingGPXParseHooks parse(final String resourceName) throws IOException, XmlPullParserException {
-        return parse(resourceName, new GPXParser());
+        return parse(resourceName, new RecordingGPXParseHooks());
+    }
+
+    private static RecordingGPXParseHooks parse(final String resourceName, final RecordingGPXParseHooks hooks) throws IOException, XmlPullParserException {
+        return parse(resourceName, new GPXParser(), hooks);
     }
 
     private static RecordingGPXParseHooks parse(final String resourceName, final GPXParser parser) throws IOException, XmlPullParserException {
-        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        return parse(resourceName, parser, new RecordingGPXParseHooks());
+    }
+
+        private static RecordingGPXParseHooks parse(final String resourceName, final GPXParser parser, final RecordingGPXParseHooks hooks) throws IOException, XmlPullParserException {
         try (InputStream is = openResource(resourceName)) {
             parser.parse(is, hooks);
         }
@@ -93,7 +100,7 @@ public class GPXParserTest {
         assertThat(cache.isOnWatchlist()).isFalse();
         assertThat(cache.getAttributes()).isNotEmpty();
 
-        final List<LogEntry> logs = hooks.getItems().get(0).getLogs();
+        final List<LogEntry> logs = hooks.getGlobalItems().get(0).logs;
         assertThat(logs).hasSize(5);
         assertThat(logs.get(0).author).isEqualTo("pheenyx");
         assertThat(logs.get(0).logType).isEqualTo(LogType.FOUND_IT);
@@ -116,7 +123,7 @@ public class GPXParserTest {
         assertThat(cache.getOwnerDisplayName()).isEqualTo("vptsz");
         assertThat(cache.getLocation()).isEqualTo("Baden-Württemberg, Germany");
 
-        final List<LogEntry> logs = hooks.getItems().get(0).getLogs();
+        final List<LogEntry> logs = hooks.getGlobalItems().get(0).logs;
         assertThat(logs).hasSize(6);
         assertThat(logs.get(0).author).isEqualTo("hanslinde");
         assertThat(logs).allMatch(log -> log.logType == LogType.FOUND_IT);
@@ -130,16 +137,19 @@ public class GPXParserTest {
         assertThat(hooks.getGeocaches()).isEmpty();
 
         final Waypoint parking = hooks.getWaypoints().get(0);
-        assertThat(parking.getName()).isEqualTo("0031J2H");
+        assertThat(parking.getName()).isEqualTo("Parkplatz");
+        assertThat(parking.getPrefix()).isEqualTo("00");
+        assertThat(parking.getLookup()).isEqualTo("---");
         assertThat(parking.getCoords()).isEqualTo(new Geopoint(49.317517, 8.545083));
         assertThat(parking.getGeocode()).isEqualTo("GC31J2H");
 
         final Waypoint stage = hooks.getWaypoints().get(1);
-        assertThat(stage.getName()).isEqualTo("S131J2H");
+        assertThat(stage.getName()).isEqualTo("Station 1");
+        assertThat(stage.getPrefix()).isEqualTo("S1");
         assertThat(stage.getGeocode()).isEqualTo("GC31J2H");
 
         // order preserved (document order)
-        assertThat(hooks.getItems()).extracting(RecordingGPXParseHooks.RecordedItem::getKind)
+        assertThat(hooks.getGlobalItems()).extracting(i -> i.kind)
             .containsExactly(RecordingGPXParseHooks.ItemKind.WAYPOINT, RecordingGPXParseHooks.ItemKind.WAYPOINT);
     }
 
@@ -149,13 +159,13 @@ public class GPXParserTest {
 
         // the file name ("train in two parts") reflects that it contains two separate <trk> elements
         assertThat(hooks.getTracks()).hasSize(2);
-        final int totalPointCount = hooks.getTracks().stream().mapToInt(RecordingGPXParseHooks.RecordedTrack::getTotalPointCount).sum();
+        final int totalPointCount = hooks.getTracks().stream().mapToInt(i -> i.totalPointCount).sum();
         assertThat(totalPointCount).isEqualTo(648);
 
-        final RecordingGPXParseHooks.RecordedTrack firstTrack = hooks.getTracks().get(0);
-        final List<ICoordinate> firstSegmentPoints = firstTrack.getSegments().get(0).getPoints();
+        final RecordingGPXParseHooks.Track firstTrack = hooks.getTracks().get(0);
+        final List<ICoordinate> firstSegmentPoints = firstTrack.segments.get(0).points;
         assertThat(firstSegmentPoints).isNotEmpty();
-        assertThat(firstTrack.getSegments().get(0).getPointCount()).isEqualTo(firstSegmentPoints.size());
+        assertThat(firstTrack.segments.get(0).pointCount).isEqualTo(firstSegmentPoints.size());
         final ICoordinate first = firstSegmentPoints.get(0);
         assertThat(first).isInstanceOf(NamedGeoCoordinate.class);
         assertThat(first.getCoords()).isEqualTo(new Geopoint(47.464799880981445, 11.045894622802734));
@@ -163,21 +173,22 @@ public class GPXParserTest {
 
         // every track point is also visible via the global, chronological items list (no classification
         // applies to plain track points without sym/type, so they all end up as (named) coordinates)
-        assertThat(hooks.getItems()).hasSize(648);
+        assertThat(hooks.getGlobalItems()).hasSize(648);
     }
 
     @Test
     public void testParseTrackFileCoordinatesOnly() throws Exception {
-        final GPXParser parser = new GPXParser().setDefaultTrackParseMode(GPXParser.WptParseMode.COORDINATES_ONLY);
-        final RecordingGPXParseHooks hooks = parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser);
+        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY);
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser, hooks);
 
         assertThat(hooks.getTracks()).hasSize(2);
-        final int totalPointCount = hooks.getTracks().stream().mapToInt(RecordingGPXParseHooks.RecordedTrack::getTotalPointCount).sum();
+        final int totalPointCount = hooks.getTracks().stream().mapToInt(i -> i.totalPointCount).sum();
         assertThat(totalPointCount).isEqualTo(648);
         // COORDINATES_ONLY still reports each point via onCoordinate/onNamedCoordinate (just without ever
         // attempting geocache/waypoint classification) - callers can build their own point list from this
-        assertThat(hooks.getItems()).hasSize(648);
-        final ICoordinate first = hooks.getTracks().get(0).getSegments().get(0).getPoints().get(0);
+        assertThat(hooks.getGlobalItems()).hasSize(648);
+        final ICoordinate first = hooks.getTracks().get(0).segments.get(0).points.get(0);
         assertThat(first.getCoords()).isEqualTo(new Geopoint(47.464799880981445, 11.045894622802734));
         // no geocache/waypoint classification whatsoever happens in COORDINATES_ONLY mode
         assertThat(hooks.getGeocaches()).isEmpty();
@@ -186,67 +197,71 @@ public class GPXParserTest {
 
     @Test
     public void testTrackWithSkipModeStillReportsAccurateCounts() throws Exception {
-        final GPXParser parser = new GPXParser().setDefaultTrackParseMode(GPXParser.WptParseMode.SKIP);
-        final RecordingGPXParseHooks hooks = parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser);
+        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.SKIP);
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        hooks.setModes(GPXParser.ParseMode.FULL, GPXParser.ParseMode.SKIP, GPXParser.ParseMode.SKIP);
+        parse("/xml/ZUG.IN.ZWEI.TEILEN.gpx", parser, hooks);
 
         assertThat(hooks.getTracks()).hasSize(2);
-        final int totalPointCount = hooks.getTracks().stream().mapToInt(RecordingGPXParseHooks.RecordedTrack::getTotalPointCount).sum();
+        final int totalPointCount = hooks.getTracks().stream().mapToInt(i -> i.totalPointCount).sum();
         assertThat(totalPointCount).isEqualTo(648);
         // SKIP never fires any per-point hook at all, so nothing is recorded beyond the counts themselves
-        assertThat(hooks.getItems()).isEmpty();
-        for (final RecordingGPXParseHooks.RecordedTrack track : hooks.getTracks()) {
-            for (final RecordingGPXParseHooks.RecordedTrackSegment segment : track.getSegments()) {
-                assertThat(segment.getPoints()).isEmpty();
-                assertThat(segment.getPointCount()).isGreaterThan(0);
+        assertThat(hooks.getGlobalItems()).isEmpty();
+        for (final RecordingGPXParseHooks.Track track : hooks.getTracks()) {
+            for (final RecordingGPXParseHooks.NamedCoordinateList segment : track.segments) {
+                assertThat(segment.points).isEmpty();
+                assertThat(segment.pointCount).isGreaterThan(0);
             }
         }
     }
 
     @Test
     public void testGeocacheSkipModeNeverFiresHook() throws Exception {
-        final GPXParser parser = new GPXParser().setGeocacheParseMode(GPXParser.WptParseMode.SKIP);
+        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.SKIP);
         final RecordingGPXParseHooks hooks = parse("/xml/gc3t1xg_gsak_110.gpx", parser);
 
         // requirement: SKIP means the hook is never called at all - not even with a placeholder
-        assertThat(hooks.getItems()).isEmpty();
+        assertThat(hooks.getGlobalItems()).isEmpty();
         assertThat(hooks.getGeocaches()).isEmpty();
     }
 
     @Test
     public void testGeocacheCoordinatesOnlyModeReportedAsNamedCoordinate() throws Exception {
-        final GPXParser parser = new GPXParser().setGeocacheParseMode(GPXParser.WptParseMode.COORDINATES_ONLY);
+        final GPXParser parser = new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY);
         final RecordingGPXParseHooks hooks = parse("/xml/gc3t1xg_gsak_110.gpx", parser);
 
         // requirement: COORDINATES_ONLY means it is never reported as a Geocache, only as a (named) coordinate
         assertThat(hooks.getGeocaches()).isEmpty();
-        assertThat(hooks.getItems()).hasSize(1);
-        final RecordingGPXParseHooks.RecordedItem item = hooks.getItems().get(0);
-        assertThat(item.getKind()).isEqualTo(RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
-        assertThat(item.getCoordinate().getCoords()).isEqualTo(new Geopoint(50.10745, 8.6587));
+        assertThat(hooks.getGlobalItems()).hasSize(1);
+        final RecordingGPXParseHooks.Item item = hooks.getGlobalItems().get(0);
+        assertThat(item.kind).isEqualTo(RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
+        assertThat(item.coordinate.getCoords()).isEqualTo(new Geopoint(50.10745, 8.6587));
         // COORDINATES_ONLY never reads extensions, so the name is the wpt's own <name> ("GC3T1XG"), not the
         // groundspeak:name ("Abus") which lives inside <extensions>
-        assertThat(((NamedGeoCoordinate) item.getCoordinate()).getName()).isEqualTo("GC3T1XG");
+        assertThat(((NamedGeoCoordinate) item.coordinate).getName()).isEqualTo("GC3T1XG");
     }
 
     @Test
     public void testWaypointSkipAndCoordinatesOnlyModes() throws Exception {
-        final RecordingGPXParseHooks skipHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setWaypointParseMode(GPXParser.WptParseMode.SKIP));
-        assertThat(skipHooks.getItems()).isEmpty();
+        final RecordingGPXParseHooks skipHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setParseMode(GPXParser.ParseMode.SKIP));
+        assertThat(skipHooks.getGlobalItems()).isEmpty();
 
-        final RecordingGPXParseHooks coordHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setWaypointParseMode(GPXParser.WptParseMode.COORDINATES_ONLY));
+        final RecordingGPXParseHooks coordHooks = parse("/gc31j2h_wpts.gpx", new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY));
         assertThat(coordHooks.getWaypoints()).isEmpty();
-        assertThat(coordHooks.getItems()).hasSize(2);
-        assertThat(coordHooks.getItems()).allMatch(item -> item.getKind() == RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
+        assertThat(coordHooks.getGlobalItems()).hasSize(2);
+        assertThat(coordHooks.getGlobalItems()).allMatch(item -> item.kind == RecordingGPXParseHooks.ItemKind.NAMED_COORDINATE);
     }
 
     @Test
-    public void testInvalidLatLonIsSkippedSilently() throws Exception {
+    public void testWaypointWithoutCoordinatesIsRetained() throws Exception {
         final RecordingGPXParseHooks hooks = parse("/gc31j2h_wpts_empty_coord.gpx");
 
-        // one valid wpt (0031J2H) and one with lat="0" lon="0" (invalid, treated as if it didn't exist)
-        assertThat(hooks.getItems()).hasSize(1);
-        assertThat(hooks.getWaypoints()).hasSize(1);
-        assertThat(hooks.getWaypoints().get(0).getName()).isEqualTo("0031J2H");
+        assertThat(hooks.getWaypoints()).hasSize(2);
+        final Waypoint stage = hooks.getWaypoints().get(1);
+        assertThat(stage.getName()).isEqualTo("Station 1");
+        assertThat(stage.getCoords()).isNull();
+        assertThat(stage.isUserDefined()).isFalse();
+        assertThat(stage.isOriginalCoordsEmpty()).isTrue();
     }
 
     @Test
@@ -287,10 +302,11 @@ public class GPXParserTest {
         for (final Waypoint waypoint : hooks.getWaypoints()) {
             assertThat(waypoint.getGeocode()).isEqualTo("TC99UN");
         }
-        assertThat(hooks.getWaypoints().get(0).getName()).isEqualTo("TC99UN1");
+        assertThat(hooks.getWaypoints().get(0).getName()).isEqualTo("Stage Two");
+        assertThat(hooks.getWaypoints().get(0).getPrefix()).isEqualTo("TC99UN1");
 
         // order preserved: geocache first, then its 4 child waypoints
-        assertThat(hooks.getItems()).extracting(RecordingGPXParseHooks.RecordedItem::getKind)
+        assertThat(hooks.getGlobalItems()).extracting(item -> item.kind)
             .containsExactly(
                 RecordingGPXParseHooks.ItemKind.GEOCACHE,
                 RecordingGPXParseHooks.ItemKind.WAYPOINT,
@@ -339,15 +355,15 @@ public class GPXParserTest {
 
     private static void assertParsesWithContent(final String resourceName) throws Exception {
         final RecordingGPXParseHooks hooks = parse(resourceName);
-        final int totalItems = hooks.getItems().size()
+        final int totalItems = hooks.getGlobalItems().size()
             + hooks.getRoutes().size()
             + hooks.getTracks().size();
         assertThat(totalItems)
             .withFailMessage("Expected at least one geocache/waypoint/coordinate/route/track in %s", resourceName)
             .isGreaterThan(0);
 
-        for (final RecordingGPXParseHooks.RecordedItem item : hooks.getItems()) {
-            assertThat(item.getCoordinate()).withFailMessage("null coordinate in %s", resourceName).isNotNull();
+        for (final RecordingGPXParseHooks.Item item : hooks.getGlobalItems()) {
+            assertThat(item.coordinate).withFailMessage("null coordinate in %s", resourceName).isNotNull();
         }
     }
 }

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXUtilsTest.java
@@ -3,8 +3,6 @@ package cgeo.geocaching.utils.gpx;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 
-import java.io.InputStream;
-
 import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,9 +12,7 @@ public class GPXUtilsTest {
     public void testParseZipWithSeparateCacheAndWaypointFiles() throws Exception {
         final GPXParser parser = new GPXParser();
         final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
-        try (InputStream is = GPXParserTest.openResource("/pq7545915.zip")) {
-            assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(2);
-        }
+        assertThat(GPXUtils.parseZip(() -> GPXParserTest.openResource("/pq7545915.zip"), parser, hooks, null)).isEqualTo(2);
 
         // "7545915-wpts.gpx" sorts alphabetically BEFORE "7545915.gpx" - proves the two-pass ordering works
         assertThat(hooks.getGeocaches()).hasSize(1);
@@ -35,9 +31,7 @@ public class GPXUtilsTest {
     public void testParseZipWithNoGpxEntriesReturnsZeroWithoutThrowing() throws Exception {
         final GPXParser parser = new GPXParser();
         final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
-        try (InputStream is = GPXParserTest.openResource("/pq_error.zip")) {
-            assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(0);
-        }
+        assertThat(GPXUtils.parseZip(() -> GPXParserTest.openResource("/pq_error.zip"), parser, hooks, null)).isEqualTo(0);
         assertThat(hooks.getGlobalItems()).isEmpty();
     }
 
@@ -45,9 +39,7 @@ public class GPXUtilsTest {
     public void testParseZipWithEntityEncodedFilename() throws Exception {
         final GPXParser parser = new GPXParser();
         final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
-        try (InputStream is = GPXParserTest.openResource("/pq_entities.zip")) {
-            assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(1);
-        }
+        assertThat(GPXUtils.parseZip(() -> GPXParserTest.openResource("/pq_entities.zip"), parser, hooks, null)).isEqualTo(1);
         assertThat(hooks.getGlobalItems()).isNotEmpty();
     }
 
@@ -55,9 +47,7 @@ public class GPXUtilsTest {
     public void testParseZipWithCp437EncodedFilename() throws Exception {
         final GPXParser parser = new GPXParser();
         final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
-        try (InputStream is = GPXParserTest.openResource("/pq_cp437.zip")) {
-            assertThat(GPXUtils.parseZip(is, parser, hooks, "cp437")).isEqualTo(1);
-        }
+        assertThat(GPXUtils.parseZip(() -> GPXParserTest.openResource("/pq_cp437.zip"), parser, hooks, "cp437")).isEqualTo(1);
         assertThat(hooks.getGlobalItems()).isNotEmpty();
     }
 
@@ -65,15 +55,11 @@ public class GPXUtilsTest {
     public void testResetAllowsReuseOfParserAcrossUnrelatedZips() throws Exception {
         final GPXParser parser = new GPXParser();
         final RecordingGPXParseHooks firstHooks = new RecordingGPXParseHooks();
-        try (InputStream is = GPXParserTest.openResource("/pq7545915.zip")) {
-            GPXUtils.parseZip(is, parser, firstHooks);
-        }
+        assertThat(GPXUtils.parseZip(() -> GPXParserTest.openResource("/pq7545915.zip"), parser, firstHooks, null)).isEqualTo(2);
         parser.reset();
 
         final RecordingGPXParseHooks secondHooks = new RecordingGPXParseHooks();
-        try (InputStream is = GPXParserTest.openResource("/pq_entities.zip")) {
-            assertThat(GPXUtils.parseZip(is, parser, secondHooks)).isEqualTo(1);
-        }
+        assertThat(GPXUtils.parseZip(() -> GPXParserTest.openResource("/pq_entities.zip"), parser, secondHooks, null)).isEqualTo(1);
         assertThat(secondHooks.getGlobalItems()).isNotEmpty();
     }
 }

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXUtilsTest.java
@@ -1,0 +1,79 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GPXUtilsTest {
+
+    @Test
+    public void testParseZipWithSeparateCacheAndWaypointFiles() throws Exception {
+        final GPXParser parser = new GPXParser();
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream is = GPXParserTest.openResource("/pq7545915.zip")) {
+            assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(2);
+        }
+
+        // "7545915-wpts.gpx" sorts alphabetically BEFORE "7545915.gpx" - proves the two-pass ordering works
+        assertThat(hooks.getGeocaches()).hasSize(1);
+        final Geocache cache = hooks.getGeocaches().get(0);
+        assertThat(cache.getGeocode()).isEqualTo("GC31J2H");
+        assertThat(cache.getName()).isEqualTo("Hockenheimer City-Brunnen");
+
+        assertThat(hooks.getWaypoints()).hasSize(1);
+        final Waypoint waypoint = hooks.getWaypoints().get(0);
+        assertThat(waypoint.getName()).isEqualTo("0031J2H");
+        assertThat(waypoint.getGeocode()).isEqualTo("GC31J2H");
+    }
+
+    @Test
+    public void testParseZipWithNoGpxEntriesReturnsZeroWithoutThrowing() throws Exception {
+        final GPXParser parser = new GPXParser();
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream is = GPXParserTest.openResource("/pq_error.zip")) {
+            assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(0);
+        }
+        assertThat(hooks.getItems()).isEmpty();
+    }
+
+    @Test
+    public void testParseZipWithEntityEncodedFilename() throws Exception {
+        final GPXParser parser = new GPXParser();
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream is = GPXParserTest.openResource("/pq_entities.zip")) {
+            assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(1);
+        }
+        assertThat(hooks.getItems()).isNotEmpty();
+    }
+
+    @Test
+    public void testParseZipWithCp437EncodedFilename() throws Exception {
+        final GPXParser parser = new GPXParser();
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream is = GPXParserTest.openResource("/pq_cp437.zip")) {
+            assertThat(GPXUtils.parseZip(is, parser, hooks, "cp437")).isEqualTo(1);
+        }
+        assertThat(hooks.getItems()).isNotEmpty();
+    }
+
+    @Test
+    public void testResetAllowsReuseOfParserAcrossUnrelatedZips() throws Exception {
+        final GPXParser parser = new GPXParser();
+        final RecordingGPXParseHooks firstHooks = new RecordingGPXParseHooks();
+        try (InputStream is = GPXParserTest.openResource("/pq7545915.zip")) {
+            GPXUtils.parseZip(is, parser, firstHooks);
+        }
+        parser.reset();
+
+        final RecordingGPXParseHooks secondHooks = new RecordingGPXParseHooks();
+        try (InputStream is = GPXParserTest.openResource("/pq_entities.zip")) {
+            assertThat(GPXUtils.parseZip(is, parser, secondHooks)).isEqualTo(1);
+        }
+        assertThat(secondHooks.getItems()).isNotEmpty();
+    }
+}
+

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXUtilsTest.java
@@ -26,7 +26,8 @@ public class GPXUtilsTest {
 
         assertThat(hooks.getWaypoints()).hasSize(1);
         final Waypoint waypoint = hooks.getWaypoints().get(0);
-        assertThat(waypoint.getName()).isEqualTo("0031J2H");
+        assertThat(waypoint.getName()).isEqualTo("Parkplatz");
+        assertThat(waypoint.getPrefix()).isEqualTo("00");
         assertThat(waypoint.getGeocode()).isEqualTo("GC31J2H");
     }
 
@@ -37,7 +38,7 @@ public class GPXUtilsTest {
         try (InputStream is = GPXParserTest.openResource("/pq_error.zip")) {
             assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(0);
         }
-        assertThat(hooks.getItems()).isEmpty();
+        assertThat(hooks.getGlobalItems()).isEmpty();
     }
 
     @Test
@@ -47,7 +48,7 @@ public class GPXUtilsTest {
         try (InputStream is = GPXParserTest.openResource("/pq_entities.zip")) {
             assertThat(GPXUtils.parseZip(is, parser, hooks)).isEqualTo(1);
         }
-        assertThat(hooks.getItems()).isNotEmpty();
+        assertThat(hooks.getGlobalItems()).isNotEmpty();
     }
 
     @Test
@@ -57,7 +58,7 @@ public class GPXUtilsTest {
         try (InputStream is = GPXParserTest.openResource("/pq_cp437.zip")) {
             assertThat(GPXUtils.parseZip(is, parser, hooks, "cp437")).isEqualTo(1);
         }
-        assertThat(hooks.getItems()).isNotEmpty();
+        assertThat(hooks.getGlobalItems()).isNotEmpty();
     }
 
     @Test
@@ -73,7 +74,7 @@ public class GPXUtilsTest {
         try (InputStream is = GPXParserTest.openResource("/pq_entities.zip")) {
             assertThat(GPXUtils.parseZip(is, parser, secondHooks)).isEqualTo(1);
         }
-        assertThat(secondHooks.getItems()).isNotEmpty();
+        assertThat(secondHooks.getGlobalItems()).isNotEmpty();
     }
 }
 

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXWaypointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXWaypointParserTest.java
@@ -1,0 +1,204 @@
+package cgeo.geocaching.utils.gpx;
+
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.models.WaypointUserNoteCombiner;
+import cgeo.geocaching.utils.xml.XmlUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GPXWaypointParserTest {
+
+    private static String document(final boolean gpx11, final String body) {
+        return "<gpx version=\"" + (gpx11 ? "1.1" : "1.0") + "\" xmlns=\"http://www.topografix.com/GPX/1/" + (gpx11 ? "1" : "0")
+                + "\" xmlns:cgeo=\"http://www.cgeo.org/wptext/1/0\" xmlns:gsak=\"http://www.gsak.net/xmlv1/6\">" + body + "</gpx>";
+    }
+
+    private static String waypoint(final boolean gpx11, final String attributes, final String name, final String note, final String extensions) {
+        return "<wpt " + attributes + "><name>" + name + "</name><desc>My stage</desc><cmt>" + note
+                + "</cmt><sym>Reference Point</sym><type>Waypoint|Reference Point</type>"
+                + (gpx11 ? "<extensions>" + extensions + "</extensions>" : extensions) + "</wpt>";
+    }
+
+    private static RecordingGPXParseHooks parse(final String xml, final GPXParser parser, final boolean namespaceAware) throws Exception {
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            parser.parse(XmlUtils.createParser(stream, namespaceAware), hooks);
+        }
+        return hooks;
+    }
+
+    @Test
+    public void testCgeoWaypointExtensionsInBothGpxVersionsAndNamespaceModes() throws Exception {
+        for (final boolean gpx11 : new boolean[] {false, true}) {
+            for (final boolean namespaceAware : new boolean[] {false, true}) {
+                final String extensions = "<gsak:wptExtension><gsak:Parent>GC12345</gsak:Parent></gsak:wptExtension>"
+                        + "<cgeo:visited> true </cgeo:visited><cgeo:userdefined> true </cgeo:userdefined>"
+                        + "<cgeo:originalCoordsEmpty> true </cgeo:originalCoordsEmpty>";
+                final String xml = document(gpx11, waypoint(gpx11, "lat=\"48\" lon=\"9\"", "OWN-AA12345", "My personal note", extensions)
+                        + waypoint(gpx11, "lat=\"48\" lon=\"9\"", "BB12345", "Listing note", ""));
+                final RecordingGPXParseHooks hooks = parse(xml, new GPXParser(), namespaceAware);
+                assertThat(hooks.getWaypoints()).hasSize(2);
+                final Waypoint own = hooks.getWaypoints().get(0);
+                assertThat(own.getName()).isEqualTo("My stage");
+                assertThat(own.getPrefix()).isEqualTo("AA");
+                assertThat(own.getGeocode()).isEqualTo("GC12345");
+                assertThat(own.getLookup()).isEqualTo("---");
+                assertThat(own.getWaypointType()).isEqualTo(WaypointType.WAYPOINT);
+                assertThat(own.isUserDefined()).isTrue();
+                assertThat(own.isVisited()).isTrue();
+                assertThat(own.isOriginalCoordsEmpty()).isTrue();
+                assertThat(own.getCoords()).isNotNull();
+                assertThat(own.getUserNote()).isEqualTo("My personal note");
+                assertThat(own.getNote()).isEmpty();
+                final Waypoint listing = hooks.getWaypoints().get(1);
+                assertThat(listing.isUserDefined()).isFalse();
+                assertThat(listing.isVisited()).isFalse();
+                assertThat(listing.isOriginalCoordsEmpty()).isFalse();
+                assertThat(listing.getPrefix()).isEqualTo("BB");
+                assertThat(listing.getNote()).isEqualTo("Listing note");
+                assertThat(listing.getUserNote()).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    public void testGsakUserDefinedWaypoints() throws Exception {
+        for (final boolean gpx11 : new boolean[] {false, true}) {
+            final String extensions = "<gsak:wptExtension><gsak:Parent>OCDDD2</gsak:Parent>"
+                    + "<gsak:Child_ByGSAK> true </gsak:Child_ByGSAK></gsak:wptExtension>";
+            final String xml = document(gpx11, waypoint(gpx11, "lat=\"48\" lon=\"9\"", "OWN-021", "A user note", extensions));
+            final Waypoint wp = parse(xml, new GPXParser(), false).getWaypoints().get(0);
+            assertThat(wp.isUserDefined()).isTrue();
+            assertThat(wp.getGeocode()).isEqualTo("OCDDD2");
+            assertThat(wp.getPrefix()).isEqualTo("021");
+            assertThat(wp.getUserNote()).isEqualTo("A user note");
+            assertThat(wp.getNote()).isEmpty();
+        }
+    }
+
+    @Test
+    public void testFalseExtensionFlags() throws Exception {
+        final String extensions = "<gsak:wptExtension><gsak:Child_ByGSAK>false</gsak:Child_ByGSAK></gsak:wptExtension>"
+                + "<cgeo:visited>false</cgeo:visited><cgeo:userdefined>false</cgeo:userdefined>"
+                + "<cgeo:originalCoordsEmpty>false</cgeo:originalCoordsEmpty>";
+        final String xml = document(true, waypoint(true, "lat=\"48\" lon=\"9\"", "AA12345", "", extensions));
+        final Waypoint wp = parse(xml, new GPXParser(), false).getWaypoints().get(0);
+        assertThat(wp.isUserDefined()).isFalse();
+        assertThat(wp.isVisited()).isFalse();
+        assertThat(wp.isOriginalCoordsEmpty()).isFalse();
+    }
+
+    @Test
+    public void testCombinedNotesRoundTrip() throws Exception {
+        for (final boolean own : new boolean[] {false, true}) {
+            for (final String listingNote : new String[] {"", "Listing note"}) {
+                final Waypoint source = new Waypoint("My stage", WaypointType.WAYPOINT, own);
+                source.setNote(listingNote);
+                source.setUserNote("My personal note\n--\nwith another separator");
+                final String note = new WaypointUserNoteCombiner(source).getCombinedNoteAndUserNote();
+                final String xml = document(true, waypoint(true, "lat=\"48\" lon=\"9\"", "AA12345", note,
+                        "<cgeo:userdefined>" + own + "</cgeo:userdefined>"));
+                final Waypoint parsed = parse(xml, new GPXParser(), false).getWaypoints().get(0);
+                assertThat(parsed.getNote()).isEqualTo(own ? "" : listingNote);
+                assertThat(parsed.getUserNote()).isEqualTo(source.getUserNote());
+            }
+        }
+    }
+
+    @Test
+    public void testEmptyCoordinatesForListingAndUserDefinedWaypoints() throws Exception {
+        for (final String attributes : new String[] {"lat=\"0\" lon=\"0\"", "lat=\"\" lon=\"\"", "", "lat=\"invalid\" lon=\"9\""}) {
+            for (final boolean own : new boolean[] {false, true}) {
+                final String xml = document(true, waypoint(true, attributes, "AA12345", "",
+                        "<cgeo:userdefined>" + own + "</cgeo:userdefined>"));
+                final RecordingGPXParseHooks hooks = parse(xml, new GPXParser(), false);
+                assertThat(hooks.getWaypoints()).hasSize(1);
+                final Waypoint wp = hooks.getWaypoints().get(0);
+                assertThat(wp.getCoords()).isNull();
+                assertThat(wp.isUserDefined()).isEqualTo(own);
+                assertThat(wp.isOriginalCoordsEmpty()).isEqualTo(!own);
+                assertThat(wp.getName()).isEqualTo("My stage");
+            }
+        }
+    }
+
+    @Test
+    public void testWaypointsWithoutCoordinatesRespectParseModes() throws Exception {
+        final String xml = document(true, waypoint(true, "lat=\"0\" lon=\"0\"", "AA12345", "", "")
+                + waypoint(true, "lat=\"48\" lon=\"9\"", "BB12345", "", ""));
+        final RecordingGPXParseHooks skipped = parse(xml, new GPXParser().setParseMode(GPXParser.ParseMode.SKIP), false);
+        assertThat(skipped.getGlobalItems()).isEmpty();
+        final RecordingGPXParseHooks coordinates = parse(xml, new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY), false);
+        assertThat(coordinates.getWaypoints()).isEmpty();
+        assertThat(coordinates.getGlobalItems()).hasSize(2);
+        assertThat(coordinates.getGlobalItems().get(0).coordinate.getCoords()).isNotNull();
+    }
+
+    @Test
+    public void testTrackAndRouteCountsIncludeWaypointsWithoutCoordinates() throws Exception {
+        final String points = waypoint(true, "lat=\"0\" lon=\"0\"", "AA12345", "", "")
+                + waypoint(true, "lat=\"48\" lon=\"9\"", "BB12345", "", "");
+        final String xml = document(true, "<rte>" + points.replace("wpt", "rtept") + "</rte><trk><trkseg>"
+                + points.replace("wpt", "trkpt") + "</trkseg></trk>");
+        final RecordingGPXParseHooks hooks = parse(xml, new GPXParser(), false);
+        assertThat(hooks.getWaypoints()).hasSize(4);
+        assertThat(hooks.getRoutes().get(0).pointCount).isEqualTo(2);
+        assertThat(hooks.getTracks().get(0).totalPointCount).isEqualTo(2);
+        assertThat(hooks.getTracks().get(0).segments.get(0).pointCount).isEqualTo(2);
+    }
+
+    @Test
+    public void testWaypointWithoutNameOrParent() throws Exception {
+        final String xml = document(true, "<wpt lat=\"48\" lon=\"9\"><type>Waypoint|Reference Point</type>"
+                + "<extensions><cgeo:visited>true</cgeo:visited></extensions></wpt>");
+        final RecordingGPXParseHooks hooks = parse(xml, new GPXParser(), false);
+        assertThat(hooks.getWaypoints()).hasSize(1);
+        final Waypoint wp = hooks.getWaypoints().get(0);
+        assertThat(wp.getName()).isEmpty();
+        assertThat(wp.getPrefix()).isEmpty();
+        assertThat(wp.isVisited()).isTrue();
+        assertThat(hooks.getGlobalItems().get(0).parentGeocode).isNull();
+    }
+
+    @Test
+    public void testExportedOpencachingWaypointsWithEmptyCoordinates() throws Exception {
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream stream = GPXParserTest.openResource("/ocddd2_empty_coord.gpx")) {
+            new GPXParser().parse(stream, hooks);
+        }
+        assertThat(hooks.getWaypoints()).hasSize(8);
+        final Waypoint emptyOwn = hooks.getWaypoints().get(4);
+        assertThat(emptyOwn.getName()).isEqualTo("Original Empty User");
+        assertThat(emptyOwn.getCoords()).isNull();
+        assertThat(emptyOwn.isUserDefined()).isTrue();
+        assertThat(emptyOwn.isOriginalCoordsEmpty()).isFalse();
+        final Waypoint modified = hooks.getWaypoints().get(6);
+        assertThat(modified.getName()).isEqualTo("Original Empty Modified");
+        assertThat(modified.getCoords()).isNotNull();
+        assertThat(modified.isUserDefined()).isFalse();
+        assertThat(modified.isOriginalCoordsEmpty()).isTrue();
+        final Waypoint blank = hooks.getWaypoints().get(7);
+        assertThat(blank.getName()).isEqualTo("Original Blank");
+        assertThat(blank.getCoords()).isNull();
+        assertThat(blank.isOriginalCoordsEmpty()).isTrue();
+    }
+
+    @Test
+    public void testOriginalCoordinatesWaypoint() throws Exception {
+        final RecordingGPXParseHooks hooks = new RecordingGPXParseHooks();
+        try (InputStream stream = GPXParserTest.openResource("/gc31j2h_wpts_original.gpx")) {
+            new GPXParser().parse(stream, hooks);
+        }
+        final Waypoint original = hooks.getWaypoints().get(0);
+        assertThat(original.getWaypointType()).isEqualTo(WaypointType.ORIGINAL);
+        assertThat(original.getName()).isEqualTo("Original Coordinates");
+        assertThat(original.getPrefix()).isEqualTo("00");
+        assertThat(original.getGeocode()).isEqualTo("GC31J2H");
+    }
+}

--- a/main/src/test/java/cgeo/geocaching/utils/gpx/GPXWaypointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/gpx/GPXWaypointParserTest.java
@@ -132,9 +132,9 @@ public class GPXWaypointParserTest {
     public void testWaypointsWithoutCoordinatesRespectParseModes() throws Exception {
         final String xml = document(true, waypoint(true, "lat=\"0\" lon=\"0\"", "AA12345", "", "")
                 + waypoint(true, "lat=\"48\" lon=\"9\"", "BB12345", "", ""));
-        final RecordingGPXParseHooks skipped = parse(xml, new GPXParser().setParseMode(GPXParser.ParseMode.SKIP), false);
+        final RecordingGPXParseHooks skipped = parse(xml, new GPXParser().setParseMode(ParseMode.SKIP), false);
         assertThat(skipped.getGlobalItems()).isEmpty();
-        final RecordingGPXParseHooks coordinates = parse(xml, new GPXParser().setParseMode(GPXParser.ParseMode.COORDINATES_ONLY), false);
+        final RecordingGPXParseHooks coordinates = parse(xml, new GPXParser().setParseMode(ParseMode.COORDINATES_ONLY), false);
         assertThat(coordinates.getWaypoints()).isEmpty();
         assertThat(coordinates.getGlobalItems()).hasSize(2);
         assertThat(coordinates.getGlobalItems().get(0).coordinate.getCoords()).isNotNull();

--- a/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
@@ -12,14 +12,15 @@ import org.junit.Test;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 import static org.xmlpull.v1.XmlPullParser.START_TAG;
 
 public class XmlNodeTest {
 
-    private List<XmlNode> parseTestXml(final String resourceName, final boolean namespaceAware, final Predicate<XmlPullParser> nodeMarker) throws XmlPullParserException, IOException {
+    private List<XmlNode> parseTestXml(final String resourceName, final boolean namespaceAware, final boolean relaxed, final Predicate<XmlPullParser> nodeMarker) throws XmlPullParserException, IOException {
         final InputStream is = XmlNodeTest.class.getResourceAsStream(resourceName);
         Objects.requireNonNull(is);
-        final XmlPullParser xpp = XmlUtils.createParser(is, namespaceAware);
+        final XmlPullParser xpp = XmlUtils.createParser(is, namespaceAware, relaxed, "UTF-8");
         final List<XmlNode> nodes = new ArrayList<>();
         while (xpp.next() != XmlPullParser.END_DOCUMENT) {
             if (xpp.getEventType() == START_TAG && nodeMarker.test(xpp)) {
@@ -31,13 +32,13 @@ public class XmlNodeTest {
     }
 
     private List<XmlNode> parseExampleXml(final boolean namespaceAware) throws XmlPullParserException, IOException {
-        final List<XmlNode> nodes = parseTestXml("/xml/example.xml", namespaceAware, xpp -> xpp.getName().equals("website"));
+        final List<XmlNode> nodes = parseTestXml("/xml/example.xml", namespaceAware, false, xpp -> xpp.getName().equals("website"));
         assertThat(nodes).hasSize(3);
         return nodes;
     }
 
     private XmlNode parseGpxXml(final boolean namespaceAware) throws XmlPullParserException, IOException {
-        final List<XmlNode> nodes = parseTestXml("/xml/gc3t1xg_gsak_110.gpx", namespaceAware, xpp -> xpp.getName().equals("wpt"));
+        final List<XmlNode> nodes = parseTestXml("/xml/gc3t1xg_gsak_110.gpx", namespaceAware, false, xpp -> xpp.getName().equals("wpt"));
         assertThat(nodes).hasSize(1);
         return nodes.get(0);
     }
@@ -45,62 +46,89 @@ public class XmlNodeTest {
     @Test
     public void testParseComplexAttribute() throws Exception {
         final XmlNode cgeoNode = parseExampleXml(false).get(0);
-        assertThat(cgeoNode.getName()).isEqualTo("website");
-        assertThat(cgeoNode.get("address").get("street").getValue()).isEqualTo("Somewherestreet 5");
+        assertThat(cgeoNode.getLocalName()).isEqualTo("website");
+        assertThat(cgeoNode.getChild("address").getChild("street").getValue()).isEqualTo("Somewherestreet 5");
     }
 
     @Test
     public void testParseList() throws Exception {
         final XmlNode cgeoNode = parseExampleXml(false).get(0);
-        assertThat(cgeoNode.getAsList("category").stream().map(XmlNode::getValue).collect(Collectors.toList()))
+        assertThat(cgeoNode.getChildrenAsList("category").stream().map(XmlNode::getValue).collect(Collectors.toList()))
                 .containsExactly("Fun", "Geocaching");
     }
 
     @Test
     public void testParseAttributes() throws Exception {
         final XmlNode cgeoNode = parseExampleXml(false).get(0);
-        assertThat(cgeoNode.get("@url").getValue()).isEqualTo("https://cgeo.org");
+        assertThat(cgeoNode.getChild("@url").getValue()).isEqualTo("https://cgeo.org");
     }
 
     @Test
     public void testParseNamespaceAware() throws Exception {
         final XmlNode cgeoNode1 = parseExampleXml(false).get(0);
-        assertThat(cgeoNode1.get("test:status").getNamespace()).isEqualTo("");
-        assertThat(cgeoNode1.get("test:status").getValue()).isEqualTo("green");
+        assertThat(cgeoNode1.getChild("status").getNamespace()).isEqualTo("");
+        assertThat(cgeoNode1.getChild("status").getValue()).isEqualTo("green");
         final XmlNode cgeoNode2 = parseExampleXml(true).get(0);
-        assertThat(cgeoNode2.get("status").getNamespace()).isEqualTo("http://cgeo.org/test");
-        assertThat(cgeoNode2.get("status").getValue()).isEqualTo("green");
+        assertThat(cgeoNode2.getChild("status").getNamespace()).isEqualTo("http://cgeo.org/test");
+        assertThat(cgeoNode2.getChild("status").getValue()).isEqualTo("green");
     }
 
     @Test
     public void testIterate() throws Exception {
         final XmlNode cgeoNode1 = parseExampleXml(true).get(0);
         final List<String> list = new ArrayList<>();
-        cgeoNode1.forEach(child -> list.add(child.getName()));
+        cgeoNode1.forEach(child -> list.add(child.getLocalName()));
         assertThat(list).containsExactlyInAnyOrder("@url", "name", "category", "category", "address", "status");
     }
 
     @Test
     public void testMoveExtensions() throws Exception {
         final XmlNode gpxNode = parseGpxXml(true);
-        assertThat(gpxNode.get("extensions").get("wptExtension").get("SmartName").getValue()).isEqualTo("Abus");
-        gpxNode.get("extensions").forEach(gpxNode::add);
-        gpxNode.remove("extensions");
-        assertThat(gpxNode.get("wptExtension").get("SmartName").getValue()).isEqualTo("Abus");
+        assertThat(gpxNode.getChild("extensions").getChild("wptExtension").getChild("SmartName").getValue()).isEqualTo("Abus");
+        gpxNode.getChild("extensions").forEach(gpxNode::addChild);
+        gpxNode.removeChild("extensions");
+        assertThat(gpxNode.getChild("wptExtension").getChild("SmartName").getValue()).isEqualTo("Abus");
     }
 
     @Test
     public void testReadComplexUTF8BOMGpx() throws Exception {
         //this file is UTF-8-BOM-encoded!
-        final List<XmlNode> nodes = parseTestXml("/xml/ZUG.IN.ZWEI.TEILEN.gpx", true, xpp -> xpp.getName().equals("trkpt"));
+        final List<XmlNode> nodes = parseTestXml("/xml/ZUG.IN.ZWEI.TEILEN.gpx", true, false, xpp -> xpp.getName().equals("trkpt"));
         assertThat(nodes).hasSize(648);
         // first element:
         // <trkpt lat="47.464799880981445" lon="11.045894622802734">
         //        <ele>782.54296875</ele>
         //      </trkpt>
-        assertThat(nodes.get(0).get("@lat").getValue()).isEqualTo("47.464799880981445");
-        assertThat(nodes.get(0).get("@lon").getValue()).isEqualTo("11.045894622802734");
-        assertThat(nodes.get(0).get("ele").getValue()).isEqualTo("782.54296875");
+        assertThat(nodes.get(0).getChild("@lat").getValue()).isEqualTo("47.464799880981445");
+        assertThat(nodes.get(0).getChild("@lon").getValue()).isEqualTo("11.045894622802734");
+        assertThat(nodes.get(0).getChild("ele").getValue()).isEqualTo("782.54296875");
+
+    }
+
+    @Test
+    public void testRelaxationAndNamespaces() throws Exception {
+        try {
+            parseTestXml("/xml/example_invalid.xml", false, false, xpp -> xpp.getName().equals("website"));
+            fail("Expected XmlPullParserException");
+        } catch (final XmlPullParserException e) {
+            // expected because XML is invalid
+        }
+
+        //without namespaces
+        final XmlNode cgeoNode = parseTestXml("/xml/example_invalid.xml", false, true, xpp -> xpp.getName().equals("website")).get(0);
+        assertThat(cgeoNode.getChild("status").getNamespace()).isEqualTo("");
+        assertThat(cgeoNode.getChild("status").getValue()).isEqualTo("green");
+        assertThat(cgeoNode.getChild("status2").getValue()).isEqualTo("red");
+        assertThat(cgeoNode.getChild("test").getValue()).isEqualTo("test");
+        assertThat(cgeoNode.getChild("unclosed").getValue()).startsWith("notclosed");
+        //with namespaces
+        final XmlNode cgeoNode1 = parseTestXml("/xml/example_invalid.xml", true, true, xpp -> xpp.getName().equals("website")).get(0);
+        assertThat(cgeoNode1.getChild("status").getNamespace()).isEqualTo("http://cgeo.org/test");
+        assertThat(cgeoNode1.getChild("status").getValue()).isEqualTo("green");
+        assertThat(cgeoNode1.getChild("status2").getValue()).isEqualTo("red");
+        assertThat(cgeoNode1.getChild("test").getValue()).isEqualTo("test");
+        assertThat(cgeoNode1.getChild("test").getNamespace()).isEqualTo(""); // undeclared namespace is empty
+        assertThat(cgeoNode1.getChild("unclosed").getValue()).startsWith("notclosed");
 
     }
 

--- a/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
@@ -66,7 +66,7 @@ public class XmlNodeTest {
     @Test
     public void testParseNamespaceAware() throws Exception {
         final XmlNode cgeoNode1 = parseExampleXml(false).get(0);
-        assertThat(cgeoNode1.getChild("status").getNamespace()).isEqualTo("");
+        assertThat(cgeoNode1.getChild("status").getNamespace()).isNull();
         assertThat(cgeoNode1.getChild("status").getValue()).isEqualTo("green");
         final XmlNode cgeoNode2 = parseExampleXml(true).get(0);
         assertThat(cgeoNode2.getChild("status").getNamespace()).isEqualTo("http://cgeo.org/test");
@@ -99,7 +99,7 @@ public class XmlNodeTest {
 
         //without namespaces
         final XmlNode cgeoNode = parseTestXml("/xml/example_invalid.xml", false, true, xpp -> xpp.getName().equals("website")).get(0);
-        assertThat(cgeoNode.getChild("status").getNamespace()).isEqualTo("");
+        assertThat(cgeoNode.getChild("status").getNamespace()).isNull();
         assertThat(cgeoNode.getChild("status").getValue()).isEqualTo("green");
         assertThat(cgeoNode.getChild("status2").getValue()).isEqualTo("red");
         assertThat(cgeoNode.getChild("test").getValue()).isEqualTo("test");
@@ -110,7 +110,7 @@ public class XmlNodeTest {
         assertThat(cgeoNode1.getChild("status").getValue()).isEqualTo("green");
         assertThat(cgeoNode1.getChild("status2").getValue()).isEqualTo("red");
         assertThat(cgeoNode1.getChild("test").getValue()).isEqualTo("test");
-        assertThat(cgeoNode1.getChild("test").getNamespace()).isEqualTo(""); // undeclared namespace is empty
+        assertThat(cgeoNode1.getChild("test").getNamespace()).isNull(); // undeclared namespace is empty
         assertThat(cgeoNode1.getChild("unclosed").getValue()).startsWith("notclosed");
 
     }

--- a/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
@@ -44,25 +44,6 @@ public class XmlNodeTest {
     }
 
     @Test
-    public void testOrderedChildrenFollowInsertionAndRemoval() {
-        final XmlNode node = new XmlNode("parent", "");
-        final XmlNode first = new XmlNode("first", "");
-        final XmlNode second = new XmlNode("second", "");
-        final XmlNode repeated = new XmlNode("first", "");
-        assertThat(node.getChildrenInOrder()).isEmpty();
-        node.addChild(first);
-        node.addChild(second);
-        node.addChild(repeated);
-        assertThat(node.getChildrenInOrder()).containsExactly(first, second, repeated);
-        assertThat(node.getChildrenAsList("first")).containsExactly(first, repeated);
-        node.removeChild("first");
-        assertThat(node.getChildrenInOrder()).containsExactly(second);
-        assertThat(node.hasChild("first")).isFalse();
-        node.addChild(first);
-        assertThat(node.getChildrenInOrder()).containsExactly(second, first);
-    }
-
-    @Test
     public void testParseComplexAttribute() throws Exception {
         final XmlNode cgeoNode = parseExampleXml(false).get(0);
         assertThat(cgeoNode.getLocalName()).isEqualTo("website");
@@ -90,23 +71,6 @@ public class XmlNodeTest {
         final XmlNode cgeoNode2 = parseExampleXml(true).get(0);
         assertThat(cgeoNode2.getChild("status").getNamespace()).isEqualTo("http://cgeo.org/test");
         assertThat(cgeoNode2.getChild("status").getValue()).isEqualTo("green");
-    }
-
-    @Test
-    public void testIterate() throws Exception {
-        final XmlNode cgeoNode1 = parseExampleXml(true).get(0);
-        final List<String> list = new ArrayList<>();
-        cgeoNode1.forEach(child -> list.add(child.getLocalName()));
-        assertThat(list).containsExactlyInAnyOrder("@url", "name", "category", "category", "address", "status");
-    }
-
-    @Test
-    public void testMoveExtensions() throws Exception {
-        final XmlNode gpxNode = parseGpxXml(true);
-        assertThat(gpxNode.getChild("extensions").getChild("wptExtension").getChild("SmartName").getValue()).isEqualTo("Abus");
-        gpxNode.getChild("extensions").forEach(gpxNode::addChild);
-        gpxNode.removeChild("extensions");
-        assertThat(gpxNode.getChild("wptExtension").getChild("SmartName").getValue()).isEqualTo("Abus");
     }
 
     @Test

--- a/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/xml/XmlNodeTest.java
@@ -20,7 +20,7 @@ public class XmlNodeTest {
     private List<XmlNode> parseTestXml(final String resourceName, final boolean namespaceAware, final boolean relaxed, final Predicate<XmlPullParser> nodeMarker) throws XmlPullParserException, IOException {
         final InputStream is = XmlNodeTest.class.getResourceAsStream(resourceName);
         Objects.requireNonNull(is);
-        final XmlPullParser xpp = XmlUtils.createParser(is, namespaceAware, relaxed, "UTF-8");
+        final XmlPullParser xpp = XmlUtils.createParser(is, null, namespaceAware, relaxed);
         final List<XmlNode> nodes = new ArrayList<>();
         while (xpp.next() != XmlPullParser.END_DOCUMENT) {
             if (xpp.getEventType() == START_TAG && nodeMarker.test(xpp)) {
@@ -41,6 +41,25 @@ public class XmlNodeTest {
         final List<XmlNode> nodes = parseTestXml("/xml/gc3t1xg_gsak_110.gpx", namespaceAware, false, xpp -> xpp.getName().equals("wpt"));
         assertThat(nodes).hasSize(1);
         return nodes.get(0);
+    }
+
+    @Test
+    public void testOrderedChildrenFollowInsertionAndRemoval() {
+        final XmlNode node = new XmlNode("parent", "");
+        final XmlNode first = new XmlNode("first", "");
+        final XmlNode second = new XmlNode("second", "");
+        final XmlNode repeated = new XmlNode("first", "");
+        assertThat(node.getChildrenInOrder()).isEmpty();
+        node.addChild(first);
+        node.addChild(second);
+        node.addChild(repeated);
+        assertThat(node.getChildrenInOrder()).containsExactly(first, second, repeated);
+        assertThat(node.getChildrenAsList("first")).containsExactly(first, repeated);
+        node.removeChild("first");
+        assertThat(node.getChildrenInOrder()).containsExactly(second);
+        assertThat(node.hasChild("first")).isFalse();
+        node.addChild(first);
+        assertThat(node.getChildrenInOrder()).containsExactly(second, first);
     }
 
     @Test

--- a/main/src/test/java/cgeo/geocaching/utils/xml/XmlUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/xml/XmlUtilsTest.java
@@ -3,11 +3,13 @@ package cgeo.geocaching.utils.xml;
 import cgeo.org.kxml2.io.KXmlSerializer;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlSerializer;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +43,18 @@ public class XmlUtilsTest {
         xml.endDocument();
         xml.flush();
         assertThat(stringWriter.toString()).isEqualTo("<?xml version='1.0' encoding='UTF-8' ?>" + expected);
+    }
+
+    @Test
+    public void testReaderParserPreservesBeginningAndNamespaces() throws Exception {
+        final XmlPullParser parser = XmlUtils.createParser(new StringReader("<root xmlns=\"urn:test\"><child>text</child></root>"), true);
+        assertThat(parser.nextTag()).isEqualTo(XmlPullParser.START_TAG);
+        assertThat(parser.getName()).isEqualTo("root");
+        assertThat(parser.getNamespace()).isEqualTo("urn:test");
+        assertThat(parser.nextTag()).isEqualTo(XmlPullParser.START_TAG);
+        assertThat(parser.nextText()).isEqualTo("text");
+        assertThat(parser.nextTag()).isEqualTo(XmlPullParser.END_TAG);
+        assertThat(parser.getName()).isEqualTo("root");
     }
 
     @Test

--- a/main/src/test/res/xml/example_invalid.xml
+++ b/main/src/test/res/xml/example_invalid.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<websites xmlns:test="http://cgeo.org/test" xmlns:testduplicate="http://cgeo.org/test">
+    <website url="https://cgeo.org">
+        <name>cgeo</name>
+        <test:status>green</test:status>
+        <testduplicate:status2>red</testduplicate:status2>
+        <nondeclared:test>test</nondeclared:test>
+        <unclosed>notclosed
+    </website>
+</websites>


### PR DESCRIPTION
Introducing a new unified gpx parser.

```
/**
 * Unified, namespace-tolerant "business element" pull-parser for GPX files relevant to Geocaching. Reacts on
 * Geocaches, Waypoints, (Named) Coordinates, Routes and Tracks instead of raw XML elements, via
 * {@link IGPXParseHooks}.
 * <br>
 * <ul>
 *     <li>Handles GPX 1.0 and GPX 1.1 (and mixtures thereof) in one unified code path (no version-specific subclasses).</li>
 *     <li>Does not rely on namespaces being correctly declared; elements/attributes are identified by local
 *     name only (namespace prefixes, if any, are simply stripped).</li>
 *     <li>Self-contained: will only use information from GPX file(s) in created objects.</li>
 *     <li>Multi-file-capability: multiple calls to "parse" may be used to scan related GPX files (eg from a ZIP file)</li>
 *     <li>Handling of enhancements such as GSAP, Groundspeak and c:geo's own tags (via dedicated methods).</li>
 * </ul>
 * <br>
 * {@link #parse} can be called repeatedly, in any order, on the same instance to handle multi-GPX-file-situations (eg from ZIP file).
 * Session-scoped state (esp the cross-file name→geocode index) is <em>not</em> cleared automatically between calls,
 * so resolution works cross-file. Call {@link #reset()} to explicitly start a new, unrelated session on a reused instance.
 */
```