### PR TITLE
Add user-defined tile overlays

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1347,6 +1347,32 @@ public class Settings {
         return getString(R.string.pref_userDefinedTileProviderUri, null);
     }
 
+    /** json array holding the configured tile overlays, see cgeo.geocaching.unifiedmap.overlays.TileOverlays */
+    @Nullable
+    public static String getTileOverlaysConfig() {
+        return getString(R.string.pref_tileOverlays, null);
+    }
+
+    public static void setTileOverlaysConfig(@Nullable final String config) {
+        putString(R.string.pref_tileOverlays, config);
+    }
+
+    /** keys of the tile overlays currently switched on in the map view */
+    public static Set<String> getTileOverlaysEnabled() {
+        final Set<String> empty = Collections.emptySet();
+        if (sharedPrefs == null) {
+            return empty;
+        }
+        return sharedPrefs.getStringSet(getKey(R.string.pref_tileOverlaysEnabled), empty);
+    }
+
+    public static void setTileOverlaysEnabled(final Set<String> keys) {
+        if (sharedPrefs == null) {
+            return;
+        }
+        sharedPrefs.edit().putStringSet(getKey(R.string.pref_tileOverlaysEnabled), keys).apply();
+    }
+
     public static void setMapLanguage(@Nullable final String language) {
         putString(R.string.pref_mapLanguage, StringUtils.isBlank(language) ? "" : language);
     }

--- a/main/src/main/java/cgeo/geocaching/settings/TileOverlayPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/TileOverlayPreference.java
@@ -1,0 +1,192 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.Keyboard;
+import cgeo.geocaching.databinding.TileOverlayEditDialogBinding;
+import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlay;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlays;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlShare;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlTester;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlUtils;
+import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+
+import android.content.ClipData;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.LayoutInflater;
+import android.widget.Button;
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.ViewCompat;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import com.google.android.material.button.MaterialButton;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * One configured tile overlay, shown as a row in the settings.
+ *
+ * <p>Follows the layout of the log templates: tapping the row opens the edit dialog, the trailing
+ * icon deletes the entry. Whether an overlay is actually drawn is decided in the map's layer
+ * selection, not here.</p>
+ */
+public class TileOverlayPreference extends Preference {
+
+    private final TileOverlay overlay;
+    private final Runnable onChanged;
+
+    public TileOverlayPreference(final Context context, @NonNull final TileOverlay overlay, @NonNull final Runnable onChanged) {
+        super(context);
+        this.overlay = overlay;
+        this.onChanged = onChanged;
+
+        setKey(overlay.getKey());
+        setTitle(overlay.getDisplayName());
+        setSummary(overlay.getUrl());
+        setIconSpaceReserved(false);
+        setPersistent(false);
+        setWidgetLayoutResource(R.layout.preference_copy_delete_buttons);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        setOnPreferenceClickListener(preference -> {
+            showEditDialog();
+            return true;
+        });
+        final MaterialButton copyButton = (MaterialButton) holder.findViewById(R.id.copyview);
+        copyButton.setIconResource(R.drawable.ic_menu_copy);
+        copyButton.setOnClickListener(v -> {
+            ClipboardUtils.copyToClipboard(TileUrlShare.format(overlay.getName(), overlay.getUrl()));
+            ViewUtils.showShortToast(getContext(), R.string.settings_tileUrl_copied);
+        });
+
+        final MaterialButton button = (MaterialButton) holder.findViewById(R.id.deleteview);
+        button.setIconResource(R.drawable.ic_menu_delete);
+        button.setOnClickListener(v -> SimpleDialog.ofContext(getContext())
+                .setTitle(R.string.settings_tileOverlays_delete)
+                .setMessage(R.string.settings_tileOverlays_delete_confirm, overlay.getDisplayName())
+                .confirm(() -> {
+                    TileOverlays.remove(overlay.getKey());
+                    onChanged.run();
+                }));
+    }
+
+    /** Opens the edit dialog. Also used for new overlays, which are not shown as a row until saved. */
+    public void showEditDialog() {
+        final TileOverlayEditDialogBinding binding = TileOverlayEditDialogBinding.inflate(LayoutInflater.from(getContext()));
+        binding.overlayName.setText(overlay.getName());
+        binding.overlayUrl.setText(overlay.getUrl());
+
+        // start on the name for a new overlay, on the uri when editing an existing one
+        final boolean isNew = TileOverlays.get(overlay.getKey()) == null;
+        Keyboard.show(getContext(), isNew ? binding.overlayName : binding.overlayUrl);
+
+        final AlertDialog dialog = Dialogs.newBuilder(getContext())
+                .setTitle(isNew ? R.string.settings_tileOverlays_add : R.string.settings_tileOverlays_edit)
+                .setView(binding.getRoot())
+                // no listener here: it is attached after show(), so that neither invalid input nor
+                // a test run closes the dialog and discards what was typed
+                .setPositiveButton(android.R.string.ok, null)
+                .setNeutralButton(R.string.settings_tileUrl_test, null)
+                .setNegativeButton(android.R.string.cancel, (d, which) -> d.dismiss())
+                .show();
+
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> save(dialog, binding));
+        dialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(v -> test(dialog, binding));
+        acceptSharedOverlayOnPaste(binding.overlayName, binding);
+        acceptSharedOverlayOnPaste(binding.overlayUrl, binding);
+    }
+
+    /**
+     * Lets a shared overlay be pasted into either field, filling both.
+     *
+     * <p>Hooks the paste action rather than reading the clipboard by itself: from Android 13 on,
+     * reading it unprompted shows a system notice and is restricted to the focused app, while
+     * handling what the user pastes needs no permission and stays silent.</p>
+     */
+    private void acceptSharedOverlayOnPaste(@NonNull final EditText field, @NonNull final TileOverlayEditDialogBinding binding) {
+        ViewCompat.setOnReceiveContentListener(field, new String[]{"text/*"}, (view, payload) -> {
+            final ClipData clip = payload.getClip();
+            final CharSequence text = clip.getItemCount() > 0 ? clip.getItemAt(0).getText() : null;
+            final String[] shared = TileUrlShare.parse(text == null ? null : text.toString());
+            if (shared == null) {
+                // not one of ours, let the field handle the paste as usual
+                return payload;
+            }
+            // only fill a name that the paste actually carries, and never replace one the user
+            // has already typed
+            if (!shared[0].isEmpty() && StringUtils.isBlank(binding.overlayName.getText())) {
+                binding.overlayName.setText(shared[0]);
+            }
+            binding.overlayUrl.setText(shared[1]);
+            binding.overlayUrlFrame.setError(null);
+            return null; // consumed
+        });
+    }
+
+    private void save(@NonNull final AlertDialog dialog, @NonNull final TileOverlayEditDialogBinding binding) {
+        // a url without placeholders gets the default tile path, as tile providers have always
+        // done, so that both features accept the same input
+        final String normalized = TileUrlUtils.normalize(String.valueOf(binding.overlayUrl.getText()));
+        final String url = normalized == null ? null : TileUrlUtils.withDefaultTilePath(normalized);
+        if (url == null) {
+            binding.overlayUrlFrame.setError(LocalizationUtils.getString(R.string.settings_tileUrl_invalid));
+            return;
+        }
+        binding.overlayUrlFrame.setError(null);
+        store(dialog, binding, url);
+    }
+
+    /**
+     * Fetches one real tile from the url in the dialog, on request.
+     *
+     * <p>A syntactically valid url can still be wrong, which shows up only as an overlay that
+     * draws nothing. Saving deliberately does not wait for this: it needs the network, and an
+     * overlay may well be typed in somewhere without one.</p>
+     */
+    private void test(@NonNull final AlertDialog dialog, @NonNull final TileOverlayEditDialogBinding binding) {
+        final String normalized = TileUrlUtils.normalize(String.valueOf(binding.overlayUrl.getText()));
+        final String url = normalized == null ? null : TileUrlUtils.withDefaultTilePath(normalized);
+        if (url == null) {
+            binding.overlayUrlFrame.setError(LocalizationUtils.getString(R.string.settings_tileUrl_invalid));
+            return;
+        }
+        binding.overlayUrlFrame.setError(null);
+
+        final Button testButton = dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
+        testButton.setEnabled(false);
+        binding.overlayUrlFrame.setHelperText(LocalizationUtils.getString(R.string.settings_tileUrl_testing));
+        AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler,
+                () -> TileUrlTester.test(url),
+                error -> {
+                    testButton.setEnabled(true);
+                    binding.overlayUrlFrame.setHelperText(null);
+                    if (error == null) {
+                        ViewUtils.showShortToast(getContext(), R.string.settings_tileUrl_testok);
+                    } else {
+                        SimpleDialog.ofContext(getContext())
+                                .setTitle(R.string.settings_tileUrl_testfailed_title)
+                                .setMessage(R.string.settings_tileUrl_testfailed, error)
+                                .show();
+                    }
+                });
+    }
+
+    private void store(@NonNull final AlertDialog dialog, @NonNull final TileOverlayEditDialogBinding binding, @NonNull final String url) {
+        TileOverlays.addOrUpdate(overlay
+                .withName(String.valueOf(binding.overlayName.getText()).trim())
+                .withUrl(url));
+        dialog.dismiss();
+        onChanged.run();
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
@@ -4,6 +4,9 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.downloader.DownloadSelectorActivity;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
+import cgeo.geocaching.settings.TileOverlayPreference;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlay;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlays;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.LocalizationUtils;
@@ -19,18 +22,23 @@ import android.os.Bundle;
 
 import androidx.preference.ListPreference;
 import androidx.preference.MultiSelectListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
 
 import java.util.HashMap;
 
 public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
     private ListPreference prefTileProvicers;
+    private PreferenceCategory tileOverlaysCategory;
 
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         initPreferences(R.xml.preferences_map_sources, rootKey);
         prefTileProvicers = findPreference(getString(R.string.pref_tileprovider));
+        tileOverlaysCategory = findPreference(getString(R.string.preference_category_map_tileoverlays));
 
         initMapSourcePreference();
+        recreateTileOverlayPreferences();
 
         final MultiSelectListPreference hideTileprovidersPref = findPreference(getString(R.string.pref_tileprovider_hidden));
         // new unified map providers
@@ -113,6 +121,28 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
             return true;
         });
 
+    }
+
+    /** (Re-)builds the rows of the user-defined tile overlays, plus the trailing "add" button */
+    private void recreateTileOverlayPreferences() {
+        tileOverlaysCategory.removeAll();
+        for (TileOverlay overlay : TileOverlays.getAll()) {
+            tileOverlaysCategory.addPreference(new TileOverlayPreference(requireContext(), overlay, this::recreateTileOverlayPreferences));
+        }
+        tileOverlaysCategory.addPreference(createTileOverlayPreferenceAddNew());
+    }
+
+    private Preference createTileOverlayPreferenceAddNew() {
+        final Preference preference = new Preference(requireContext());
+        preference.setTitle(R.string.settings_tileOverlays_add);
+        preference.setLayoutResource(R.layout.preference_button);
+        preference.setIconSpaceReserved(false);
+        preference.setPersistent(false);
+        preference.setOnPreferenceClickListener(pref -> {
+            new TileOverlayPreference(requireContext(), TileOverlay.create("", ""), this::recreateTileOverlayPreferences).showEditDialog();
+            return true;
+        });
+        return preference;
     }
 
     private void setUserDefinedTileProviderUriSummary(final String uri) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/LayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/LayerHelper.java
@@ -8,21 +8,22 @@ public class LayerHelper {
     public static final int ZINDEX_CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM = 101;
     public static final int ZINDEX_CACHE_WAYPOINT_HIGHLIGHTER_MARKER = 100;
 
-    public static final int ZINDEX_ELEVATIONCHARTMARKERPOSITION = 16;
-    public static final int ZINDEX_POSITION = 15;
-    public static final int ZINDEX_POSITION_ELEVATION = 14;
-    public static final int ZINDEX_SEARCHCENTER = 13;
-    public static final int ZINDEX_SCALEBAR = 12;   // OSM only
-    public static final int ZINDEX_GEOCACHE = 11;
-    public static final int ZINDEX_WAYPOINT = 10;
-    public static final int ZINDEX_COORD_POINT = 9;
-    public static final int ZINDEX_DIRECTION_LINE = 8;
-    public static final int ZINDEX_TRACK_ROUTE = 7;
-    public static final int ZINDEX_POSITION_ACCURACY_CIRCLE = 6;
-    public static final int ZINDEX_HISTORY = 5;
-    public static final int ZINDEX_CIRCLE = 4;
-    public static final int ZINDEX_LABELS = 3;      // OSM only
-    public static final int ZINDEX_BUILDINGS = 2;   // OSM only
+    public static final int ZINDEX_ELEVATIONCHARTMARKERPOSITION = 17;
+    public static final int ZINDEX_POSITION = 16;
+    public static final int ZINDEX_POSITION_ELEVATION = 15;
+    public static final int ZINDEX_SEARCHCENTER = 14;
+    public static final int ZINDEX_SCALEBAR = 13;   // OSM only
+    public static final int ZINDEX_GEOCACHE = 12;
+    public static final int ZINDEX_WAYPOINT = 11;
+    public static final int ZINDEX_COORD_POINT = 10;
+    public static final int ZINDEX_DIRECTION_LINE = 9;
+    public static final int ZINDEX_TRACK_ROUTE = 8;
+    public static final int ZINDEX_POSITION_ACCURACY_CIRCLE = 7;
+    public static final int ZINDEX_HISTORY = 6;
+    public static final int ZINDEX_CIRCLE = 5;
+    public static final int ZINDEX_LABELS = 4;      // OSM only
+    public static final int ZINDEX_TILE_OVERLAY = 3; // user-defined tile overlays, drawn above the map but below its labels
+    public static final int ZINDEX_BUILDINGS = 2;   // OSM only, shared with the hillshading layer
     public static final int ZINDEX_BASEMAP = 1;     // this is hard-coded in VTM:Map.java
 
     private LayerHelper() {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -64,6 +64,8 @@ import cgeo.geocaching.unifiedmap.layers.PositionHistoryLayer;
 import cgeo.geocaching.unifiedmap.layers.PositionLayer;
 import cgeo.geocaching.unifiedmap.layers.TracksLayer;
 import cgeo.geocaching.unifiedmap.layers.WherigoLayer;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlayMenuHelper;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlays;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.ActionBarUtils;
@@ -1079,6 +1081,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 menu.inflate(R.menu.map_mapview);
                 DownloaderUtils.addManageOfflineDataMenu(this, menu.getMenu().findItem(R.id.menu_manage_offline_data));
                 TileProviderFactory.addMapviewMenuItems(this, menu);
+                TileOverlayMenuHelper.addMenuItems(menu.getMenu());
                 menu.setOnMenuItemClickListener(this::onOptionsItemSelected);
                 menu.setForceShowIcon(true);
                 menu.show();
@@ -1099,6 +1102,13 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         } else if (id == R.id.menu_backgroundmap) {
             Settings.setMapBackgroundMapLayer(!Settings.getMapBackgroundMapLayer());
             item.setChecked(Settings.getMapBackgroundMapLayer());
+            changeMapSource(mapFragment.currentTileProvider);
+        } else if (TileOverlayMenuHelper.getOverlayKey(id) != null) {
+            // checked before the dynamic block below, so that an overlay can never be shadowed by a map source or language id
+            final String overlayKey = TileOverlayMenuHelper.getOverlayKey(id);
+            final boolean enabled = !TileOverlays.isEnabled(overlayKey);
+            TileOverlays.setEnabled(overlayKey, enabled);
+            item.setChecked(enabled);
             changeMapSource(mapFragment.currentTileProvider);
         } else { // dynamic submenus: Map language, Map source
             final String language = TileProviderFactory.getLanguage(id);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.unifiedmap.AbstractMapFragment;
 import cgeo.geocaching.unifiedmap.UnifiedMapActivity;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GoogleV2GeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlayLayerHelper;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractGoogleTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
@@ -30,6 +31,9 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -38,9 +42,12 @@ import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.TileOverlay;
+import com.google.android.gms.maps.model.TileOverlayOptions;
 
 public class GoogleMapsFragment extends AbstractMapFragment implements OnMapReadyCallback {
     private GoogleMap mMap;
+    private final List<TileOverlay> overlays = new ArrayList<>();
     private final GoogleMapController mapController = new GoogleMapController();
     private GestureDetector gestureDetector;
 
@@ -171,8 +178,30 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
         final boolean needsUpdate = super.setTileSource(newSource, force);
         if (needsUpdate) {
             ((AbstractGoogleTileProvider) newSource).setMapType(mMap);
+            addTileOverlays();
         }
         return needsUpdate;
+    }
+
+    /**
+     * (Re-)creates the user-defined tile overlays. Existing ones are removed first, as this is
+     * called on every tile source change and they must not stack up.
+     */
+    private void addTileOverlays() {
+        removeTileOverlays();
+        for (TileOverlayOptions options : TileOverlayLayerHelper.getTileLayersGoogle()) {
+            final TileOverlay overlay = mMap.addTileOverlay(options);
+            if (overlay != null) {
+                overlays.add(overlay);
+            }
+        }
+    }
+
+    private void removeTileOverlays() {
+        for (TileOverlay overlay : overlays) {
+            overlay.remove();
+        }
+        overlays.clear();
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -12,6 +12,7 @@ import cgeo.geocaching.unifiedmap.UnifiedMapActivity;
 import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeV6GeoItemLayer;
 import cgeo.geocaching.unifiedmap.layers.MBTilesLayerHelper;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlayLayerHelper;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeOnlineTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
@@ -33,7 +34,11 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.text.HtmlCompat;
 import androidx.core.util.Pair;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.mapsforge.core.graphics.Canvas;
@@ -50,6 +55,7 @@ import org.mapsforge.map.android.util.AndroidUtil;
 import org.mapsforge.map.android.view.MapView;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.download.TileDownloadLayer;
 import org.mapsforge.map.model.Model;
 import org.mapsforge.map.model.common.Observer;
 import org.mapsforge.map.view.InputListener;
@@ -63,6 +69,8 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
     private View mapAttribution;
     private boolean doReapplyTheme = false;
     private MapEventsReceiver mapEventsReceiver = null;
+    private final List<TileDownloadLayer> overlayLayers = new ArrayList<>();
+    private final Map<String, TileCache> overlayCaches = new HashMap<>();
 
     public MapsforgeFragment() {
         super(R.layout.unifiedmap_mapsforge_fragment);
@@ -135,6 +143,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
                 mMapView.getLayerManager().getLayers().add(backgroundMap);
             }
         }
+        addTileOverlays();
 
         if (this.mapAttribution != null) {
             this.mapAttribution.setOnClickListener(v -> displayMapAttribution());
@@ -194,11 +203,13 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
         if (currentTileProvider instanceof AbstractMapsforgeOnlineTileProvider) {
             ((AbstractMapsforgeOnlineTileProvider) currentTileProvider).addTileLayer(this, mMapView);
         }
+        addTileOverlays();
     }
 
     @Override
     public void onPause() {
         // mMapView.onPause();
+        removeTileOverlays();
         if (currentTileProvider instanceof AbstractMapsforgeOnlineTileProvider) {
             ((AbstractMapsforgeOnlineTileProvider) currentTileProvider).removeTileLayer(mMapView);
         }
@@ -207,9 +218,42 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
         mMapView.getModel().mapViewPosition.removeObserver(this);
     }
 
+    /**
+     * (Re-)creates the layers for the enabled tile overlays. Existing ones are removed first, as
+     * this is called both on tile source changes and on resume and layers must not stack up.
+     */
+    private void addTileOverlays() {
+        removeTileOverlays();
+        for (TileDownloadLayer overlay : TileOverlayLayerHelper.getTileLayersMapsforge(requireContext(), mMapView, overlayCaches)) {
+            // appended, so that overlays end up above the base map, which is inserted at index 0
+            mMapView.getLayerManager().getLayers().add(overlay);
+            overlay.onResume();
+            overlayLayers.add(overlay);
+        }
+    }
+
+    /** Tear down the overlay layers but keep their caches, mirroring AbstractMapsforgeTileProvider.removeTileLayer */
+    private void removeTileOverlays() {
+        for (TileDownloadLayer overlay : overlayLayers) {
+            overlay.onPause();
+            mMapView.getLayerManager().getLayers().remove(overlay);
+            overlay.onDestroy(); // without this the layer's JobQueue keeps holding mapViewPosition
+        }
+        overlayLayers.clear();
+    }
+
+    private void destroyTileOverlayCaches() {
+        for (TileCache cache : overlayCaches.values()) {
+            cache.destroy();
+        }
+        overlayCaches.clear();
+    }
+
     @Override
     public void onDestroyView() {
 //        themeHelper.disposeTheme();
+        removeTileOverlays();
+        destroyTileOverlayCaches();
         mapEventsReceiver = null;
         mMapView.destroyAll();
         super.onDestroyView();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeVtmGeoItemLayer;
 import cgeo.geocaching.unifiedmap.layers.HillShadingLayerHelper;
 import cgeo.geocaching.unifiedmap.layers.MBTilesLayerHelper;
+import cgeo.geocaching.unifiedmap.overlays.TileOverlayLayerHelper;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeVTMTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
@@ -140,6 +141,9 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         }
         if (Settings.getMapShadingShowLayer()) {
             addLayer(2, HillShadingLayerHelper.getBitmapTileLayer(getContext(), mMap));
+        }
+        for (BitmapTileLayer overlay : TileOverlayLayerHelper.getTileLayersVTM(mMap)) {
+            addLayer(LayerHelper.ZINDEX_TILE_OVERLAY, overlay);
         }
 
         if (this.mapAttribution != null) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlay.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlay.java
@@ -1,0 +1,120 @@
+package cgeo.geocaching.unifiedmap.overlays;
+
+import cgeo.geocaching.unifiedmap.tiles.TileUrlUtils;
+import cgeo.geocaching.utils.JsonUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A user-defined tile overlay: a raster tile source drawn on top of the current map source.
+ *
+ * <p>Unlike a tile provider an overlay does not replace the base map, so several overlays can be
+ * active at the same time. Tiles are expected to be transparent where they carry no information.</p>
+ */
+public class TileOverlay {
+
+    private static final String JSON_KEY = "key";
+    private static final String JSON_NAME = "name";
+    private static final String JSON_URL = "url";
+
+    /** stable identifier, used to remember which overlays are switched on */
+    private final String key;
+    private final String name;
+    private final String url;
+
+    public TileOverlay(@NonNull final String key, @NonNull final String name, @NonNull final String url) {
+        this.key = key;
+        this.name = name;
+        this.url = url;
+    }
+
+    /** creates a new overlay with a freshly generated key */
+    @NonNull
+    public static TileOverlay create(@NonNull final String name, @NonNull final String url) {
+        return new TileOverlay(UUID.randomUUID().toString(), name, url);
+    }
+
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    /** the name as entered by the user, which may be empty */
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * The name to show in the settings and in the map's layer selection: the user-given name, or
+     * the host of the url when no name was entered.
+     *
+     * <p>Derived on read rather than stored, so that correcting a typo in the url also corrects a
+     * name that was never explicitly set.</p>
+     */
+    @NonNull
+    public String getDisplayName() {
+        if (StringUtils.isNotBlank(name)) {
+            return name;
+        }
+        final String host = TileUrlUtils.host(url);
+        return host != null ? host : url;
+    }
+
+    /** the normalised XYZ url template, see {@link TileUrlUtils} */
+    @NonNull
+    public String getUrl() {
+        return url;
+    }
+
+    @NonNull
+    public TileOverlay withName(@NonNull final String newName) {
+        return new TileOverlay(key, newName, url);
+    }
+
+    @NonNull
+    public TileOverlay withUrl(@NonNull final String newUrl) {
+        return new TileOverlay(key, name, newUrl);
+    }
+
+    @NonNull
+    public ObjectNode toJson() {
+        final ObjectNode node = JsonUtils.createObjectNode();
+        JsonUtils.setText(node, JSON_KEY, key);
+        JsonUtils.setText(node, JSON_NAME, name);
+        JsonUtils.setText(node, JSON_URL, url);
+        return node;
+    }
+
+    /**
+     * Reads an overlay from its json representation.
+     *
+     * @return the overlay, or {@code null} if the node is incomplete or holds an unusable url
+     */
+    @Nullable
+    public static TileOverlay fromJson(@Nullable final JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+        final String key = JsonUtils.getText(node, JSON_KEY, null);
+        final String name = JsonUtils.getText(node, JSON_NAME, null);
+        final String url = TileUrlUtils.normalize(JsonUtils.getText(node, JSON_URL, null));
+        if (StringUtils.isBlank(key) || url == null) {
+            return null;
+        }
+        return new TileOverlay(key, StringUtils.defaultString(name), url);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return getDisplayName() + " (" + url + ")";
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlayLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlayLayerHelper.java
@@ -1,0 +1,179 @@
+package cgeo.geocaching.unifiedmap.overlays;
+
+import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.unifiedmap.tiles.TileUrlUtils;
+import cgeo.geocaching.utils.Log;
+
+import android.content.Context;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.android.gms.maps.model.TileOverlayOptions;
+import com.google.android.gms.maps.model.UrlTileProvider;
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.android.util.AndroidUtil;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.download.TileDownloadLayer;
+import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
+import org.mapsforge.map.view.MapView;
+import org.oscim.layers.tile.bitmap.BitmapTileLayer;
+import org.oscim.map.Map;
+import org.oscim.tiling.source.OkHttpEngine;
+import org.oscim.tiling.source.bitmap.BitmapTileSource;
+
+/**
+ * Builds the renderer specific layers for the user-defined tile overlays.
+ *
+ * <p>Overlays are drawn on top of the current map source and are expected to deliver tiles that are
+ * transparent where they carry no data, so no additional alpha blending is applied.</p>
+ */
+public final class TileOverlayLayerHelper {
+
+    /** matches the range used by the user-defined tile providers */
+    private static final int ZOOM_MIN = 2;
+    private static final int ZOOM_MAX = 18;
+
+    /** side length of a tile in pixels, as the XYZ scheme defines it */
+    private static final int TILE_SIZE = 256;
+
+    private static final int VTM_CACHE_SIZE = 20 * 1024 * 1024;
+
+    private TileOverlayLayerHelper() {
+        //no instance
+    }
+
+    /**
+     * Returns a TileDownloadLayer for every enabled overlay (Mapsforge variant).
+     *
+     * @param cacheByKey caches per overlay key, owned by the caller and reused across rebuilds.
+     *                   Each overlay needs a cache of its own so that tiles of different overlays
+     *                   cannot collide, but creating them anew on every rebuild would leak them.
+     */
+    public static List<TileDownloadLayer> getTileLayersMapsforge(final Context context, final MapView mapView, final java.util.Map<String, TileCache> cacheByKey) {
+        final List<TileOverlay> overlays = TileOverlays.getEnabled();
+        if (overlays.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final List<TileDownloadLayer> result = new ArrayList<>();
+        for (TileOverlay overlay : overlays) {
+            final URL sample = toUrl(overlay);
+            if (sample == null) {
+                continue;
+            }
+            final AbstractTileSource tileSource = new AbstractTileSource(new String[]{sample.getHost()}, portOf(sample)) {
+                @Override
+                public int getParallelRequestsLimit() {
+                    return 8;
+                }
+
+                @Override
+                public URL getTileUrl(final Tile tile) throws MalformedURLException {
+                    return new URL(TileUrlUtils.forTile(overlay.getUrl(), tile.zoomLevel, tile.tileX, tile.tileY));
+                }
+
+                @Override
+                public byte getZoomLevelMax() {
+                    return (byte) ZOOM_MAX;
+                }
+
+                @Override
+                public byte getZoomLevelMin() {
+                    return (byte) ZOOM_MIN;
+                }
+
+                @Override
+                public boolean hasAlpha() {
+                    // overlays must keep their transparency, otherwise they would hide the map below
+                    return true;
+                }
+            };
+            tileSource.setUserAgent("cgeo");
+
+            final TileCache tileCache = cacheByKey.computeIfAbsent(overlay.getKey(), key ->
+                    AndroidUtil.createTileCache(context, "overlaycache-" + key,
+                            mapView.getModel().displayModel.getTileSize(), 2f, mapView.getModel().frameBufferModel.getOverdrawFactor()));
+            result.add(new TileDownloadLayer(tileCache, mapView.getModel().mapViewPosition, tileSource, AndroidGraphicFactory.INSTANCE));
+        }
+        return result;
+    }
+
+    /** returns a BitmapTileLayer for every enabled overlay (VTM variant) */
+    public static List<BitmapTileLayer> getTileLayersVTM(final Map map) {
+        final List<TileOverlay> overlays = TileOverlays.getEnabled();
+        if (overlays.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final List<BitmapTileLayer> result = new ArrayList<>();
+        for (TileOverlay overlay : overlays) {
+            final String[] parts = TileUrlUtils.split(overlay.getUrl());
+            if (parts == null) {
+                continue;
+            }
+            final OkHttpClient.Builder httpBuilder = new OkHttpClient.Builder();
+            httpBuilder.cache(new Cache(new File(LocalStorage.getExternalPrivateCgeoDirectory(), "overlaytiles"), VTM_CACHE_SIZE));
+            final BitmapTileSource tileSource = BitmapTileSource.builder()
+                    .url(parts[0])
+                    .tilePath(parts[1])
+                    .zoomMax(ZOOM_MAX)
+                    .zoomMin(ZOOM_MIN)
+                    .build();
+            tileSource.setHttpEngine(new OkHttpEngine.OkHttpFactory(httpBuilder));
+            tileSource.setHttpRequestHeaders(Collections.singletonMap("User-Agent", "cgeo-android"));
+            result.add(new BitmapTileLayer(map, tileSource));
+        }
+        return result;
+    }
+
+    /** returns a TileOverlayOptions for every enabled overlay (Google Maps variant) */
+    public static List<TileOverlayOptions> getTileLayersGoogle() {
+        final List<TileOverlay> overlays = TileOverlays.getEnabled();
+        if (overlays.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final List<TileOverlayOptions> result = new ArrayList<>();
+        for (TileOverlay overlay : overlays) {
+            result.add(new TileOverlayOptions().tileProvider(new UrlTileProvider(TILE_SIZE, TILE_SIZE) {
+                @Override
+                public URL getTileUrl(final int x, final int y, final int zoom) {
+                    if (zoom < ZOOM_MIN || zoom > ZOOM_MAX) {
+                        return null; // nothing to draw outside the range the overlay declares
+                    }
+                    try {
+                        return new URL(TileUrlUtils.forTile(overlay.getUrl(), zoom, x, y));
+                    } catch (final MalformedURLException e) {
+                        Log.w("Cannot use tile overlay '" + overlay.getName() + "': " + e.getMessage());
+                        return null;
+                    }
+                }
+            }).transparency(0f).fadeIn(false));
+        }
+        return result;
+    }
+
+    private static URL toUrl(final TileOverlay overlay) {
+        try {
+            return new URL(overlay.getUrl());
+        } catch (final MalformedURLException e) {
+            Log.w("Cannot use tile overlay '" + overlay.getName() + "': " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static int portOf(final URL url) {
+        if (url.getPort() > 0) {
+            return url.getPort();
+        }
+        return "http".equals(url.getProtocol()) ? 80 : 443;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlayMenuHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlayMenuHelper.java
@@ -1,0 +1,67 @@
+package cgeo.geocaching.unifiedmap.overlays;
+
+import cgeo.geocaching.R;
+
+import android.view.Menu;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds the configured tile overlays to the map view popup menu.
+ *
+ * <p>Overlays are independent of each other, so unlike the map sources they are not part of a
+ * single-choice group. Menu ids are handed out from a band of their own, well away from the ids
+ * the tile providers use, and are resolved back to overlay keys via {@link #getOverlayKey(int)}.</p>
+ */
+public final class TileOverlayMenuHelper {
+
+    /** tile providers count up from -1000000000, so this band cannot be reached by them */
+    private static final int MENU_ID_BASE = -1500000000;
+
+    /**
+     * Menu items are sorted by this value, not by their group - the groups only control dividers
+     * and checkable behaviour. The map sources count up from 0 and the offline map entries
+     * start at 90, so this keeps the overlays after all map sources - which matters because
+     * those are a single-choice group and must not be split by the overlay checkboxes.
+     */
+    private static final int MENU_ORDER = 50;
+
+    private static final Map<Integer, String> menuIdToOverlayKey = new HashMap<>();
+
+    private TileOverlayMenuHelper() {
+        //no instance
+    }
+
+    public static void addMenuItems(@NonNull final Menu menu) {
+        synchronized (menuIdToOverlayKey) {
+            menuIdToOverlayKey.clear();
+
+            final List<TileOverlay> overlays = TileOverlays.getAll();
+            for (int i = 0; i < overlays.size(); i++) {
+                final TileOverlay overlay = overlays.get(i);
+                final int menuId = MENU_ID_BASE + i;
+                menuIdToOverlayKey.put(menuId, overlay.getKey());
+                menu.add(R.id.menu_group_tile_overlays, menuId, MENU_ORDER, overlay.getDisplayName())
+                        .setCheckable(true)
+                        .setChecked(TileOverlays.isEnabled(overlay.getKey()));
+            }
+        }
+    }
+
+    /**
+     * Resolves a menu item id back to the overlay it stands for.
+     *
+     * @return the overlay key, or {@code null} if the id does not belong to an overlay
+     */
+    @Nullable
+    public static String getOverlayKey(final int menuId) {
+        synchronized (menuIdToOverlayKey) {
+            return menuIdToOverlayKey.get(menuId);
+        }
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlays.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/overlays/TileOverlays.java
@@ -1,0 +1,132 @@
+package cgeo.geocaching.unifiedmap.overlays;
+
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.JsonUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+/**
+ * Storage of the user-defined tile overlays.
+ *
+ * <p>The configured overlays live in a single preference holding a json array, while the subset
+ * currently switched on in the map view is kept in a separate string set of overlay keys. Keeping
+ * the two apart means toggling an overlay on the map never rewrites the configuration itself, and
+ * mirrors how hidden tile providers are stored.</p>
+ */
+public final class TileOverlays {
+
+    private TileOverlays() {
+        //no instance
+    }
+
+    /** all configured overlays, in the order the user arranged them */
+    @NonNull
+    public static List<TileOverlay> getAll() {
+        final List<TileOverlay> result = new ArrayList<>();
+        final JsonNode root = JsonUtils.stringToNode(Settings.getTileOverlaysConfig(), true);
+        if (root == null || !root.isArray()) {
+            return result;
+        }
+        for (JsonNode node : root) {
+            final TileOverlay overlay = TileOverlay.fromJson(node);
+            if (overlay != null) {
+                result.add(overlay);
+            }
+        }
+        return result;
+    }
+
+    public static void save(@NonNull final List<TileOverlay> overlays) {
+        final ArrayNode array = JsonUtils.createArrayNode();
+        for (TileOverlay overlay : overlays) {
+            array.add(overlay.toJson());
+        }
+        Settings.setTileOverlaysConfig(JsonUtils.nodeToString(array, true));
+
+        // drop enabled-flags of overlays that no longer exist
+        final Set<String> stillKnown = new HashSet<>();
+        for (TileOverlay overlay : overlays) {
+            stillKnown.add(overlay.getKey());
+        }
+        final Set<String> enabled = new HashSet<>(Settings.getTileOverlaysEnabled());
+        if (enabled.retainAll(stillKnown)) {
+            Settings.setTileOverlaysEnabled(enabled);
+        }
+    }
+
+    /** the overlays that should currently be drawn, in configuration order */
+    @NonNull
+    public static List<TileOverlay> getEnabled() {
+        final Set<String> enabled = Settings.getTileOverlaysEnabled();
+        if (enabled.isEmpty()) {
+            return Collections.emptyList();
+        }
+        final List<TileOverlay> result = new ArrayList<>();
+        for (TileOverlay overlay : getAll()) {
+            if (enabled.contains(overlay.getKey())) {
+                result.add(overlay);
+            }
+        }
+        return result;
+    }
+
+    public static boolean isEnabled(@NonNull final String key) {
+        return Settings.getTileOverlaysEnabled().contains(key);
+    }
+
+    public static void setEnabled(@NonNull final String key, final boolean enabled) {
+        final Set<String> current = new HashSet<>(Settings.getTileOverlaysEnabled());
+        final boolean changed = enabled ? current.add(key) : current.remove(key);
+        if (changed) {
+            Settings.setTileOverlaysEnabled(current);
+        }
+    }
+
+    /** adds a new overlay, or replaces the existing one carrying the same key */
+    public static void addOrUpdate(@NonNull final TileOverlay overlay) {
+        final List<TileOverlay> overlays = getAll();
+        for (int i = 0; i < overlays.size(); i++) {
+            if (overlays.get(i).getKey().equals(overlay.getKey())) {
+                overlays.set(i, overlay);
+                save(overlays);
+                return;
+            }
+        }
+        overlays.add(overlay);
+        save(overlays);
+    }
+
+    public static void remove(@NonNull final String key) {
+        final List<TileOverlay> overlays = getAll();
+        boolean removed = false;
+        for (int i = overlays.size() - 1; i >= 0; i--) {
+            if (overlays.get(i).getKey().equals(key)) {
+                overlays.remove(i);
+                removed = true;
+            }
+        }
+        if (removed) {
+            save(overlays);
+        }
+    }
+
+    @Nullable
+    public static TileOverlay get(@NonNull final String key) {
+        for (TileOverlay overlay : getAll()) {
+            if (overlay.getKey().equals(key)) {
+                return overlay;
+            }
+        }
+        return null;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tiles/TileUrlShare.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tiles/TileUrlShare.java
@@ -1,0 +1,74 @@
+package cgeo.geocaching.unifiedmap.tiles;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * The text form of a single configured tile source, for passing one to somebody else through a
+ * chat message.
+ *
+ * <p>Deliberately plain text rather than json: several chat clients replace straight quotes with
+ * typographic ones, which would silently break json at the receiving end, and a plain line stays
+ * readable to whoever has to decide whether to trust the link.</p>
+ */
+public final class TileUrlShare {
+
+    private static final char SEPARATOR = ';';
+
+    private TileUrlShare() {
+        //no instance
+    }
+
+    /** the shareable form of an entry: {@code name;uri}, or just the uri if it has no name */
+    @NonNull
+    public static String format(@NonNull final String name, @NonNull final String url) {
+        return StringUtils.isBlank(name) ? url : name.trim() + SEPARATOR + url;
+    }
+
+    /**
+     * Reads a shared entry back.
+     *
+     * <p>The split happens at the start of the uri, not at the separator, so that neither side has
+     * to avoid a ';'. A name may contain one, and so may a url - it is a legal query sub-delimiter,
+     * as in {@code https://example.com/{z}/{x}/{y}.png?a=1;b=2}. Splitting on the separator would
+     * mangle both cases; looking for the scheme instead needs no escaping at all.</p>
+     *
+     * @return the name (possibly empty) and the normalised uri, or {@code null} if there is no
+     *         usable uri in the text
+     */
+    @Nullable
+    public static String[] parse(@Nullable final String text) {
+        final String trimmed = StringUtils.trimToNull(text);
+        if (trimmed == null) {
+            return null;
+        }
+
+        final int uriStart = indexOfScheme(trimmed);
+        if (uriStart < 0) {
+            return null;
+        }
+
+        final String url = TileUrlUtils.normalize(trimmed.substring(uriStart));
+        if (url == null) {
+            return null;
+        }
+        final String name = StringUtils.stripEnd(trimmed.substring(0, uriStart).trim(), String.valueOf(SEPARATOR)).trim();
+        return new String[]{name, url};
+    }
+
+    /** position of the first {@code http://} or {@code https://} in the text, or -1 */
+    private static int indexOfScheme(@NonNull final String text) {
+        final String lower = text.toLowerCase(Locale.US);
+        final int http = lower.indexOf("http://");
+        final int https = lower.indexOf("https://");
+        if (http < 0) {
+            return https;
+        }
+        return https < 0 ? http : Math.min(http, https);
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tiles/TileUrlTester.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tiles/TileUrlTester.java
@@ -1,0 +1,102 @@
+package cgeo.geocaching.unifiedmap.tiles;
+
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.network.Network;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import okhttp3.Response;
+import org.mapsforge.core.util.MercatorProjection;
+
+/**
+ * Checks that a tile url template actually serves tiles.
+ *
+ * <p>Syntax validation alone cannot catch a wrong path, which simply yields 404s and a layer
+ * that silently draws nothing. This fetches one real tile before the overlay is stored.</p>
+ */
+public final class TileUrlTester {
+
+    /** zoom to test at: low enough to exist in sparse overlays, high enough to be a real request */
+    private static final byte TEST_ZOOM = 12;
+
+    private static final int TILE_SIZE = 256;
+
+    /**
+     * Geocaching HQ (GCK25B, N 47 38.938 W 122 20.887).
+     *
+     * <p>A fallback is needed because the test has to pick a real place to request a tile for, and
+     * on a fresh installation no map position has been stored yet - that preference defaults to
+     * 0/0, which is open ocean in the Gulf of Guinea, where nearly every sparse tile source legitimately has
+     * nothing to serve. The check would then fail for perfectly good urls. Any populated place
+     * would do; this one is at least on topic.</p>
+     */
+    private static final Geopoint DEFAULT_POSITION = new Geopoint(47.6489667, -122.3481167);
+
+    private TileUrlTester() {
+        //no instance
+    }
+
+    /**
+     * Fetches a single tile, from around the last map position so that the test hits an area the
+     * user actually looks at rather than a low zoom level many overlays do not serve at all.
+     *
+     * <p>Blocking - must not be called on the UI thread.</p>
+     *
+     * @return {@code null} if a tile was served, otherwise a short description of what went wrong
+     */
+    @Nullable
+    public static String test(@NonNull final String urlTemplate) {
+        final String url = buildTileUrl(urlTemplate);
+        if (url == null) {
+            return "invalid url";
+        }
+
+        try {
+            final Response response = Network.getRequest(url).blockingGet();
+            try {
+                if (!response.isSuccessful()) {
+                    return "HTTP " + response.code();
+                }
+                // Anything the server actually answers with is accepted: a tile that looks empty
+                // may just mean there is no data here, and some servers serve images as
+                // application/octet-stream. Only a textual response is rejected, which is how an
+                // error page or a captive portal answering 200 gives itself away.
+                final String contentType = response.header("Content-Type");
+                return contentType != null && contentType.startsWith("text/") ? contentType : null;
+            } finally {
+                response.close();
+            }
+        } catch (final RuntimeException e) {
+            // blockingGet wraps any IOException from the request into a RuntimeException
+            Log.d("Tile url test failed for '" + url + "': " + e);
+            return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+        }
+    }
+
+    /**
+     * Where to fetch the test tile from: the last map position, which is the area the user
+     * actually looks at, or {@link #DEFAULT_POSITION} when there is none yet.
+     */
+    @NonNull
+    private static Geopoint testPosition() {
+        final Geopoint mapCenter = Settings.getMapCenter();
+        return mapCenter.getLatitudeE6() == 0 && mapCenter.getLongitudeE6() == 0 ? DEFAULT_POSITION : mapCenter;
+    }
+
+    /** resolves the template for a tile at the last known map position */
+    @Nullable
+    private static String buildTileUrl(@NonNull final String urlTemplate) {
+        if (!TileUrlUtils.isValid(urlTemplate)) {
+            return null;
+        }
+        final Geopoint center = testPosition();
+        final int tileX = MercatorProjection.pixelXToTileX(
+                MercatorProjection.longitudeToPixelX(center.getLongitude(), TEST_ZOOM, TILE_SIZE), TEST_ZOOM, TILE_SIZE);
+        final int tileY = MercatorProjection.pixelYToTileY(
+                MercatorProjection.latitudeToPixelY(center.getLatitude(), TEST_ZOOM, TILE_SIZE), TEST_ZOOM, TILE_SIZE);
+        return TileUrlUtils.forTile(urlTemplate, TEST_ZOOM, tileX, tileY);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tiles/TileUrlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tiles/TileUrlUtils.java
@@ -1,0 +1,163 @@
+package cgeo.geocaching.unifiedmap.tiles;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Validation and normalisation of the XYZ tile url templates that the user can configure,
+ * both for tile overlays and for user-defined tile providers.
+ *
+ * <p>A template is accepted when it is an http(s) url containing the placeholders for zoom level,
+ * tile column and tile row. Placeholders are recognised case-insensitively and are normalised to
+ * the upper case spelling used throughout the tile provider classes, so that both
+ * {@code https://example.com/{z}/{x}/{y}.png} and {@code https://example.com/{Z}/{X}/{Y}.png}
+ * describe the same tile source. Query parameters are preserved verbatim, which is what api keys
+ * usually rely on.</p>
+ */
+public final class TileUrlUtils {
+
+    /** appended to a url that carries no placeholders, as the user-defined tile providers do */
+    public static final String DEFAULT_TILE_PATH = "/{Z}/{X}/{Y}.png";
+
+    /**
+     * Matches {x}, {X}, {y}, ... including the surrounding braces.
+     * Both braces must be escaped: Android uses ICU for regex, which rejects a lone closing
+     * brace that the JVM used for unit tests still accepts as a literal.
+     */
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{([xXyYzZ])\\}");
+
+    private TileUrlUtils() {
+        //no instance
+    }
+
+    /**
+     * Normalises a user-entered url.
+     *
+     * <p>The placeholders are optional: a url without them gets the default tile path appended
+     * when it is used, which is how user-defined tile providers have always worked. Use
+     * {@link #withDefaultTilePath} to get the form that actually addresses a tile.</p>
+     *
+     * @return the normalised url, or {@code null} if it is not an http(s) url with a host
+     */
+    @Nullable
+    public static String normalize(@Nullable final String url) {
+        final String trimmed = StringUtils.trimToNull(url);
+        if (trimmed == null) {
+            return null;
+        }
+
+        if (!isHttpUrl(trimmed)) {
+            return null;
+        }
+
+        final StringBuffer sb = new StringBuffer(trimmed.length());
+        final Matcher matcher = PLACEHOLDER.matcher(trimmed);
+        boolean hasX = false;
+        boolean hasY = false;
+        boolean hasZ = false;
+        while (matcher.find()) {
+            final char placeholder = Character.toUpperCase(matcher.group(1).charAt(0));
+            switch (placeholder) {
+                case 'X':
+                    hasX = true;
+                    break;
+                case 'Y':
+                    hasY = true;
+                    break;
+                default:
+                    hasZ = true;
+                    break;
+            }
+            matcher.appendReplacement(sb, "{" + placeholder + "}");
+        }
+        matcher.appendTail(sb);
+
+        final String normalized = sb.toString();
+        if (hasX && hasY && hasZ) {
+            return normalized;
+        }
+        // no placeholders: still usable, as long as there is a host to append the tile path to
+        try {
+            return StringUtils.isBlank(new URL(normalized).getHost()) ? null : normalized;
+        } catch (final MalformedURLException e) {
+            return null;
+        }
+    }
+
+    /** whether the given url can be used as a tile source */
+    public static boolean isValid(@Nullable final String url) {
+        return normalize(url) != null;
+    }
+
+    /**
+     * The template a url actually resolves to, appending the default tile path when the url leaves
+     * the placeholders out - mirroring what the user-defined tile providers do with such a url.
+     */
+    @NonNull
+    public static String withDefaultTilePath(@NonNull final String url) {
+        if (PLACEHOLDER.matcher(url).find()) {
+            return url;
+        }
+        return (url.endsWith("/") ? url.substring(0, url.length() - 1) : url) + DEFAULT_TILE_PATH;
+    }
+
+    /**
+     * Splits a normalised template into the part mapsforge and VTM need separately: the base url
+     * ({@code scheme://host[:port]}) and the remaining path including query parameters.
+     *
+     * @return a two element array of base url and tile path, or {@code null} if the template is unusable
+     */
+    @Nullable
+    public static String[] split(@Nullable final String url) {
+        final String normalized = normalize(url);
+        if (normalized == null) {
+            return null;
+        }
+        final int schemeEnd = normalized.indexOf("://") + 3;
+        final int pathStart = normalized.indexOf('/', schemeEnd);
+        if (pathStart < 0) {
+            return null;
+        }
+        return new String[]{normalized.substring(0, pathStart), normalized.substring(pathStart)};
+    }
+
+    private static boolean isHttpUrl(@NonNull final String url) {
+        final String lower = url.toLowerCase(Locale.US);
+        return lower.startsWith("http://") || lower.startsWith("https://");
+    }
+
+    /**
+     * The host of a url template, used as display name for entries the user did not name.
+     *
+     * @return the host, or {@code null} if the template is unusable or carries no host
+     */
+    @Nullable
+    public static String host(@Nullable final String url) {
+        final String normalized = normalize(url);
+        if (normalized == null) {
+            return null;
+        }
+        try {
+            return StringUtils.trimToNull(new URL(normalized).getHost());
+        } catch (final MalformedURLException e) {
+            return null;
+        }
+    }
+
+    /** resolves the placeholders of a normalised template for a concrete tile */
+    @NonNull
+    public static String forTile(@NonNull final String template, final int zoomLevel, final int tileX, final int tileY) {
+        return template
+                .replace("{Z}", String.valueOf(zoomLevel))
+                .replace("{X}", String.valueOf(tileX))
+                .replace("{Y}", String.valueOf(tileY));
+    }
+}

--- a/main/src/main/res/layout/preference_copy_delete_buttons.xml
+++ b/main/src/main/res/layout/preference_copy_delete_buttons.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- widget layout for a preference row that can be copied to the clipboard and deleted -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/copyview"
+        style="@style/button_icon" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/deleteview"
+        style="@style/button_icon" />
+
+</LinearLayout>

--- a/main/src/main/res/layout/tile_overlay_edit_dialog.xml
+++ b/main/src/main/res/layout/tile_overlay_edit_dialog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/overlay_name_frame"
+        style="@style/textinput_edittext_singleline"
+        android:hint="@string/settings_tileUrl_name">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/overlay_name"
+            style="@style/textinput_embedded_singleline"
+            android:inputType="text"
+            tools:ignore="LabelFor" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/overlay_url_frame"
+        style="@style/textinput_edittext_singleline"
+        android:hint="@string/settings_tileUrl_uri">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/overlay_url"
+            style="@style/textinput_embedded_singleline"
+            android:inputType="textUri"
+            tools:ignore="LabelFor" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="@string/settings_tileOverlays_url_hint"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+</LinearLayout>

--- a/main/src/main/res/menu/map_mapview.xml
+++ b/main/src/main/res/menu/map_mapview.xml
@@ -6,6 +6,9 @@
         android:id="@+id/menu_group_map_sources"
         android:checkableBehavior="single" >
     </group>
+    <!-- user-defined tile overlays, filled at runtime; not single-choice, several can be active -->
+    <group android:id="@+id/menu_group_tile_overlays" >
+    </group>
     <group android:id="@+id/menu_group_offlinemaps">
         <item
             android:orderInCategory="90"

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -212,6 +212,9 @@
     <string translatable="false" name="pref_previous_tileprovider">previous_tileprovider</string>
     <string translatable="false" name="pref_tileprovider_hidden">tileprovider_hidden</string>
     <string translatable="false" name="pref_userDefinedTileProviderUri">userDefinedTileProviderUri</string>
+    <string translatable="false" name="pref_tileOverlays">tileOverlays</string>
+    <string translatable="false" name="preference_category_map_tileoverlays">fakekey_category_map_tileoverlays</string>
+    <string translatable="false" name="pref_tileOverlaysEnabled">tileOverlaysEnabled</string>
 
     <!-- category offline maps -->
     <string translatable="false" name="pref_fakekey_info_offline_maps">fakekey_info_offline_maps</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1011,6 +1011,24 @@
     <string name="settings_unifiedMapVariants_title">UnifiedMap variants</string>
     <string name="settings_userDefinedTileProvider">User-defined tile provider</string>
     <string name="settings_userDefinedTileProviderUri">Enter full Uri (without trailing slash) to tile provider, or enter full Uri with parameters (including {X}, {Y} and {Z}). Make sure you have checked and comply to their usage conditions.</string>
+    <string name="settings_tileOverlays">User-defined overlays</string>
+    <string name="settings_tileOverlays_summary">Tile servers whose tiles are drawn on top of the map, for example sea marks or hiking routes</string>
+    <string name="settings_tileOverlays_add">Add overlay</string>
+    <string name="settings_tileOverlays_edit">Edit overlay</string>
+    <string name="settings_tileOverlays_url_hint">Enter the full Uri including the {X}, {Y} and {Z} placeholders. Tiles must be transparent where they carry no data. Make sure you have checked and comply to the provider\'s usage conditions.</string>
+    <string name="settings_tileOverlays_delete">Delete overlay</string>
+    <string name="settings_tileOverlays_delete_confirm">Delete overlay \"%1$s\"?</string>
+
+    <!-- shared by the user-defined tile providers and the user-defined tile overlays -->
+    <string name="settings_tileUrl_name">Name</string>
+    <string name="settings_tileUrl_uri">Uri</string>
+    <string name="settings_tileUrl_invalid">Please enter a http(s) Uri containing {X}, {Y} and {Z}</string>
+    <string name="settings_tileUrl_test">Test</string>
+    <string name="settings_tileUrl_testing">Checking\u2026</string>
+    <string name="settings_tileUrl_testok">A tile was received</string>
+    <string name="settings_tileUrl_testfailed_title">No tile received</string>
+    <string name="settings_tileUrl_testfailed">Could not load a tile from this server (%1$s). The Uri may be wrong, or the server may be temporarily unavailable.</string>
+    <string name="settings_tileUrl_copied">Copied, ready to be shared</string>
     <string name="settings_title_data_dir">Geocache data folder</string>
     <string name="settings_title_data_dir_usage">Geocache data folder (%1$s used)</string>
     <string name="calculate_dataDir_title">Geocache data usage</string>

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -35,6 +35,13 @@
             android:summary="@string/settings_userDefinedTileProviderUri"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
+    <cgeo.geocaching.settings.PreferenceCategory
+        android:key="@string/preference_category_map_tileoverlays"
+        android:title="@string/settings_tileOverlays"
+        android:summary="@string/settings_tileOverlays_summary"
+        app:iconSpaceReserved="false">
+        <!-- Filled dynamically -->
+    </cgeo.geocaching.settings.PreferenceCategory>
     <PreferenceCategory
         android:title="@string/settings_title_offline_maps"
         app:iconSpaceReserved="false">

--- a/main/src/test/java/cgeo/geocaching/unifiedmap/overlays/TileOverlayTest.java
+++ b/main/src/test/java/cgeo/geocaching/unifiedmap/overlays/TileOverlayTest.java
@@ -1,0 +1,60 @@
+package cgeo.geocaching.unifiedmap.overlays;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TileOverlayTest {
+
+    private static final String URL = "https://tiles.openseamap.org/seamark/{Z}/{X}/{Y}.png";
+
+    @Test
+    public void displayNameUsesTheGivenName() {
+        assertThat(new TileOverlay("k", "Sea marks", URL).getDisplayName()).isEqualTo("Sea marks");
+    }
+
+    @Test
+    public void displayNameFallsBackToHostWhenNameIsBlank() {
+        assertThat(new TileOverlay("k", "", URL).getDisplayName()).isEqualTo("tiles.openseamap.org");
+        assertThat(new TileOverlay("k", "   ", URL).getDisplayName()).isEqualTo("tiles.openseamap.org");
+    }
+
+    @Test
+    public void createGeneratesDistinctKeys() {
+        assertThat(TileOverlay.create("a", URL).getKey())
+                .isNotEqualTo(TileOverlay.create("a", URL).getKey());
+    }
+
+    @Test
+    public void survivesAJsonRoundTrip() {
+        final TileOverlay original = new TileOverlay("key-1", "Sea marks", URL);
+        final TileOverlay restored = TileOverlay.fromJson(original.toJson());
+        assertThat(restored).isNotNull();
+        assertThat(restored.getKey()).isEqualTo("key-1");
+        assertThat(restored.getName()).isEqualTo("Sea marks");
+        assertThat(restored.getUrl()).isEqualTo(URL);
+    }
+
+    @Test
+    public void jsonRoundTripKeepsABlankName() {
+        final TileOverlay restored = TileOverlay.fromJson(new TileOverlay("key-1", "", URL).toJson());
+        assertThat(restored).isNotNull();
+        assertThat(restored.getName()).isEmpty();
+        assertThat(restored.getDisplayName()).isEqualTo("tiles.openseamap.org");
+    }
+
+    @Test
+    public void fromJsonRejectsEntriesWithoutAUsableUrl() {
+        assertThat(TileOverlay.fromJson(new TileOverlay("key-1", "n", "not a url").toJson())).isNull();
+        assertThat(TileOverlay.fromJson(new TileOverlay("", "n", URL).toJson())).isNull();
+        assertThat(TileOverlay.fromJson(null)).isNull();
+    }
+
+    @Test
+    public void withNameAndWithUrlKeepTheKey() {
+        final TileOverlay original = new TileOverlay("key-1", "Sea marks", URL);
+        assertThat(original.withName("Renamed").getKey()).isEqualTo("key-1");
+        assertThat(original.withName("Renamed").getDisplayName()).isEqualTo("Renamed");
+        assertThat(original.withUrl("https://other.example/{Z}/{X}/{Y}.png").getUrl())
+                .isEqualTo("https://other.example/{Z}/{X}/{Y}.png");
+    }
+}

--- a/main/src/test/java/cgeo/geocaching/unifiedmap/tiles/TileUrlShareTest.java
+++ b/main/src/test/java/cgeo/geocaching/unifiedmap/tiles/TileUrlShareTest.java
@@ -1,0 +1,87 @@
+package cgeo.geocaching.unifiedmap.tiles;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TileUrlShareTest {
+
+    private static final String URL = "https://tiles.openseamap.org/seamark/{Z}/{X}/{Y}.png";
+
+    @Test
+    public void formatsNameAndUrl() {
+        assertThat(TileUrlShare.format("Sea marks", URL)).isEqualTo("Sea marks;" + URL);
+    }
+
+    @Test
+    public void formatsUrlOnlyWhenThereIsNoName() {
+        assertThat(TileUrlShare.format("", URL)).isEqualTo(URL);
+        assertThat(TileUrlShare.format("   ", URL)).isEqualTo(URL);
+    }
+
+    @Test
+    public void parsesNameAndUrl() {
+        assertThat(TileUrlShare.parse("Sea marks;" + URL)).containsExactly("Sea marks", URL);
+    }
+
+    @Test
+    public void parsesABareUrl() {
+        assertThat(TileUrlShare.parse(URL)).containsExactly("", URL);
+    }
+
+    @Test
+    public void normalisesThePlaceholdersWhileParsing() {
+        assertThat(TileUrlShare.parse("Sea marks;https://example.com/{z}/{x}/{y}.png"))
+                .containsExactly("Sea marks", "https://example.com/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void trimsSurroundingWhitespace() {
+        assertThat(TileUrlShare.parse("  Sea marks ; " + URL + "  ")).containsExactly("Sea marks", URL);
+    }
+
+    @Test
+    public void keepsASemicolonThatBelongsToTheUrl() {
+        final String withSemicolon = "https://example.com/{Z}/{X}/{Y}.png?a=1;b=2";
+        assertThat(TileUrlShare.parse(withSemicolon)).containsExactly("", withSemicolon);
+    }
+
+    @Test
+    public void splitsOnlyOnTheFirstSeparator() {
+        final String withSemicolon = "https://example.com/{Z}/{X}/{Y}.png?a=1;b=2";
+        assertThat(TileUrlShare.parse("My map;" + withSemicolon)).containsExactly("My map", withSemicolon);
+    }
+
+    @Test
+    public void keepsASemicolonThatBelongsToTheName() {
+        assertThat(TileUrlShare.parse("My;name;" + URL)).containsExactly("My;name", URL);
+    }
+
+    @Test
+    public void roundTripsANameContainingASemicolon() {
+        assertThat(TileUrlShare.parse(TileUrlShare.format("My;name", URL)))
+                .containsExactly("My;name", URL);
+    }
+
+    @Test
+    public void roundTripsThroughFormatAndParse() {
+        final String shared = TileUrlShare.format("My map", "https://example.com/{z}/{x}/{y}.png?a=1;b=2");
+        assertThat(TileUrlShare.parse(shared))
+                .containsExactly("My map", "https://example.com/{Z}/{X}/{Y}.png?a=1;b=2");
+    }
+
+    @Test
+    public void rejectsTextWithoutAUsableUrl() {
+        assertThat(TileUrlShare.parse("just some chat text")).isNull();
+        assertThat(TileUrlShare.parse("Name;not a url")).isNull();
+        assertThat(TileUrlShare.parse("")).isNull();
+        assertThat(TileUrlShare.parse(null)).isNull();
+    }
+
+    @Test
+    public void acceptsAUrlWithoutPlaceholders() {
+        // the default tile path is appended when such a url is used
+        assertThat(TileUrlShare.parse("https://example.com/tiles"))
+                .containsExactly("", "https://example.com/tiles");
+    }
+
+}

--- a/main/src/test/java/cgeo/geocaching/unifiedmap/tiles/TileUrlUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/unifiedmap/tiles/TileUrlUtilsTest.java
@@ -1,0 +1,133 @@
+package cgeo.geocaching.unifiedmap.tiles;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TileUrlUtilsTest {
+
+    @Test
+    public void normalizesUppercasePlaceholders() {
+        assertThat(TileUrlUtils.normalize("https://example.com/{Z}/{X}/{Y}.png"))
+                .isEqualTo("https://example.com/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void normalizesLowercasePlaceholders() {
+        assertThat(TileUrlUtils.normalize("https://example.com/{z}/{x}/{y}.png"))
+                .isEqualTo("https://example.com/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void normalizesMixedCasePlaceholders() {
+        assertThat(TileUrlUtils.normalize("https://example.com/{z}/{X}/{y}.png"))
+                .isEqualTo("https://example.com/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void trimsSurroundingWhitespace() {
+        assertThat(TileUrlUtils.normalize("  https://example.com/{z}/{x}/{y}.png  "))
+                .isEqualTo("https://example.com/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void keepsQueryParameters() {
+        assertThat(TileUrlUtils.normalize("https://example.com/tiles?z={z}&x={x}&y={y}&key=abc123"))
+                .isEqualTo("https://example.com/tiles?z={Z}&x={X}&y={Y}&key=abc123");
+    }
+
+    @Test
+    public void acceptsPlainHttp() {
+        assertThat(TileUrlUtils.normalize("http://example.com/{z}/{x}/{y}.png"))
+                .isEqualTo("http://example.com/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void acceptsPartialOrMissingPlaceholders() {
+        // the default tile path gets appended to these, as the tile providers have always done
+        assertThat(TileUrlUtils.normalize("https://example.com/tiles.png")).isEqualTo("https://example.com/tiles.png");
+        assertThat(TileUrlUtils.normalize("https://example.com/{z}/{x}.png")).isEqualTo("https://example.com/{Z}/{X}.png");
+    }
+
+    @Test
+    public void rejectsNonHttpSchemes() {
+        assertThat(TileUrlUtils.normalize("ftp://example.com/{z}/{x}/{y}.png")).isNull();
+        assertThat(TileUrlUtils.normalize("file:///tiles/{z}/{x}/{y}.png")).isNull();
+    }
+
+    @Test
+    public void rejectsBlankInput() {
+        assertThat(TileUrlUtils.normalize(null)).isNull();
+        assertThat(TileUrlUtils.normalize("")).isNull();
+        assertThat(TileUrlUtils.normalize("   ")).isNull();
+    }
+
+    @Test
+    public void isValidMatchesNormalize() {
+        assertThat(TileUrlUtils.isValid("https://example.com/{z}/{x}/{y}.png")).isTrue();
+        assertThat(TileUrlUtils.isValid("ftp://example.com/{z}/{x}/{y}.png")).isFalse();
+    }
+
+    @Test
+    public void splitsIntoBaseAndTilePath() {
+        assertThat(TileUrlUtils.split("https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"))
+                .containsExactly("https://tiles.openseamap.org", "/seamark/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void splitsKeepingPortAndQuery() {
+        assertThat(TileUrlUtils.split("https://example.com:8443/t?z={z}&x={x}&y={y}"))
+                .containsExactly("https://example.com:8443", "/t?z={Z}&x={X}&y={Y}");
+    }
+
+    @Test
+    public void splitReturnsNullForUnusableTemplate() {
+        assertThat(TileUrlUtils.split("nonsense")).isNull();
+    }
+
+    @Test
+    public void extractsHost() {
+        assertThat(TileUrlUtils.host("https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"))
+                .isEqualTo("tiles.openseamap.org");
+        assertThat(TileUrlUtils.host("https://example.com:8443/t?z={z}&x={x}&y={y}"))
+                .isEqualTo("example.com");
+    }
+
+    @Test
+    public void extractsHostWithoutPlaceholders() {
+        // tile providers may be configured with a bare url, so the host is still wanted there
+        assertThat(TileUrlUtils.host("https://example.com/tiles")).isEqualTo("example.com");
+    }
+
+    @Test
+    public void hostIsNullForUnusableTemplate() {
+        assertThat(TileUrlUtils.host("ftp://example.com/{z}/{x}/{y}.png")).isNull();
+        assertThat(TileUrlUtils.host("not a url at all")).isNull();
+        assertThat(TileUrlUtils.host(null)).isNull();
+    }
+
+    @Test
+    public void allowsAUrlWithoutPlaceholders() {
+        assertThat(TileUrlUtils.normalize("https://example.com/tiles"))
+                .isEqualTo("https://example.com/tiles");
+        assertThat(TileUrlUtils.normalize("https://example.com/{z}/{x}/{y}.png"))
+                .isEqualTo("https://example.com/{Z}/{X}/{Y}.png");
+        assertThat(TileUrlUtils.normalize("ftp://example.com/tiles")).isNull();
+        assertThat(TileUrlUtils.normalize("nonsense")).isNull();
+    }
+
+    @Test
+    public void appendsTheDefaultTilePathOnlyWhenNeeded() {
+        assertThat(TileUrlUtils.withDefaultTilePath("https://example.com/tiles"))
+                .isEqualTo("https://example.com/tiles/{Z}/{X}/{Y}.png");
+        assertThat(TileUrlUtils.withDefaultTilePath("https://example.com/tiles/"))
+                .isEqualTo("https://example.com/tiles/{Z}/{X}/{Y}.png");
+        assertThat(TileUrlUtils.withDefaultTilePath("https://example.com/{Z}/{X}/{Y}.png"))
+                .isEqualTo("https://example.com/{Z}/{X}/{Y}.png");
+    }
+
+    @Test
+    public void resolvesPlaceholdersForTile() {
+        assertThat(TileUrlUtils.forTile("https://example.com/{Z}/{X}/{Y}.png", 14, 8802, 4780))
+                .isEqualTo("https://example.com/14/8802/4780.png");
+    }
+}


### PR DESCRIPTION
## Description

Adds support for user-defined tile overlays: raster tile layers drawn *on top* of the
current map source, rather than replacing it.

Until now c:geo can only swap the base map. A user-defined tile provider takes over the
whole map, so raster data meant to complement a map — sea marks, hiking and cycling
routes, piste maps, national ortho layers — cannot be shown together with it. The only
transparent raster layer so far is hillshading, which is fed from local DEM files and is
not configurable.

What this adds:

- A new **User-defined overlays** group under *Settings → Map Sources*, listing the
  configured overlays one per row with an inline delete icon and an "add" button below,
  following the layout of the log templates.
- Each overlay is switched on and off individually in the map's layer selection, directly
  below the map sources. Several overlays can be active at once, and they are independent
  of the map source in use.
- Tiles are expected to carry their own transparency, so no alpha blending is applied.
- The name is optional; when left empty the host of the url is shown instead. It is
  derived on read rather than stored, so correcting a typo in the url also corrects a name
  that was never explicitly set. Names need not be unique.

Details worth calling out:

- Url templates accept `{x}/{y}/{z}` in either case and are normalised to the upper case
  spelling used elsewhere in the tile provider classes. Query parameters are preserved,
  which api keys usually depend on. Only `http`/`https` are accepted. As with the existing
  user-defined tile provider, a url without placeholders is accepted and gets the default
  tile path appended.
- Configuration and on/off state live in two separate new preferences, so toggling an
  overlay on the map never rewrites the configuration. Both are new keys, nothing is
  migrated, and older versions simply ignore them.
- Every overlay gets a key of its own that stays stable across renames, so the enabled
  state cannot be confused between entries.
- Implemented for both the Mapsforge and the VTM renderer. A new z-index between the
  buildings and the labels slot places overlays above the map and its hillshading, but
  below street labels and all cache and route items.
- Saving validates the Uri by actually fetching one tile from it, so a typo in the host or
  path is caught at once instead of showing up later as an overlay that silently draws
  nothing. The check is advisory: if it fails, the reason is shown and the overlay can
  still be saved anyway, since a server may cover only some regions or be temporarily
  unavailable. What it can and cannot catch is described further down.
- **Sharing an overlay with somebody else.** Copying one puts a single line of plain text
  on the clipboard - the name and the Uri - which can be sent through any chat client or
  mail. At the other end, pasting it into either field of the add dialog is recognised and
  fills in both. A bare Uri without a name works as well, so a link found on a website can
  be pasted straight in. The text stays readable, so the recipient can see what they are
  about to add before adding it.
- Unit tests cover the url handling, the shareable form and the stored json.

### Screenshots

<img width="320" alt="Screenshot_20260910-140909" src="https://github.com/user-attachments/assets/8e35c25f-0194-48e1-991f-868a211486e1" />


<img width="320" alt="Screenshot_20260910-141012" src="https://github.com/user-attachments/assets/f711c7d8-106b-4b2d-8fb1-a02398dd8799" />


The same view with nothing enabled, with one overlay, and with two - showing that several
can be active at once and that they compose over whatever map source is underneath:

<table>
<tr>
<td>
<img width="240" alt="Screenshot_20260910-141044" src="https://github.com/user-attachments/assets/fecbe640-88e0-4cc7-bbf8-c8959b3c0c5d" />
</td>
<td>
<img width="240" alt="Screenshot_20260910-141049" src="https://github.com/user-attachments/assets/11e127a7-0483-4f00-a27d-a518d3ba0d43" />
</td>
<td>
<img width="240" alt="Screenshot_20260910-141057" src="https://github.com/user-attachments/assets/ce1bf926-73ca-4727-a089-25820391bf70" />
</td>
</tr>
<tr>
<td align="center"><em>no overlay</em></td>
<td align="center"><em>sea marks</em></td>
<td align="center"><em>sea marks + turf zones</em></td>
</tr>
</table>

Both of them in the layer selection, below the map sources, each with its own checkbox:

<img width="320" alt="Screenshot_20260910-141315" src="https://github.com/user-attachments/assets/ad2ab71f-f77f-4d29-8c2c-6b04bd2b9094" />


The sea marks come from openseamap.org and the zones from a Turf tile server of my own,
which I plan to make generally available in a week or two. Neither is shipped with c:geo or
suggested anywhere in the app - they are just what I had configured while testing.

## Related issues

No open issue asks for this directly, as far as I can find. The nearest requests - #3954
(*custom WMS map data sources*) and #1286 (*eniro maps*) - are about replacing the base map
rather than drawing on top of it, and are answered by the sibling pull request for
user-defined tile providers instead.

- #18494 — *Add support for multiple custom online maps*. Related but separate: that one is
  about base maps, this one about overlays. See the note on the sibling pull requests below.

## Additional context

**One deliberate divergence from the log templates layout it otherwise follows:** the edit
dialog keeps a Cancel button. The log templates dialog has none and relies on tapping
outside to dismiss, which we thought worth diverging from rather than copying.

Overlays are their own preference category rather than a row inside *Map Data*. We tried
a de-emphasised sub-heading first, on the grounds that overlays are one aspect of map data
rather than an unrelated topic, but the section divider above it still read as "new
section" and contradicted the muted title. A normal category makes both cues agree and
matches the rest of the app.

**On how many entries the layer selection can take.** The overlays are listed inline there,
one checkbox each, which is fine for a handful. If you expect people to configure more than
that and would rather keep the menu short, they could just as well go behind a submenu, the
way *Manage offline data* does - either always, or only once there is more than one. Happy
to change it; it is a small change and I have no strong preference.

**One of three related map pull requests.** They touch the same corner of the code and were
built to fit together, but none depends on another and each can be merged, changed or
rejected on its own:

- this one, user-defined tile overlays (#18587)
- user-defined tile providers, superseding #18494 (#18586)
- a grayscale option for the map (#18588)

The two tile pull requests share `cgeo.geocaching.unifiedmap.tiles` - url handling, the
shareable text form and the tile check - and a block of shared strings. Those files are
byte-identical in both branches, so whichever is merged first, the other merges them
without a conflict. Ordering of the two settings categories is the one thing that needs a
hand: whichever lands second should place its category after the one already there.

Merging all three will produce conflicts, since they add to the same menu, the same
settings screen and the same string file. Just say the word after each one you take and I
will rebase the remaining ones onto it, so you never have to resolve anything yourself.

A branch with all three merged is available for testing at
`https://github.com/magma1447/cgeo/tree/demo/map-features`.

~~**Google Maps renderer is not implemented.** Overlays work on the Mapsforge and VTM
fragments; selecting a Google map source swaps in `GoogleMapsFragment`, which would need
its own `addTileOverlay` call. It is a small addition, but `maps_api2_key` is empty in the
repository so Google sources never register in a locally built APK, and I have no way to
test it. Happy to add it blind if you would rather have it in this PR than as a follow-up.~~

**Attribution and usage conditions** are the user's responsibility, as with the existing
user-defined tile provider. No overlay is shipped as a default or suggested in the UI.

**What the url check can and cannot catch.** It fetches one tile at zoom 12 around the last
map position, or around Geocaching HQ when no map position has been stored yet.

It catches an unreachable or misspelled host, TLS failures, HTTP error codes, and error
pages served as html. It does not catch a wrong path on a server that answers unknown
paths with a default tile - openseamap.org for instance returns the same small transparent
png for `/seamark/12/2253/1204.pn`, `/seamarkXX/...` and `/nonsense/...` as it does for a
genuinely empty area, so no check could tell those apart. Conversely a server that covers
only one region, or that 404s where it has no data, can fail the check for a perfectly
good url - hence saving anyway.

**Strings**: only `main/src/main/res/values/strings.xml` was touched, no `values-XX/`.

**Testing**: built and run on a Pixel (Android 17, API 37), against OpenSeaMap seamarks and
Waymarked Trails hiking tiles. Verified on both the Mapsforge and the VTM renderer:
overlays render with correct transparency over the base map, toggle on and off, survive
map source changes, and persist across restarts. LeakCanary run over toggle and
map-source-change cycles on both renderers. Checkstyle, lint and the unit test suite pass
locally.

**AI assistance**: this contribution was written with AI assistance (Claude Opus 5). I
have reviewed and tested everything submitted here.
