### PR TITLE
Fix HealthScoreGeocacheFilter: dont include null values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ captures/
 .claude/
 
 main/usage.txt
+
+temp/

--- a/main/src/androidTest/java/cgeo/geocaching/filters/NumberRangeGeocacheFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/NumberRangeGeocacheFilterTest.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.filters;
 
 import cgeo.geocaching.filters.core.DifficultyGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.HealthScoreGeocacheFilter;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.functions.Action1;
 
@@ -58,10 +59,42 @@ public class NumberRangeGeocacheFilterTest {
             f.setSpecialNumber(5f, false);
             f.setMinMaxRange(1f, 6f);
         }, false);
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // is done in called test method
+    public void includeNull() {
+        //null and not null
+        assertSingleHealth(c -> c.setHealthScore(null), f -> f.setIncludeNull(true), true);
+        assertSingleHealth(c -> c.setHealthScore(null), f -> f.setIncludeNull(false), false);
+        assertSingleHealth(c -> c.setHealthScore(10), f -> f.setIncludeNull(true), true);
+        assertSingleHealth(c -> c.setHealthScore(10), f -> f.setIncludeNull(false), true);
+
+        //combine with special filter
+        assertSingleHealth(c -> c.setHealthScore(Geocache.HEALTH_SCORE_UNKNOWN), f -> {
+            f.setIncludeNull(true);
+            f.setSpecialNumber(Geocache.HEALTH_SCORE_UNKNOWN, true);
+        }, true);
+        assertSingleHealth(c -> c.setHealthScore(Geocache.HEALTH_SCORE_UNKNOWN), f -> {
+            f.setIncludeNull(false);
+            f.setSpecialNumber(Geocache.HEALTH_SCORE_UNKNOWN, true);
+        }, true);
+        assertSingleHealth(c -> c.setHealthScore(Geocache.HEALTH_SCORE_UNKNOWN), f -> {
+            f.setIncludeNull(true);
+            f.setSpecialNumber(Geocache.HEALTH_SCORE_UNKNOWN, false);
+        }, false);
+        assertSingleHealth(c -> c.setHealthScore(Geocache.HEALTH_SCORE_UNKNOWN), f -> {
+            f.setIncludeNull(false);
+            f.setSpecialNumber(Geocache.HEALTH_SCORE_UNKNOWN, false);
+        }, false);
 
     }
 
     private void assertSingle(final Action1<Geocache> cacheSetter, final Action1<DifficultyGeocacheFilter> filterSetter, final Boolean expectedResult) {
         GeocacheFilterTestUtils.testSingle(GeocacheFilterType.DIFFICULTY, cacheSetter, filterSetter, expectedResult);
+    }
+
+    private void assertSingleHealth(final Action1<Geocache> cacheSetter, final Action1<HealthScoreGeocacheFilter> filterSetter, final Boolean expectedResult) {
+        GeocacheFilterTestUtils.testSingle(GeocacheFilterType.HEALTH_SCORE, cacheSetter, filterSetter, expectedResult);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/filters/core/HealthScoreGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/HealthScoreGeocacheFilter.java
@@ -1,30 +1,21 @@
 package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.models.Geocache;
-import cgeo.geocaching.storage.SqlBuilder;
-import cgeo.geocaching.utils.JsonUtils;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class HealthScoreGeocacheFilter extends NumberRangeGeocacheFilter<Integer> {
 
-    private static final String CONFIG_KEY_INCLUDE_UNSCORED = "includeUnscored";
-
-    private boolean includeUnscored = true;
-
     public HealthScoreGeocacheFilter() {
-        super(Integer::valueOf, f -> Math.round(f));
+        super(Integer::valueOf, Math::round);
+        setIncludeUnscored(false);
     }
 
     public boolean isIncludeUnscored() {
-        return includeUnscored;
+        return getIncludeSpecialNumber();
     }
 
     public void setIncludeUnscored(final boolean includeUnscored) {
-        this.includeUnscored = includeUnscored;
+        this.setSpecialNumber(Geocache.HEALTH_SCORE_UNKNOWN, includeUnscored);
+        this.setIncludeNull(includeUnscored);
     }
 
     @Override
@@ -42,54 +33,9 @@ public class HealthScoreGeocacheFilter extends NumberRangeGeocacheFilter<Integer
         if (cache == null) {
             return null;
         }
+
         final Integer score = cache.getHealthScore();
-        if (score == null) {
-            return true; // not yet computed — always pass through
-        }
-        if (score == Geocache.HEALTH_SCORE_UNKNOWN) {
-            return includeUnscored;
-        }
-        return super.filter(cache);
-    }
-
-    @Override
-    public boolean isFiltering() {
-        return !includeUnscored || super.isFiltering();
-    }
-
-    @Override
-    public void addToSql(final SqlBuilder sqlBuilder) {
-        // NULL health_score = not yet computed → always include
-        sqlBuilder.openWhere(SqlBuilder.WhereType.OR);
-        sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".health_score IS NULL");
-        if (includeUnscored) {
-            // include HEALTH_SCORE_UNKNOWN (-1) OR range
-            sqlBuilder.openWhere(SqlBuilder.WhereType.OR);
-            sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".health_score = " + Geocache.HEALTH_SCORE_UNKNOWN);
-            super.addToSql(sqlBuilder);
-            sqlBuilder.closeWhere();
-        } else {
-            // exclude HEALTH_SCORE_UNKNOWN (-1) AND apply range
-            sqlBuilder.openWhere(SqlBuilder.WhereType.AND);
-            sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".health_score <> " + Geocache.HEALTH_SCORE_UNKNOWN);
-            super.addToSql(sqlBuilder);
-            sqlBuilder.closeWhere();
-        }
-        sqlBuilder.closeWhere();
-    }
-
-    @Nullable
-    @Override
-    public ObjectNode getJsonConfig() {
-        final ObjectNode node = super.getJsonConfig();
-        JsonUtils.setBoolean(node, CONFIG_KEY_INCLUDE_UNSCORED, includeUnscored);
-        return node;
-    }
-
-    @Override
-    public void setJsonConfig(@NonNull final ObjectNode config) {
-        super.setJsonConfig(config);
-        includeUnscored = JsonUtils.getBoolean(config, CONFIG_KEY_INCLUDE_UNSCORED, true);
+        return isInRange(score);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/filters/core/NumberRangeFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/NumberRangeFilter.java
@@ -2,14 +2,10 @@ package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.storage.SqlBuilder;
 import cgeo.geocaching.utils.JsonUtils;
-import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.functions.Func1;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -17,8 +13,8 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang3.StringUtils;
 
 
 public class NumberRangeFilter<T extends Number & Comparable<T>> {
@@ -26,8 +22,10 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
     private T minRangeValue;
     private T maxRangeValue;
 
-    private T specialNumber;
-    private Boolean includeSpecialNumber;
+    private final Set<T> specialNumberInclude = new HashSet<>();
+    private final Set<T> specialNumberExclude = new HashSet<>();
+
+    private boolean includeNull = false;
 
     private final Func1<String, T> numberParser;
     private final Func1<Float, T> numberConverter;
@@ -38,8 +36,18 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
     }
 
     public boolean isInRange(final T value) {
-        if (includeSpecialNumber != null && specialNumber != null && isEqualValue(value, specialNumber)) {
-            return includeSpecialNumber;
+        if (value == null) {
+            return includeNull;
+        }
+        for (T special : specialNumberInclude) {
+            if (isEqualValue(value, special)) {
+                return true;
+            }
+        }
+        for (T special : specialNumberExclude) {
+            if (isEqualValue(value, special)) {
+                return false;
+            }
         }
 
         if (minRangeValue != null && minRangeValue.compareTo(value) > 0) {
@@ -61,16 +69,31 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
         return maxRangeValue;
     }
 
-    public void setSpecialNumber(final T specialNumber) {
-        this.specialNumber = specialNumber;
+    public void setSpecialNumbers(final Collection<T> include, final Collection<T> exclude) {
+        this.specialNumberInclude.clear();
+        if (include != null) {
+            this.specialNumberInclude.addAll(include);
+        }
+        this.specialNumberExclude.clear();
+        if (exclude != null) {
+            this.specialNumberExclude.addAll(exclude);
+        }
     }
 
-    public Boolean getIncludeSpecialNumber() {
-        return includeSpecialNumber;
+    public Set<T> getSpecialNumberInclude() {
+        return specialNumberInclude;
     }
 
-    public void setIncludeSpecialNumber(final Boolean includeSpecialNumber) {
-        this.includeSpecialNumber = includeSpecialNumber;
+    public Set<T> getSpecialNumberExclude() {
+        return specialNumberExclude;
+    }
+
+    public void setIncludeNull(final boolean includeNull) {
+        this.includeNull = includeNull;
+    }
+
+    public boolean getIncludeNull() {
+        return includeNull;
     }
 
     public Collection<T> getValuesInRange(final T[] values) {
@@ -110,58 +133,31 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
         setMinMaxRange(foundMinUnlimited ? null : min, foundMaxUnlimited ? null : max);
     }
 
-
-    public void setConfig(final List<String> config) {
-        if (config == null || config.size() < 2) {
-            return;
-        }
-
-        minRangeValue = parseString(config.get(0));
-        maxRangeValue = parseString(config.get(1));
-        specialNumber = config.size() >= 3 ? parseString(config.get(2)) : null;
-        includeSpecialNumber = config.size() >= 4 ? Boolean.valueOf(config.get(3)) : null;
-    }
-
-    public List<String> getConfig() {
-        final List<String> config = new ArrayList<>(Arrays.asList(
-                minRangeValue == null ? "-" : String.valueOf(minRangeValue),
-                maxRangeValue == null ? "-" : String.valueOf(maxRangeValue)));
-        if (specialNumber != null && includeSpecialNumber != null) {
-            config.add(String.valueOf(specialNumber));
-            config.add(Boolean.toString(includeSpecialNumber));
-        }
-        return config;
-    }
-
-    private T parseString(final String text) {
-        if (StringUtils.isBlank(text) || "-".equals(text)) {
-            return null;
-        }
-        try {
-            return this.numberParser.call(text);
-        } catch (Exception e) {
-            Log.w("Problem parsing '" + text + "' as a number", e);
-            return null;
-        }
-    }
-
     public boolean isFilled() {
-        return minRangeValue != null || maxRangeValue != null || (specialNumber != null && includeSpecialNumber != null);
+        return minRangeValue != null || maxRangeValue != null || includeNull || !specialNumberInclude.isEmpty() || !specialNumberExclude.isEmpty();
     }
 
     public void addRangeToSqlBuilder(final SqlBuilder sqlBuilder, final String valueExpression, final Func1<T, T> valueConverter) {
-        final boolean hasSpecial = specialNumber != null && includeSpecialNumber != null;
+        final boolean hasSpecial = !specialNumberInclude.isEmpty() || !specialNumberExclude.isEmpty();
         final boolean hasMinMax = minRangeValue != null || maxRangeValue != null;
 
-        if (valueExpression == null || (!hasSpecial && !hasMinMax)) {
+        if (valueExpression == null || (!hasSpecial && !hasMinMax && !includeNull)) {
             sqlBuilder.addWhereAlwaysInclude();
         } else {
-            if (hasSpecial) {
-                sqlBuilder.openWhere(includeSpecialNumber ? SqlBuilder.WhereType.OR : SqlBuilder.WhereType.AND);
-                final T sn = valueConverter == null ? specialNumber : valueConverter.call(specialNumber);
-                if (includeSpecialNumber) {
+            if (includeNull || !specialNumberInclude.isEmpty()) {
+                sqlBuilder.openWhere(SqlBuilder.WhereType.OR);
+                if (includeNull) {
+                    sqlBuilder.addWhere(valueExpression + " IS NULL");
+                }
+                for (T specialNumber : specialNumberInclude) {
+                    final T sn = valueConverter == null ? specialNumber : valueConverter.call(specialNumber);
                     sqlBuilder.addWhere(valueExpression + " = " + sn);
-                } else {
+                }
+            }
+            if (!specialNumberExclude.isEmpty()) {
+                sqlBuilder.openWhere(SqlBuilder.WhereType.AND);
+                for (T specialNumber : specialNumberExclude) {
+                    final T sn = valueConverter == null ? specialNumber : valueConverter.call(specialNumber);
                     sqlBuilder.addWhere(valueExpression + " <> " + sn);
                 }
             }
@@ -177,7 +173,10 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
             }
             sqlBuilder.closeWhere();
 
-            if (hasSpecial) {
+            if (!specialNumberExclude.isEmpty()) {
+                sqlBuilder.closeWhere();
+            }
+            if (includeNull || !specialNumberInclude.isEmpty()) {
                 sqlBuilder.closeWhere();
             }
 
@@ -206,9 +205,32 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
         if (node != null) {
             minRangeValue = floatToValue(JsonUtils.getFloat(node, "min", null));
             maxRangeValue = floatToValue(JsonUtils.getFloat(node, "max", null));
-            specialNumber = floatToValue(JsonUtils.getFloat(node, "special", null));
-            includeSpecialNumber = JsonUtils.getBoolean(node, "includeSpecial", false);
+            includeNull = JsonUtils.getBoolean(node, "includeNull", false);
+            final Set<T> specialNumberInclude = getArrayNode(node, "specialInclude");
+            final Set<T> specialNumberExclude = getArrayNode(node, "specialExclude");
+
+            //legacy
+            final T legacySpecialNumber = floatToValue(JsonUtils.getFloat(node, "special", null));
+            final Boolean includeSpecialNumber = JsonUtils.getBoolean(node, "includeSpecial", false);
+            if (legacySpecialNumber != null && includeSpecialNumber != null) {
+                (includeSpecialNumber ? specialNumberInclude : specialNumberExclude).add(legacySpecialNumber);
+            }
+            setSpecialNumbers(specialNumberInclude, specialNumberExclude);
         }
+    }
+
+    private Set<T> getArrayNode(final JsonNode node, final String key) {
+        final Set<T> result = new HashSet<>();
+        final JsonNode arrayNode = JsonUtils.get(node, key);
+        if (arrayNode instanceof ArrayNode) {
+            for (JsonNode specialNumberNode : arrayNode) {
+                final Float specialNumberFloat = JsonUtils.toFloat(specialNumberNode, null);
+                if (specialNumberFloat != null) {
+                    result.add(floatToValue(specialNumberFloat));
+                }
+            }
+        }
+        return result;
     }
 
     private T floatToValue(final Float value) {
@@ -220,10 +242,17 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
         final ObjectNode node = JsonUtils.createObjectNode();
         JsonUtils.setFloat(node, "min", minRangeValue);
         JsonUtils.setFloat(node, "max", maxRangeValue);
-        if (specialNumber != null && includeSpecialNumber != null) {
-            JsonUtils.setFloat(node, "special", specialNumber);
-            JsonUtils.setBoolean(node, "includeSpecial", includeSpecialNumber);
+        JsonUtils.setBoolean(node, "includeNull", includeNull);
+        final ArrayNode specialNumberExcludeNode = JsonUtils.createArrayNode();
+        for (T specialNumber : specialNumberExclude) {
+            specialNumberExcludeNode.add(JsonUtils.fromFloat(specialNumber));
         }
+        JsonUtils.set(node, "specialExclude", specialNumberExcludeNode);
+        final ArrayNode specialNumberIncludeNode = JsonUtils.createArrayNode();
+        for (T specialNumber : specialNumberInclude) {
+            specialNumberIncludeNode.add(JsonUtils.fromFloat(specialNumber));
+        }
+        JsonUtils.set(node, "specialInclude", specialNumberIncludeNode);
         return node;
     }
 

--- a/main/src/main/java/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
@@ -8,6 +8,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -21,12 +23,17 @@ public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>
     }
 
     public void setSpecialNumber(final T specialNumber, final Boolean include) {
-        numberRangeFilter.setSpecialNumber(specialNumber);
-        numberRangeFilter.setIncludeSpecialNumber(include);
+        final Set<T> includeSet = Boolean.TRUE.equals(include) && specialNumber != null ? Collections.singleton(specialNumber) : Collections.emptySet();
+        final Set<T> excludeSet = Boolean.FALSE.equals(include) && specialNumber != null ? Collections.singleton(specialNumber) : Collections.emptySet();
+        numberRangeFilter.setSpecialNumbers(includeSet, excludeSet);
     }
 
-    public Boolean getIncludeSpecialNumber() {
-        return numberRangeFilter.getIncludeSpecialNumber();
+    public boolean getIncludeSpecialNumber() {
+        return !numberRangeFilter.getSpecialNumberInclude().isEmpty();
+    }
+
+    public void setIncludeNull(final Boolean includeNull) {
+        numberRangeFilter.setIncludeNull(includeNull);
     }
 
     protected abstract T getValue(Geocache cache);
@@ -51,7 +58,7 @@ public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>
         return isInRange(gcValue);
     }
 
-    private boolean isInRange(final T value) {
+    protected boolean isInRange(final T value) {
         return numberRangeFilter.isInRange(value);
     }
 

--- a/main/src/main/java/cgeo/geocaching/filters/gui/DifficultyAndTerrainFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/DifficultyAndTerrainFilterViewHolder.java
@@ -44,7 +44,7 @@ public class DifficultyAndTerrainFilterViewHolder extends BaseFilterViewHolder<D
     public void setViewFromFilter(@NonNull final DifficultyAndTerrainGeocacheFilter filter) {
         if (diffView != null) {
             diffView.setViewFromFilter(filter.difficultyGeocacheFilter);
-            includeCheckbox.right.setChecked(Boolean.TRUE.equals(filter.difficultyGeocacheFilter.getIncludeSpecialNumber()));
+            includeCheckbox.right.setChecked(filter.difficultyGeocacheFilter.getIncludeSpecialNumber());
         }
         if (terrainView != null) {
             terrainView.setViewFromFilter(filter.terrainGeocacheFilter);


### PR DESCRIPTION
Fix HealthScoreGeocacheFilter: dont include null values

The bug made the feature pretty much unusable because every unknown cache (= not stored offline or no health score calc running) was marked as "unhealthy". Fixed with this PR. I had to extend NumberFilter capabilities for this