### PR TITLE
Support multiple user-defined tile providers

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -41,6 +41,7 @@ import cgeo.geocaching.ui.AvatarUtils;
 import cgeo.geocaching.ui.notifications.Notifications;
 import cgeo.geocaching.unifiedmap.UnifiedMapType;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
+import cgeo.geocaching.unifiedmap.tileproviders.PrefUserDefinedTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
@@ -1342,9 +1343,60 @@ public class Settings {
         return sharedPrefs.getStringSet(getKey(R.string.pref_tileprovider_hidden), empty);
     }
 
-    @Nullable
-    public static String getUserDefinedTileProviderUri() {
-        return getString(R.string.pref_userDefinedTileProviderUri, null);
+    /**
+     * User-defined tile providers, stored as a JSON list.
+     * Understands the legacy format as well, where the very same preference held a single, bare tile provider Uri.
+     */
+    /**
+     * The user-defined tile providers.
+     *
+     * <p>Falls back to the single provider of earlier versions while the new preference has not
+     * been written yet. Nothing is migrated eagerly and the old preference is never touched, so a
+     * version without this feature keeps working after a downgrade.</p>
+     */
+    @NonNull
+    public static List<PrefUserDefinedTileProvider> getUserDefinedTileProviders() {
+        final String value = StringUtils.trimToEmpty(getString(R.string.pref_userDefinedTileProviders, null));
+        // an empty *string*, not an empty list: a list that has been written is at least "[]", so
+        // this is only true while the preference has never been written. Emptying the list keeps
+        // it empty and does not bring the legacy provider back.
+        if (StringUtils.isEmpty(value)) {
+            final String legacyUri = StringUtils.trimToNull(getString(R.string.old_pref_userDefinedTileProviderUri, null));
+            return legacyUri == null ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(
+                    // keeps LEGACY_KEY, so the derived tile provider id stays what it was and neither the
+                    // selected map source nor the list of hidden map sources needs rewriting
+                    new PrefUserDefinedTileProvider(PrefUserDefinedTileProvider.LEGACY_KEY, null, legacyUri)));
+        }
+        try {
+            return MAPPER.readValue(value, new TypeReference<List<PrefUserDefinedTileProvider>>() {
+            });
+        } catch (JsonProcessingException e) {
+            Log.e("Failure parsing user-defined tile providers: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Adds, updates or (if the given provider has no Uri) removes a user-defined tile provider.
+     */
+    public static void putUserDefinedTileProvider(final PrefUserDefinedTileProvider provider) {
+        final List<PrefUserDefinedTileProvider> providers = getUserDefinedTileProviders();
+        final int index = providers.indexOf(provider);
+        if (StringUtils.isBlank(provider.getUri())) {
+            if (index == -1) {
+                return;
+            }
+            providers.remove(index);
+        } else if (index == -1) {
+            providers.add(provider);
+        } else {
+            providers.set(index, provider);
+        }
+        try {
+            putString(R.string.pref_userDefinedTileProviders, MAPPER.writeValueAsString(providers));
+        } catch (JsonProcessingException e) {
+            Log.e("Failure writing user-defined tile providers: " + e.getMessage());
+        }
     }
 
     /** json array holding the configured tile overlays, see cgeo.geocaching.unifiedmap.overlays.TileOverlays */

--- a/main/src/main/java/cgeo/geocaching/settings/UserDefinedTileProviderPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/UserDefinedTileProviderPreference.java
@@ -1,0 +1,197 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.Keyboard;
+import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.unifiedmap.tileproviders.PrefUserDefinedTileProvider;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlTester;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlUtils;
+import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+
+import android.content.ClipData;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.ViewCompat;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputLayout;
+import org.apache.commons.lang3.StringUtils;
+
+/** Preference to add / edit / remove a single user-defined tile provider */
+public class UserDefinedTileProviderPreference extends Preference {
+
+    public UserDefinedTileProviderPreference(final Context context) {
+        super(context);
+        setWidgetLayoutResource(R.layout.preference_copy_delete_buttons);
+    }
+
+    public UserDefinedTileProviderPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public UserDefinedTileProviderPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        setOnPreferenceClickListener(preference -> {
+            launchEditDialog();
+            return false;
+        });
+        final MaterialButton copyButton = (MaterialButton) holder.findViewById(R.id.copyview);
+        copyButton.setIconResource(R.drawable.ic_menu_copy);
+        copyButton.setOnClickListener(v -> {
+            final PrefUserDefinedTileProvider provider = getProvider();
+            if (provider != null) {
+                ClipboardUtils.copyToClipboard(provider.toShareableText());
+                ViewUtils.showShortToast(getContext(), R.string.settings_tileUrl_copied);
+            }
+        });
+
+        final MaterialButton button = (MaterialButton) holder.findViewById(R.id.deleteview);
+        button.setIconResource(R.drawable.ic_menu_delete);
+        button.setOnClickListener(v -> SimpleDialog.ofContext(getContext())
+                .setTitle(R.string.settings_userDefinedTileProvider)
+                .setMessage(R.string.settings_userDefinedTileProvider_remove_confirm)
+                .confirm(() -> {
+                    // a provider without Uri gets removed
+                    Settings.putUserDefinedTileProvider(new PrefUserDefinedTileProvider(getKey(), null, null));
+                    callChangeListener(null);
+                }));
+    }
+
+    public void launchEditDialog() {
+        final View v = LayoutInflater.from(getContext()).inflate(R.layout.userdefined_tileprovider_preference_dialog, null);
+        final TextInputLayout uriLayout = v.findViewById(R.id.editLayout);
+        final EditText editTitle = v.findViewById(R.id.title);
+        final EditText editUri = v.findViewById(R.id.edit);
+
+        final PrefUserDefinedTileProvider provider = getProvider();
+        final boolean isNew = provider == null;
+        if (!isNew) {
+            editTitle.setText(provider.getName());
+            editUri.setText(provider.getUri());
+        }
+        Dialogs.moveCursorToEnd(editUri);
+        Keyboard.show(getContext(), isNew ? editTitle : editUri);
+
+        final AlertDialog dialog = Dialogs.newBuilder(getContext())
+                .setView(v)
+                .setTitle(isNew ? R.string.settings_userDefinedTileProvider_addnew : R.string.settings_userDefinedTileProvider_edit)
+                // listeners are attached after show(), so that neither an invalid Uri nor a test
+                // run dismisses the dialog and discards what was typed
+                .setPositiveButton(android.R.string.ok, null)
+                .setNeutralButton(R.string.settings_tileUrl_test, null)
+                .setNegativeButton(android.R.string.cancel, (d, which) -> d.dismiss())
+                .show();
+
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v2 -> save(dialog, uriLayout, editTitle, editUri));
+        dialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(v2 -> test(dialog, uriLayout, editUri));
+        acceptSharedProviderOnPaste(editTitle, uriLayout, editTitle, editUri);
+        acceptSharedProviderOnPaste(editUri, uriLayout, editTitle, editUri);
+    }
+
+    /**
+     * Lets a shared tile provider be pasted into either field, filling both.
+     *
+     * <p>Hooks the paste action rather than reading the clipboard by itself: from Android 13 on,
+     * reading it unprompted shows a system notice and is restricted to the focused app, while
+     * handling what the user pastes needs no permission and stays silent.</p>
+     */
+    private void acceptSharedProviderOnPaste(@NonNull final EditText field, @NonNull final TextInputLayout uriLayout,
+                                             @NonNull final EditText editTitle, @NonNull final EditText editUri) {
+        ViewCompat.setOnReceiveContentListener(field, new String[]{"text/*"}, (view, payload) -> {
+            final ClipData clip = payload.getClip();
+            final CharSequence text = clip.getItemCount() > 0 ? clip.getItemAt(0).getText() : null;
+            final PrefUserDefinedTileProvider shared = PrefUserDefinedTileProvider.fromShareableText(text == null ? null : text.toString());
+            if (shared == null) {
+                // not one of ours, let the field handle the paste as usual
+                return payload;
+            }
+            // only fill a name that the paste actually carries, and never replace one the user
+            // has already typed
+            if (StringUtils.isNotEmpty(shared.getName()) && StringUtils.isBlank(editTitle.getText())) {
+                editTitle.setText(shared.getName());
+            }
+            editUri.setText(shared.getUri());
+            uriLayout.setError(null);
+            return null; // consumed
+        });
+    }
+
+    private void save(@NonNull final AlertDialog dialog, @NonNull final TextInputLayout uriLayout,
+                      @NonNull final EditText editTitle, @NonNull final EditText editUri) {
+        final String uri = TileUrlUtils.normalize(editUri.getText().toString());
+        if (uri == null) {
+            uriLayout.setError(LocalizationUtils.getString(R.string.settings_tileUrl_invalid));
+            return;
+        }
+        uriLayout.setError(null);
+        store(dialog, editTitle, uri);
+    }
+
+    /**
+     * Fetches one real tile from the Uri in the dialog, on request.
+     *
+     * <p>A syntactically valid Uri can still be wrong, which shows up only as a map that stays
+     * empty. Saving deliberately does not wait for this: it needs the network, and an entry may
+     * well be typed somewhere without one.</p>
+     */
+    private void test(@NonNull final AlertDialog dialog, @NonNull final TextInputLayout uriLayout, @NonNull final EditText editUri) {
+        final String uri = TileUrlUtils.normalize(editUri.getText().toString());
+        if (uri == null) {
+            uriLayout.setError(LocalizationUtils.getString(R.string.settings_tileUrl_invalid));
+            return;
+        }
+        uriLayout.setError(null);
+
+        final Button testButton = dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
+        testButton.setEnabled(false);
+        uriLayout.setHelperText(LocalizationUtils.getString(R.string.settings_tileUrl_testing));
+        AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler,
+                () -> TileUrlTester.test(TileUrlUtils.withDefaultTilePath(uri)),
+                error -> {
+                    testButton.setEnabled(true);
+                    uriLayout.setHelperText(null);
+                    if (error == null) {
+                        ViewUtils.showShortToast(getContext(), R.string.settings_tileUrl_testok);
+                    } else {
+                        SimpleDialog.ofContext(getContext())
+                                .setTitle(R.string.settings_tileUrl_testfailed_title)
+                                .setMessage(R.string.settings_tileUrl_testfailed, error)
+                                .show();
+                    }
+                });
+    }
+
+    private void store(@NonNull final AlertDialog dialog, @NonNull final EditText editTitle, @NonNull final String uri) {
+        Settings.putUserDefinedTileProvider(new PrefUserDefinedTileProvider(getKey(), editTitle.getText().toString().trim(), uri));
+        callChangeListener(uri);
+        dialog.dismiss();
+    }
+
+    private PrefUserDefinedTileProvider getProvider() {
+        for (PrefUserDefinedTileProvider provider : Settings.getUserDefinedTileProviders()) {
+            if (provider.getKey().equals(getKey())) {
+                return provider;
+            }
+        }
+        return null;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
@@ -5,14 +5,14 @@ import cgeo.geocaching.downloader.DownloadSelectorActivity;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.settings.TileOverlayPreference;
+import cgeo.geocaching.settings.UserDefinedTileProviderPreference;
 import cgeo.geocaching.unifiedmap.overlays.TileOverlay;
 import cgeo.geocaching.unifiedmap.overlays.TileOverlays;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
+import cgeo.geocaching.unifiedmap.tileproviders.PrefUserDefinedTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
-import cgeo.geocaching.utils.PreferenceUtils;
-import cgeo.geocaching.utils.SettingsUtils;
 import cgeo.geocaching.utils.ShareUtils;
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
@@ -26,9 +26,11 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 
 import java.util.HashMap;
+import static java.util.UUID.randomUUID;
 
 public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
     private ListPreference prefTileProvicers;
+    private PreferenceCategory userDefinedTileProvidersCategory;
     private PreferenceCategory tileOverlaysCategory;
 
     @Override
@@ -54,12 +56,8 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
         hideTileprovidersPref.setEntries(tpEntries);
         hideTileprovidersPref.setEntryValues(tpValues);
 
-        setUserDefinedTileProviderUriSummary(Settings.getUserDefinedTileProviderUri());
-        PreferenceUtils.setOnPreferenceChangeListener(findPreference(getString(R.string.pref_userDefinedTileProviderUri)), (preference, newValue) -> {
-            setUserDefinedTileProviderUriSummary(String.valueOf(newValue));
-            setFlagForRestartRequired();
-            return true;
-        });
+        userDefinedTileProvidersCategory = findPreference(getString(R.string.preference_category_userdefined_tileproviders));
+        recreateUserDefinedTileProviderPreferences();
 
         final ListPreference unifiedMapVariants = findPreference(getString(R.string.pref_unifiedMapVariants));
         unifiedMapVariants.setEntries(new String[]{ "Mapsforge", "VTM", "Mapsforge + VTM" });
@@ -123,6 +121,26 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
 
     }
 
+    private void recreateUserDefinedTileProviderPreferences() {
+        userDefinedTileProvidersCategory.removeAll();
+        for (PrefUserDefinedTileProvider provider : Settings.getUserDefinedTileProviders()) {
+            userDefinedTileProvidersCategory.addPreference(createUserDefinedTileProviderPreference(provider));
+        }
+        userDefinedTileProvidersCategory.addPreference(createUserDefinedTileProviderPreferenceAddNew());
+    }
+
+    private Preference createUserDefinedTileProviderPreferenceAddNew() {
+        final Preference preference = new Preference(requireContext());
+        preference.setTitle(R.string.settings_userDefinedTileProvider_addnew);
+        preference.setLayoutResource(R.layout.preference_button);
+        preference.setIconSpaceReserved(false);
+        preference.setOnPreferenceClickListener(pref -> {
+            createUserDefinedTileProviderPreference(new PrefUserDefinedTileProvider(randomUUID().toString(), "", "")).launchEditDialog();
+            return true;
+        });
+        return preference;
+    }
+
     /** (Re-)builds the rows of the user-defined tile overlays, plus the trailing "add" button */
     private void recreateTileOverlayPreferences() {
         tileOverlaysCategory.removeAll();
@@ -145,8 +163,19 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
         return preference;
     }
 
-    private void setUserDefinedTileProviderUriSummary(final String uri) {
-        SettingsUtils.setPrefSummary(this, R.string.pref_userDefinedTileProviderUri, LocalizationUtils.getString(R.string.settings_userDefinedTileProviderUri) + "\n\n" + uri);
+    private UserDefinedTileProviderPreference createUserDefinedTileProviderPreference(final PrefUserDefinedTileProvider provider) {
+        final UserDefinedTileProviderPreference preference = new UserDefinedTileProviderPreference(requireContext());
+        preference.setKey(provider.getKey());
+        preference.setPersistent(false);
+        preference.setTitle(provider.getDisplayName());
+        preference.setSummary(provider.getUri());
+        preference.setIconSpaceReserved(false);
+        preference.setOnPreferenceChangeListener((pref, newValue) -> {
+            recreateUserDefinedTileProviderPreferences();
+            setFlagForRestartRequired();
+            return true;
+        });
+        return preference;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/PrefUserDefinedTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/PrefUserDefinedTileProvider.java
@@ -1,0 +1,113 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlShare;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
+
+/** The stored form of a user-defined tile provider, as kept in the preferences. */
+public class PrefUserDefinedTileProvider {
+    /**
+     * Key of a tile provider read from the legacy single-Uri format of the setting.
+     * Deliberately "null", as the tile provider id derived from it must stay identical to
+     * the one used before multiple providers were supported (which appended the Uri's last
+     * path segment, always null for user-defined providers) - otherwise an upgrading user
+     * would lose their selected map source.
+     */
+    public static final String LEGACY_KEY = "null";
+
+    private final @NonNull String key;
+    private final String name;
+    private final String uri;
+
+    @JsonCreator
+    public PrefUserDefinedTileProvider(@JsonProperty("key") final String key, @JsonProperty("name") final String name, @JsonProperty("uri") final String uri) {
+        this.key = key;
+        this.name = name;
+        this.uri = uri;
+    }
+
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * Name to display for this provider: the name the user gave it, the host of its uri, or a
+     * generic fallback. Not part of the stored form - it is derived at read time, so renaming the
+     * fallback or fixing the host extraction takes effect without rewriting anybody's settings.
+     */
+    @JsonIgnore
+    public String getDisplayName() {
+        if (StringUtils.isNotBlank(name)) {
+            return name;
+        }
+        final String host = TileUrlUtils.host(uri);
+        return StringUtils.isNotBlank(host) ? host : LocalizationUtils.getString(R.string.settings_userDefinedTileProvider);
+    }
+
+    /** a provider can only be registered if it has a uri with a host */
+    @JsonIgnore
+    public boolean isConfigured() {
+        return StringUtils.isNotBlank(TileUrlUtils.host(uri));
+    }
+
+    /** the form to hand to somebody else, e.g. in a chat message: {@code name;uri} */
+    @NonNull
+    public String toShareableText() {
+        return TileUrlShare.format(StringUtils.defaultString(name), StringUtils.defaultString(uri));
+    }
+
+    /**
+     * Reads a provider back from text somebody shared.
+     *
+     * <p>Gets a key of its own, as it describes a provider this installation has not seen before.
+     * Callers that only want the name and the uri - the paste handler in the edit dialog - simply
+     * ignore it.</p>
+     *
+     * @return the provider, or {@code null} if the text holds no usable uri
+     */
+    @Nullable
+    public static PrefUserDefinedTileProvider fromShareableText(@Nullable final String text) {
+        final String[] shared = TileUrlShare.parse(text);
+        return shared == null ? null : new PrefUserDefinedTileProvider(UUID.randomUUID().toString(), shared[0], shared[1]);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final PrefUserDefinedTileProvider p = (PrefUserDefinedTileProvider) o;
+        return p.getKey().equals(this.getKey());
+    }
+
+    @Override
+    public int hashCode() {
+        return key.hashCode();
+    }
+
+    @Override
+    @NonNull
+    public String toString() {
+        return StringUtils.isNotBlank(name) ? name : StringUtils.defaultString(uri);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -99,6 +99,9 @@ public class TileProviderFactory {
         }
         tileProviders.clear();
 
+        final List<PrefUserDefinedTileProvider> userDefinedTileProviders =
+                CollectionStream.of(Settings.getUserDefinedTileProviders()).filter(PrefUserDefinedTileProvider::isConfigured).toList();
+
         // --------------------------------------------------------------------
         // online-based map providers
         // --------------------------------------------------------------------
@@ -117,8 +120,8 @@ public class TileProviderFactory {
             registerTileProvider(new CyclosmSource());
             registerTileProvider(new OpenTopoMapSource());
 
-            if (UserDefinedMapsforgeOnlineSource.isConfigured()) {
-                registerTileProvider(new UserDefinedMapsforgeOnlineSource());
+            for (PrefUserDefinedTileProvider userDefined : userDefinedTileProviders) {
+                registerTileProvider(new UserDefinedMapsforgeOnlineSource(userDefined));
             }
         }
 
@@ -129,8 +132,8 @@ public class TileProviderFactory {
             registerTileProvider(new CyclosmVTMSource());
             registerTileProvider(new OpenTopoMapVTMSource());
 
-            if (UserDefinedMapsforgeVTMOnlineSource.isConfigured()) {
-                registerTileProvider(new UserDefinedMapsforgeVTMOnlineSource());
+            for (PrefUserDefinedTileProvider userDefined : userDefinedTileProviders) {
+                registerTileProvider(new UserDefinedMapsforgeVTMOnlineSource(userDefined));
             }
         }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
@@ -1,19 +1,19 @@
 package cgeo.geocaching.unifiedmap.tileproviders;
 
-import cgeo.geocaching.R;
-import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.utils.LocalizationUtils;
-
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 
 import org.apache.commons.lang3.StringUtils;
 
 public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTileProvider {
-    UserDefinedMapsforgeOnlineSource() {
-        super(LocalizationUtils.getString(R.string.settings_userDefinedTileProvider), Uri.parse(Settings.getUserDefinedTileProviderUri()), "/{Z}/{X}/{Y}.png", 2, 18, new Pair<>(LocalizationUtils.getString(R.string.settings_userDefinedTileProvider), true));
-        final Uri fullUri = Uri.parse(Settings.getUserDefinedTileProviderUri());
+    @NonNull private final String key;
+
+    UserDefinedMapsforgeOnlineSource(final PrefUserDefinedTileProvider provider) {
+        super(provider.getDisplayName(), Uri.parse(provider.getUri()), "/{Z}/{X}/{Y}.png", 2, 18, new Pair<>(provider.getDisplayName(), true));
+        this.key = provider.getKey();
+        final Uri fullUri = Uri.parse(provider.getUri());
 
         final String mapUri = fullUri.getScheme() + "://" + fullUri.getHost();
         setMapUri(Uri.parse(mapUri));
@@ -31,9 +31,14 @@ public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTil
         }
     }
 
-    public static boolean isConfigured() {
-        final String uri = Settings.getUserDefinedTileProviderUri();
-        return StringUtils.isNotBlank(uri) && StringUtils.isNotBlank(Uri.parse(uri).getHost());
+    /**
+     * Deriving the id from the map Uri (as the superclass does) is not sufficient here,
+     * as several user-defined providers may share the same host.
+     */
+    @Override
+    @NonNull
+    public String getId() {
+        return getClass().getName() + ":" + key;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
@@ -1,20 +1,20 @@
 package cgeo.geocaching.unifiedmap.tileproviders;
 
-import cgeo.geocaching.R;
-import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.utils.LocalizationUtils;
-
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 
 import org.apache.commons.lang3.StringUtils;
 import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
 
 public class UserDefinedMapsforgeVTMOnlineSource extends AbstractMapsforgeVTMOnlineTileProvider {
-    UserDefinedMapsforgeVTMOnlineSource() {
-        super(LocalizationUtils.getString(R.string.settings_userDefinedTileProvider), Uri.parse(Settings.getUserDefinedTileProviderUri()), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(LocalizationUtils.getString(R.string.settings_userDefinedTileProvider), true));
-        final Uri fullUri = Uri.parse(Settings.getUserDefinedTileProviderUri());
+    @NonNull private final String key;
+
+    UserDefinedMapsforgeVTMOnlineSource(final PrefUserDefinedTileProvider provider) {
+        super(provider.getDisplayName(), Uri.parse(provider.getUri()), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(provider.getDisplayName(), true));
+        this.key = provider.getKey();
+        final Uri fullUri = Uri.parse(provider.getUri());
 
         final String mapUri = fullUri.getScheme() + "://" + fullUri.getHost();
         setMapUri(Uri.parse(mapUri));
@@ -33,8 +33,13 @@ public class UserDefinedMapsforgeVTMOnlineSource extends AbstractMapsforgeVTMOnl
         supportsHillshading = true;
     }
 
-    public static boolean isConfigured() {
-        final String uri = Settings.getUserDefinedTileProviderUri();
-        return StringUtils.isNotBlank(uri) && StringUtils.isNotBlank(Uri.parse(uri).getHost());
+    /**
+     * Deriving the id from the map Uri (as the superclass does) is not sufficient here,
+     * as several user-defined providers may share the same host.
+     */
+    @Override
+    @NonNull
+    public String getId() {
+        return getClass().getName() + ":" + key;
     }
 }

--- a/main/src/main/res/layout/userdefined_tileprovider_preference_dialog.xml
+++ b/main/src/main/res/layout/userdefined_tileprovider_preference_dialog.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp"
+    tools:context=".settings.UserDefinedTileProviderPreference" >
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/titleLayout"
+        style="@style/textinput_edittext">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/title"
+            style="@style/textinput_embedded"
+            android:inputType="textCapSentences"
+            android:autofillHints="@string/settings_tileUrl_name"
+            android:hint="@string/settings_tileUrl_name" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/editLayout"
+        style="@style/textinput_edittext">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit"
+            style="@style/textinput_embedded"
+            android:inputType="textUri|textNoSuggestions"
+            android:importantForAutofill="no"
+            android:hint="@string/settings_tileUrl_uri" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp"
+        android:text="@string/settings_userDefinedTileProviderUri"
+        android:textSize="@dimen/textSize_detailsSecondary" />
+
+</LinearLayout>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -211,7 +211,13 @@
     <string translatable="false" name="pref_tileprovider">tileprovider</string>
     <string translatable="false" name="pref_previous_tileprovider">previous_tileprovider</string>
     <string translatable="false" name="pref_tileprovider_hidden">tileprovider_hidden</string>
-    <string translatable="false" name="pref_userDefinedTileProviderUri">userDefinedTileProviderUri</string>
+    <!-- superseded by pref_userDefinedTileProviders, kept so the single provider of older
+         versions can be migrated and so those versions keep working after a downgrade -->
+    <string translatable="false" name="old_pref_userDefinedTileProviderUri">userDefinedTileProviderUri</string>
+    <string translatable="false" name="pref_userDefinedTileProviders">userDefinedTileProviders</string>
+
+    <!-- category user-defined tile providers -->
+    <string translatable="false" name="preference_category_userdefined_tileproviders">fakekey_category_userdefined_tileproviders</string>
     <string translatable="false" name="pref_tileOverlays">tileOverlays</string>
     <string translatable="false" name="preference_category_map_tileoverlays">fakekey_category_map_tileoverlays</string>
     <string translatable="false" name="pref_tileOverlaysEnabled">tileOverlaysEnabled</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1010,6 +1010,11 @@
     <string name="settings_hide_tileproviders_summary">Exclude one or more map sources from map source selection</string>
     <string name="settings_unifiedMapVariants_title">UnifiedMap variants</string>
     <string name="settings_userDefinedTileProvider">User-defined tile provider</string>
+    <string name="settings_userDefinedTileProviders">User-defined tile providers</string>
+    <string name="settings_userDefinedTileProviders_summary">Tile servers to use as the map itself, in addition to the ones c:geo comes with</string>
+    <string name="settings_userDefinedTileProvider_addnew">Add a new tile provider</string>
+    <string name="settings_userDefinedTileProvider_edit">Edit tile provider</string>
+    <string name="settings_userDefinedTileProvider_remove_confirm">Do you really want to remove this tile provider?</string>
     <string name="settings_userDefinedTileProviderUri">Enter full Uri (without trailing slash) to tile provider, or enter full Uri with parameters (including {X}, {Y} and {Z}). Make sure you have checked and comply to their usage conditions.</string>
     <string name="settings_tileOverlays">User-defined overlays</string>
     <string name="settings_tileOverlays_summary">Tile servers whose tiles are drawn on top of the map, for example sea marks or hiking routes</string>

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -28,13 +28,12 @@
             android:summary="%s"
             android:title="@string/settings_unifiedMapVariants_title"
             app:iconSpaceReserved="false" />
-        <cgeo.geocaching.settings.TextPreference
-            android:defaultValue=""
-            android:key="@string/pref_userDefinedTileProviderUri"
-            android:title="@string/settings_userDefinedTileProvider"
-            android:summary="@string/settings_userDefinedTileProviderUri"
-            app:iconSpaceReserved="false" />
     </PreferenceCategory>
+    <cgeo.geocaching.settings.PreferenceCategory
+        android:key="@string/preference_category_userdefined_tileproviders"
+        android:title="@string/settings_userDefinedTileProviders"
+        android:summary="@string/settings_userDefinedTileProviders_summary"
+        app:iconSpaceReserved="false" />
     <cgeo.geocaching.settings.PreferenceCategory
         android:key="@string/preference_category_map_tileoverlays"
         android:title="@string/settings_tileOverlays"

--- a/main/src/test/java/cgeo/geocaching/unifiedmap/tileproviders/PrefUserDefinedTileProviderTest.java
+++ b/main/src/test/java/cgeo/geocaching/unifiedmap/tileproviders/PrefUserDefinedTileProviderTest.java
@@ -1,0 +1,93 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the stored form of a user-defined tile provider. The list is kept as json in a
+ * preference, so what it serialises to has to stay readable by later versions.
+ */
+public class PrefUserDefinedTileProviderTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String URL = "https://example.com/{Z}/{X}/{Y}.png";
+
+    @Test
+    public void survivesAJsonRoundTrip() throws Exception {
+        final PrefUserDefinedTileProvider original = new PrefUserDefinedTileProvider("key-1", "My map", URL);
+        final PrefUserDefinedTileProvider restored =
+                MAPPER.readValue(MAPPER.writeValueAsString(original), PrefUserDefinedTileProvider.class);
+
+        assertThat(restored.getKey()).isEqualTo("key-1");
+        assertThat(restored.getName()).isEqualTo("My map");
+        assertThat(restored.getUri()).isEqualTo(URL);
+    }
+
+    @Test
+    public void survivesAJsonRoundTripAsAList() throws Exception {
+        final List<PrefUserDefinedTileProvider> original = List.of(
+                new PrefUserDefinedTileProvider("key-1", "One", URL),
+                new PrefUserDefinedTileProvider("key-2", null, URL));
+        final List<PrefUserDefinedTileProvider> restored =
+                MAPPER.readValue(MAPPER.writeValueAsString(original), new TypeReference<List<PrefUserDefinedTileProvider>>() { });
+
+        assertThat(restored).hasSize(2);
+        assertThat(restored.get(0).getName()).isEqualTo("One");
+        assertThat(restored.get(1).getName()).isNull();
+    }
+
+    @Test
+    public void identityIsTheKeyAlone() {
+        // putUserDefinedTileProvider finds the entry to replace via indexOf, so equality must not
+        // depend on the name or the uri
+        final PrefUserDefinedTileProvider a = new PrefUserDefinedTileProvider("key-1", "One", URL);
+        final PrefUserDefinedTileProvider b = new PrefUserDefinedTileProvider("key-1", "Renamed", "https://other.example/{Z}/{X}/{Y}.png");
+        final PrefUserDefinedTileProvider c = new PrefUserDefinedTileProvider("key-2", "One", URL);
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(c);
+    }
+
+    @Test
+    public void onlyTheThreeFieldsAreStored() throws Exception {
+        // getDisplayName() and isConfigured() are derived from the fields, not stored alongside
+        // them. Without @JsonIgnore they would be written out as well, and that is the kind of
+        // thing that is only noticed once somebody's settings no longer read back.
+        final List<String> fields = new ArrayList<>();
+        MAPPER.readTree(MAPPER.writeValueAsString(new PrefUserDefinedTileProvider("key-1", "My map", URL)))
+                .fieldNames().forEachRemaining(fields::add);
+
+        assertThat(fields).containsExactlyInAnyOrder("key", "name", "uri");
+    }
+
+    @Test
+    public void survivesBeingSharedAsText() {
+        final PrefUserDefinedTileProvider shared =
+                PrefUserDefinedTileProvider.fromShareableText(new PrefUserDefinedTileProvider("key-1", "My map", URL).toShareableText());
+
+        assertThat(shared).isNotNull();
+        assertThat(shared.getName()).isEqualTo("My map");
+        assertThat(shared.getUri()).isEqualTo(URL);
+        // the receiving installation knows nothing of the sender's key, so it gets one of its own
+        assertThat(shared.getKey()).isNotEqualTo("key-1");
+    }
+
+    @Test
+    public void isNotReadBackFromTextWithoutAUri() {
+        assertThat(PrefUserDefinedTileProvider.fromShareableText("just some chat text")).isNull();
+        assertThat(PrefUserDefinedTileProvider.fromShareableText(null)).isNull();
+    }
+
+    @Test
+    public void unknownFieldsWouldNotBreakReading() throws Exception {
+        final String json = "{\"key\":\"key-1\",\"name\":\"My map\",\"uri\":\"" + URL + "\"}";
+        assertThat(MAPPER.readValue(json, PrefUserDefinedTileProvider.class).getKey()).isEqualTo("key-1");
+    }
+}


### PR DESCRIPTION
## Description

Replaces the single user-defined tile provider with a list, so several can be configured,
named and switched between. They are managed under *Settings → Map Sources* in the same
way as the log templates: one row per provider with an inline delete icon, and an "add"
button below.

**This supersedes #18494 by @fabiancz.** More on that below - the short version is that
this started from that pull request's review and takes what came out of it.

Details worth calling out:

- **An existing provider carries over.** Somebody who has configured the single
  user-defined provider today will find it in the list after updating, still selected as
  their map source if it was. Nothing is lost and nothing has to be re-entered.
- The list is stored in a preference of its own. As long as that new preference is empty,
  the old one is read instead and its provider shown as the single entry in the list. The
  old preference is never written to or cleared, so downgrading to a version without this
  feature still finds the provider it knows about.
- The entry carried over that way keeps a fixed key, so the tile provider id derived from
  it stays byte-identical to the one used before. That id is what `pref_tileprovider`,
  `pref_previous_tileprovider` and `pref_tileprovider_hidden` store, so none of them needs
  rewriting and the map source selection survives untouched.
- Deriving the id from the map Uri alone is not enough once there is more than one
  provider, since several may share a host - `getId()` returned `<class>:null` for every
  user-defined provider, so they would collide in `TileProviderFactory`.
- Uris are validated and their placeholders normalised, accepting `{x}`, `{y}` and `{z}` in
  either case. A bare `scheme://host` stays valid, as before, and gets the default tile
  path appended.
- Saving validates the Uri by actually fetching one tile from it, so a typo in the host or
  path is caught at once instead of showing up later as a map that stays empty. The check
  is advisory: if it fails, the reason is shown and the provider can still be saved anyway,
  since a server may cover only some regions or be temporarily unavailable.
- **Sharing a provider with somebody else.** Copying one puts a single line of plain text
  on the clipboard - the name and the Uri - which can be sent through any chat client or
  mail. At the other end, pasting it into either field of the add dialog is recognised and
  fills in both. A bare Uri without a name works as well, so a link found on a website can
  be pasted straight in. The text stays readable, so the recipient can see what they are
  about to add before adding it.
- Unit tests cover the url handling, the shareable form and the stored json.

### Screenshots

<img width="320" alt="Screenshot_20260910-140300" src="https://github.com/user-attachments/assets/0c7cbd06-77cb-47ac-81f7-f620c58ecea5" />


<img width="320" alt="Screenshot_20260910-140335" src="https://github.com/user-attachments/assets/b05c4ab2-40a8-474c-8cec-0a95de55f2d6" />


The configured providers appear for both renderers - here with a raster one in use, and
with its VTM counterpart:

<table>
<tr>
<td>
<img width="300" alt="Screenshot_20260910-140425" src="https://github.com/user-attachments/assets/46f3f6ed-c0a5-49b4-ab66-a72c7ea4ca4d" />
</td>
<td>
<img width="300" alt="Screenshot_20260910-140440" src="https://github.com/user-attachments/assets/906b9b38-40f5-49ae-8cd8-3351b47ff56b" />
</td>
</tr>
</table>

## Related issues

- Supersedes #18494 — *Add support for multiple custom online maps*.
- #15884 — *Custom parameters for user-defined tile provider URL*, and #15714, which added
  the single user-defined provider this builds on.

## Additional context

**On superseding #18494.** That pull request asked for exactly this feature and its review
produced the requirements this implementation follows: a new preference with the data
migrated from the old one rather than the old key being reused, individual tile provider
ids, url validation and normalisation with case-insensitive placeholders, unit tests, and
green Checkstyle and lint. @fabiancz also raised the replace-versus-extend question that
was never resolved, and @moving-bits suggested that a combination of the two proposals
would be ideal. This pull request is that combination. The question of how to proceed was
left open on that thread and has had no reply there since 2026-08-31.

None of this is meant to push @fabiancz's work aside - the shape of the settings UI, the
url validation and the idea of unit testing it all come from there, and the credit for
them is his. What this adds on top is the preference migration that keeps older versions
working, the id handling, and the pieces shared with the sibling pull requests below. If
you would rather have #18494 with these changes applied to it instead, that is fine by me
and I am happy to help get it there.

**One of three related map pull requests.** They touch the same corner of the code and were
built to fit together, but none depends on another and each can be merged, changed or
rejected on its own:

- this one, user-defined tile providers (#18586)
- user-defined tile overlays (#18587)
- a grayscale option for the map (#18588)

This one and the overlay pull request share `cgeo.geocaching.unifiedmap.tiles` - url
handling, the shareable text form and the tile check - and a block of shared strings. Those
files are byte-identical in both branches, so whichever is merged first, the other merges
them without a conflict. Ordering of the two settings categories is the one thing that
needs a hand: whichever lands second should place its category after the one already there.

Merging all three will produce conflicts, since they add to the same menu, the same
settings screen and the same string file. Just say the word after each one you take and I
will rebase the remaining ones onto it, so you never have to resolve anything yourself.

A branch with all three merged is available for testing at
`https://github.com/magma1447/cgeo/tree/demo/map-features`.

**Strings**: only `main/src/main/res/values/strings.xml` was touched, no `values-XX/`.

**Testing**: built and run on a Pixel (Android 17, API 37) with several providers
configured. The upgrade from a single provider was verified by reading the id derivation
rather than on the device: the old id was `<class>:null`, because the map Uri is rewritten
to `scheme://host` and has no last path segment, and the migrated entry reproduces exactly
that string. Checkstyle, lint and the unit test suite pass locally.

**AI assistance**: this contribution was written with AI assistance (Claude Opus 5). I have
reviewed and tested everything submitted here.
